### PR TITLE
Add skipped_tests.txt support for tests that should not run

### DIFF
--- a/test/skipped_tests.txt
+++ b/test/skipped_tests.txt
@@ -1,0 +1,9 @@
+# Skipped tests that will not be run
+# Format: one test directory/path name per line
+# Comments start with #
+
+# Tests listed here will be completely skipped (not run at all)
+# This is different from failing_tests.txt where tests are run but expected to fail
+
+# Yosys tests that are skipped due to runtime issues
+arch/xilinx/priority_memory.v  # Skipped due to excessive runtime


### PR DESCRIPTION
- Added skipped_tests.txt file to list tests that should be completely skipped
- Different from failing_tests.txt where tests are run but expected to fail
- Updated run_all_tests.sh and run_yosys_tests.sh to load and honor skip list
- Fixed parsing to handle comments and inline comments properly
- Added arch/xilinx/priority_memory.v to skip list due to excessive runtime

The skip mechanism:
1. Loads test paths from skipped_tests.txt (one per line)
2. Supports comments with # and inline comments
3. Completely skips matching tests (doesn't run them at all)
4. Shows clear message when skipping: "Skipping test: X (marked in skipped_tests.txt)"
5. Counts skipped tests separately in statistics

This is useful for tests that take too long or cause issues that prevent the test suite from completing.

🤖 Generated with [Claude Code](https://claude.ai/code)