### PR TITLE
Bump yosys submodule to v0.64

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Yosys frontend that converts SystemVerilog to RTLIL (Register Transfer Level Intermediate Language) via UHDM (Universal Hardware Data Model). The workflow is: SystemVerilog → Surelog → UHDM → UHDM Frontend → RTLIL → Yosys synthesis.
 
+The Yosys submodule is pinned at **v0.64** (`third_party/yosys`).
+
 ## Build Commands
 
 ```bash
@@ -235,6 +237,13 @@ All 156 tests are currently passing (0 failures). `test/failing_tests.txt` is em
 
 - When UHDM and Verilog synthesize differently (e.g., `gB → PP[0]` vs `PP[0] → gB`), `equiv_make` creates circular equiv cells that `equiv_induct` cannot resolve
 - Fix in `test_equivalence.sh`: add `opt -purge` before `design -stash` for both gold and gate — removes dead wires (unused signals) that cause the circular dependency
+
+### Equivalence Checking: Public-Typed Built-In Gates After write_verilog Round-Trip (Yosys 0.64+)
+
+- `synth -auto-top; write_verilog -noexpr` escapes built-in gate cell types to public Verilog identifiers (`\$_MUX_`, `\$_AND_`, …); reading the synth output back creates cells of *public* type
+- Yosys 0.64's `equiv_induct` aborts with "No SAT model available for cell …" because satgen only models the internal `$_MUX_`/`$_AND_`/etc. (in v0.62 this was just a warning, so the test passed despite some unmodelled cells)
+- Yosys 0.64's abc default mapping prefers `$_MUX_` heavily where v0.62 used `$_ANDNOT_`/`$_ORNOT_`, so this hits any synth output containing muxes (e.g. the `rotate` test)
+- Fix in `test_equivalence.sh`: after `equiv_make` (which pairs gold/gate by structure while they still reference the simcells library stubs from `read_verilog -lib +/simcells.v`), run `chtype -map \$_AND_ $_AND_` (and friends — `NAND`, `OR`, `NOR`, `XOR`, `XNOR`, `NOT`, `ANDNOT`, `ORNOT`, `MUX`, `NMUX`) to convert the public-typed cells back to their internal counterparts so satgen has SAT models for `equiv_simple` and `equiv_induct`
 
 ### Typed Net Declarations (`wand integer`, `wor typename`, etc.)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ This enables full SystemVerilog synthesis capability in Yosys, including advance
   - `svtypes_enum_simple` - Bare enums, typedef enums with `logic [1:0]`, parenthesized type declarations (`(states_t) state1;`), enum constant initialization, FSM transitions, and combinational assertions
   - `const_fold_func` - Compile-time constant function evaluation with recursive functions (`pow_flip_a`, `pow_flip_b`), bitwise AND/OR/XNOR operations, bit-select LHS assignments (`out6[exp] = flip(base)`), nested function call arguments
 - **Recent Fixes**:
+  - Yosys submodule bumped to **v0.64** (was v0.62-40); equiv flow updated for the new strictness ✅
+    - **What changed upstream**: yosys 0.64's `equiv_induct` treats unmodelled cells as a fatal error rather than a warning. `write_verilog` escapes built-in gate cell types (`$_MUX_`, `$_AND_`, …) to public Verilog identifiers (`\$_MUX_`, …); reading the synth output back creates cells of *public* type — satgen has no SAT model for those public types, so equiv_induct aborted. v0.64's abc mapping also prefers `$_MUX_` cells where v0.62 used `$_ANDNOT_`/`$_ORNOT_`, so this hit the `rotate` test in particular
+    - **Fix**: in `test/test_equivalence.sh`, after `equiv_make` pairs gold/gate by structure (it matches them while they still reference the simcells library stubs from `read_verilog -lib +/simcells.v`), `chtype -map \$_AND_ $_AND_` (and friends — `NAND`, `OR`, `NOR`, `XOR`, `XNOR`, `NOT`, `ANDNOT`, `ORNOT`, `MUX`, `NMUX`) converts the public-typed cells back to their internal counterparts so satgen has SAT models for the `equiv_simple` + `equiv_induct` passes
   - `struct_sizebits` — array/range query system functions now resolve hier_paths and walk the full multi-dim typespec ✅
     - **Root cause**: the existing `$bits/$size/$high/$low/$left/$right` handler in `import_expression` for `vpiSysFuncCall` only knew how to inspect a `ref_obj` argument, only recognised `logic_typespec`, and only looked at the *first* range. Anything like `$dimensions(s.sy.y)` (hier_path argument), `$size(s.sz.z, 2)` (2-arg form picking a non-outermost dim), `$bits` of a packed struct/union, or `$increment` was unhandled — fell through to "unhandled system function call: …" and returned the operand wire itself, making the assertions reference `s` (an undriven 221-bit struct) and the synth output show `s = 221'hxx…`
     - **Fix**: rewrote the handler to (1) follow hier_paths via `ExprEval::decodeHierPath(MEMBER)` to find the leaf member's typespec; (2) walk that typespec collecting *all* dimensions (multi-range `Ranges()` on `logic_typespec`, then recurse into nested `Elem_typespec`); (3) strip one outer dim per surrounding `bit_select` for cases like `s.sz.z[3][3]`; (4) honour the optional 2nd argument to pick a specific dimension index; (5) added handlers for `$dimensions` (returns `max(1, dims.size())`) and `$increment` (`+1` if `L<R`, else `-1`); (6) for atomic/struct/union types treat the whole as a single `[bits-1:0]` dim so `$size(s)` returns total bits
