### PR TITLE
Fix CI: Add libfl-dev package for FlexLexer.h header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           libreadline-dev \
           bison \
           flex \
+          libfl-dev \
           libunwind-dev \
           libgoogle-perftools-dev \
           ccache 


### PR DESCRIPTION
The GitHub Actions CI was failing with:
  fatal error: FlexLexer.h: No such file or directory

This header file is provided by the libfl-dev package on Ubuntu, not just the flex package. Adding libfl-dev to the apt install list resolves the compilation error in the Yosys build.

🤖 Generated with [Claude Code](https://claude.ai/code)