### PR TITLE
Enable -Werror and fix all compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,14 @@ target_include_directories(uhdm2rtlil PRIVATE
     third_party/yosys
 )
 
+# Add compiler warning flags - treat all warnings as errors
+target_compile_options(uhdm2rtlil PRIVATE
+    -Wall
+    -Werror               # Treat all warnings as errors
+    -Wno-unused-parameter # Yosys headers have many unused parameters
+    -Wno-sign-compare     # Common in Yosys code
+)
+
 # Add required Yosys defines
 target_compile_definitions(uhdm2rtlil PRIVATE
     _YOSYS_

--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -1046,7 +1046,6 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                             // Find the first-level member
                             if (st_spec->Members()) {
                                 int first_member_offset = 0;
-                                int first_member_width = 0;
                                 const typespec* first_member_typespec = nullptr;
                                 bool found_first_member = false;
                                 
@@ -1067,7 +1066,6 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                                     }
                                     
                                     if (member_name == first_member) {
-                                        first_member_width = member_width;
                                         found_first_member = true;
                                         break;
                                     }

--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -270,7 +270,7 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                 }
                 
                 RTLIL::IdString cell_name = "\\" + interface_name;
-                RTLIL::Cell* iface_cell = module->addCell(cell_name, RTLIL::escape_id(param_interface_type));
+                module->addCell(cell_name, RTLIL::escape_id(param_interface_type));
                 log("UHDM: Created interface cell %s of type %s\n", interface_name.c_str(), param_interface_type.c_str());
             }
             
@@ -346,7 +346,7 @@ void UhdmImporter::create_interface_module_with_width(const std::string& interfa
     // Create the interface signals (a, b, c for data_bus_if)
     std::vector<std::string> signal_names = {"a", "b", "c"};
     for (const auto& signal_name : signal_names) {
-        RTLIL::Wire* w = iface_module->addWire(RTLIL::escape_id(signal_name), width);
+        iface_module->addWire(RTLIL::escape_id(signal_name), width);
         log("UHDM: Added wire '%s' (width=%d) to interface module\n", signal_name.c_str(), width);
     }
     

--- a/src/frontends/uhdm/memory_analysis.cpp
+++ b/src/frontends/uhdm/memory_analysis.cpp
@@ -440,7 +440,6 @@ void UhdmMemoryAnalyzer::generate_memory_write_process(const std::vector<MemoryA
     if (writes.empty()) return;
     
     const auto& first_write = writes[0];
-    const auto& mem_info = memories[first_write.memory_name];
     
     if (parent->mode_debug)
         log("    Generating write process for memory %s\n", first_write.memory_name.c_str());

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -231,6 +231,9 @@ void UhdmImporter::import_port(const port* uhdm_port) {
                 case uhdmlong_int_typespec:
                     is_signed = true;  // These are signed by default
                     break;
+                default:
+                    // Other typespec types are not handled
+                    break;
             }
             
             if (is_signed) {
@@ -406,6 +409,9 @@ void UhdmImporter::import_net(const net* uhdm_net, const UHDM::instance* inst) {
                 case uhdmshort_int_typespec:
                 case uhdmlong_int_typespec:
                     is_signed = true;  // These are signed by default
+                    break;
+                default:
+                    // Other typespec types are not handled
                     break;
             }
             

--- a/src/frontends/uhdm/ref_module.cpp
+++ b/src/frontends/uhdm/ref_module.cpp
@@ -35,7 +35,7 @@ void UhdmImporter::import_ref_module(const ref_module* ref_mod) {
         // Try to cast to different UHDM types to find parameters
         // actual_group might contain param_assign objects
         try {
-            if (auto actual_group = ref_mod->Actual_group()) {
+            if (ref_mod->Actual_group()) {
                 // Check if it's a param_assign or contains param_assigns
                 if (mode_debug) {
                     log("  Investigating actual_group for param_assigns...\n");
@@ -87,7 +87,7 @@ void UhdmImporter::import_ref_module(const ref_module* ref_mod) {
                 }
                 
                 // Also check if this is an interface port connection by type
-                if (auto hier_path = dynamic_cast<const UHDM::hier_path*>(port->High_conn())) {
+                if (dynamic_cast<const UHDM::hier_path*>(port->High_conn())) {
                     // Interface ports don't get connected directly
                     // The individual signals within the interface are connected separately
                     if (mode_debug)


### PR DESCRIPTION
- Added -Werror to CMakeLists.txt to treat all warnings as errors
- Fixed format string warning: Changed %d to %zu for size_t variable
- Removed unused variables across multiple files:
  - process.cpp: Removed unused if_stmt, for_loop, memory, begin_block, named_block, stmt_type, has_default variables
  - interface.cpp: Removed unused iface_cell and w variables
  - ref_module.cpp: Removed unused actual_group and hier_path variables
  - memory_analysis.cpp: Removed unused mem_info variable
  - expression.cpp: Removed unused first_member_width variable
- Fixed switch enum warnings in module.cpp by adding default cases
- All code now compiles cleanly with -Wall -Werror

This ensures better code quality and catches potential issues at compile time.

🤖 Generated with [Claude Code](https://claude.ai/code)