### PR TITLE
Improve test infrastructure and fix equivalence checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Top-level Makefile for uhdm2rtlil
-.PHONY: all debug test clean plugin
+.PHONY: all debug test test-all test-yosys clean plugin install help
 
 # Use bash as the default shell
 SHELL := /usr/bin/env bash
@@ -24,10 +24,20 @@ debug: build-debug
 	@echo "Building uhdm2rtlil in Debug mode..."
 	@cd build-debug && make -j$(CPU_CORES)
 
-# Test target
+# Test target - runs our internal tests only
 test: all
 	@echo "Running tests..."
 	@cd build && make test
+
+# Test all target - runs internal tests + all Yosys tests
+test-all: all
+	@echo "Running all tests (internal + Yosys)..."
+	@cd test && ./run_all_tests.sh --all
+
+# Test Yosys target - runs only Yosys tests
+test-yosys: all
+	@echo "Running Yosys tests..."
+	@cd test && ./run_all_tests.sh --yosys
 
 # Create release build directory and configure
 build: | build/Makefile
@@ -71,10 +81,12 @@ plugin: all
 # Help target
 help:
 	@echo "Available targets:"
-	@echo "  all      - Build in Release mode (default)"
-	@echo "  debug    - Build in Debug mode"
-	@echo "  plugin   - Build and show plugin location"
-	@echo "  test     - Run tests"
-	@echo "  clean    - Clean build artifacts"
-	@echo "  install  - Install the plugin"
-	@echo "  help     - Show this help message"
+	@echo "  all        - Build in Release mode (default)"
+	@echo "  debug      - Build in Debug mode"
+	@echo "  plugin     - Build and show plugin location"
+	@echo "  test       - Run internal tests only"
+	@echo "  test-all   - Run all tests (internal + Yosys)"
+	@echo "  test-yosys - Run Yosys tests only"
+	@echo "  clean      - Clean build artifacts"
+	@echo "  install    - Install the plugin"
+	@echo "  help       - Show this help message"

--- a/README.md
+++ b/README.md
@@ -128,16 +128,25 @@ Each test case is a directory containing:
 
 ### Running Tests
 ```bash
-# Run all tests
-cd test
-bash run_all_tests.sh
+# Run internal tests only (our test suite)
+make test
 
-# Run specific test
+# Run all tests (internal + Yosys tests)
+make test-all
+
+# Run Yosys tests only
+make test-yosys
+
+# Run specific test from test directory
+cd test
 bash test_uhdm_workflow.sh simple_counter
 
-# Run tests using CMake
-cd build
-make test
+# Run tests with options from test directory
+cd test
+bash run_all_tests.sh                    # Run internal tests only
+bash run_all_tests.sh --all              # Run all tests (internal + Yosys)
+bash run_all_tests.sh --yosys           # Run all Yosys tests
+bash run_all_tests.sh --yosys add_sub   # Run specific Yosys test pattern
 
 # Test output explanation:
 # ✓ PASSED - UHDM and Verilog frontends produce functionally equivalent results
@@ -149,6 +158,29 @@ make test
 # 2. Synthesis and formal equivalence check - Uses Yosys equiv_make/equiv_simple/equiv_induct
 # 3. Validates functional equivalence even when gate counts differ
 ```
+
+### Yosys Test Integration
+
+The UHDM frontend can run the full Yosys test suite to validate compatibility:
+
+```bash
+# Run all Yosys tests
+make test-yosys
+
+# Run specific Yosys test directory
+cd test
+./run_all_tests.sh --yosys ../third_party/yosys/tests/arch/common
+
+# Run specific Yosys test
+./run_all_tests.sh --yosys ../third_party/yosys/tests/arch/common/add_sub.v
+```
+
+The Yosys test runner:
+- Automatically finds self-contained Verilog/SystemVerilog tests
+- Runs both Verilog and UHDM frontends on each test
+- Performs formal equivalence checking when both frontends succeed
+- Reports UHDM-only successes (tests that only work with UHDM frontend)
+- Creates test results in `test/run/` directory structure
 
 ### Current Test Cases
 - **simple_counter** - 8-bit counter with async reset (tests increment logic, reset handling)
@@ -315,6 +347,20 @@ The UHDM frontend now handles elaboration automatically:
 3. **Map to RTLIL**: Convert UHDM objects to equivalent RTLIL constructs
 4. **Add Tests**: Create test cases comparing UHDM vs Verilog frontend outputs
 5. **Validate**: Ensure generated RTLIL produces correct synthesis results
+
+### Development Setup
+
+#### Git Hooks
+The project includes Git hooks to maintain code quality:
+
+```bash
+# Enable Git hooks (one-time setup)
+git config core.hooksPath .githooks
+
+# What the hooks do:
+# - Prevent commits of files larger than 10MB
+# - Prevent commits of test/run/**/*.v files (generated test outputs)
+```
 
 ### Debugging
 ```bash


### PR DESCRIPTION
Major improvements:
- Fix equivalence checking for designs with parameterized modules by adding flatten step
- Add test-all and test-yosys Makefile targets for running Yosys test suite
- Fix test_equivalence.sh to handle both absolute and relative paths correctly
- Update run_yosys_tests.sh to maintain proper directory structure matching Yosys tests
- Remove timestamps from netlist diffs to avoid unnecessary changes
- Move overall statistics to end of test output for better readability

Documentation updates:
- Document new test targets in README.md
- Add Yosys test integration section
- Add development setup section with Git hooks instructions

All 22 internal tests now pass with 100% success rate. The infrastructure is ready for running the full Yosys test suite.

🤖 Generated with [Claude Code](https://claude.ai/code)