@@ -755,7 +758,7 @@ uhdm2rtlil/
 │   └── */                      # Individual test cases
 ├── third_party/                # External dependencies
 │   ├── Surelog/               # SystemVerilog parser (includes UHDM)
-│   └── yosys/                 # Synthesis framework
+│   └── yosys/                 # Synthesis framework (pinned at v0.64)
 ├── .github/workflows/         # CI/CD configuration
 ├── build/                     # Build artifacts
 ├── CMakeLists.txt            # CMake build configuration

--- a/test/test_equivalence.sh
+++ b/test/test_equivalence.sh
@@ -292,6 +292,24 @@ design -copy-from gold_flat -as gold *
 design -copy-from gate_flat -as gate *
 
 equiv_make gold gate equiv
+# Yosys 0.64's write_verilog escapes built-in gate cell types
+# (`\$_MUX_`, `\$_AND_`, …), so reading the synth output back creates
+# cells of *public* type — satgen has no SAT model for those and
+# `equiv_induct` aborts.  Convert the public-typed cells back to their
+# internal counterparts after `equiv_make` (it pairs them by structure
+# while they still match the simcells library) but before the SAT-based
+# passes.
+chtype -map \$_AND_ $_AND_
+chtype -map \$_NAND_ $_NAND_
+chtype -map \$_OR_ $_OR_
+chtype -map \$_NOR_ $_NOR_
+chtype -map \$_XOR_ $_XOR_
+chtype -map \$_XNOR_ $_XNOR_
+chtype -map \$_NOT_ $_NOT_
+chtype -map \$_ANDNOT_ $_ANDNOT_
+chtype -map \$_ORNOT_ $_ORNOT_
+chtype -map \$_MUX_ $_MUX_
+chtype -map \$_NMUX_ $_NMUX_
 equiv_simple
 equiv_induct
 equiv_status -assert


### PR DESCRIPTION
Update third_party/yosys from v0.62-40 (131911291) to v0.64 (6d2c445aebd37261d0e33ed4d90d09fd1a7bf618).

Adjusts test/test_equivalence.sh for two yosys 0.64 changes:

1. equiv_induct now treats unmodelled cells as a fatal error rather than a warning. write_verilog escapes built-in gate cell types ($_MUX_, $_AND_, …) to public Verilog identifiers (\$_MUX_, …), so reading the synth output back creates cells of *public* type — satgen has no SAT model for those public types and equiv_induct aborts.

   Fix: after equiv_make pairs gold/gate by structure (it matches them while they still reference the simcells library stubs from `read_verilog -lib +/simcells.v`), `chtype -map \$_AND_ $_AND_` (and friends, including $_MUX_ which v0.64's abc mapping uses heavily where v0.62 used $_ANDNOT_/$_ORNOT_) converts the public-typed cells back to their internal counterparts so satgen has SAT models for the equiv_simple + equiv_induct passes.

Test: run_all_tests.sh reports 166/166 functional with the v0.64 submodule (161 passing equiv + 5 UHDM-only, 0 true failures).