### PR TITLE
Add Verilator-based simulation equivalence check for UHDM-only tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,23 @@ target_link_libraries(uhdm2rtlil dl pthread)
 # Installation
 install(TARGETS uhdm2rtlil DESTINATION ${INSTALL_DIR}/share/yosys/plugins)
 
+# Auxiliary Yosys plugin: extract_clocks_resets.  Used by
+# test/test_sim_equivalence.py to drive a Verilator co-simulation
+# testbench against the synthesized netlist.  Built via `yosys-config
+# --build` so we don't have to replicate the Yosys include / link
+# flags here.
+set(EXTRACT_CR_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/extract_clocks_resets/extract_clocks_resets.cc)
+set(EXTRACT_CR_SO ${CMAKE_CURRENT_BINARY_DIR}/extract_clocks_resets.so)
+add_custom_command(
+    OUTPUT ${EXTRACT_CR_SO}
+    COMMAND ${CMAKE_BINARY_DIR}/yosys_install/bin/yosys-config
+            --build ${EXTRACT_CR_SO} ${EXTRACT_CR_SRC}
+    DEPENDS ${EXTRACT_CR_SRC} yosys
+    COMMENT "Building extract_clocks_resets Yosys plugin"
+)
+add_custom_target(extract_clocks_resets ALL DEPENDS ${EXTRACT_CR_SO})
+
 # Add test target
 add_custom_target(test
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test/run_all_tests.sh

--- a/src/plugins/extract_clocks_resets/extract_clocks_resets.cc
+++ b/src/plugins/extract_clocks_resets/extract_clocks_resets.cc
@@ -1,0 +1,168 @@
+// Yosys plugin: extract clock and reset top-level input names from the
+// current design.  Used by test/test_sim_equivalence.sh to drive a
+// Verilator co-simulation testbench.
+//
+// Usage:
+//   yosys -m extract_clocks_resets.so \
+//         -p "read_verilog <file>; hierarchy -check -auto-top;
+//             extract_clocks_resets -o ports.txt"
+//
+// Output format (one entry per line):
+//   PORT <name> <width> [input|output|inout]
+//   CLOCK <name>
+//   RESET <name> <active_high_polarity 0|1>
+
+#include "kernel/yosys.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+static bool starts_with(const std::string &s, const std::string &p) {
+    return s.size() >= p.size() && s.compare(0, p.size(), p) == 0;
+}
+
+struct ExtractClocksResetsPass : public Pass {
+    ExtractClocksResetsPass()
+        : Pass("extract_clocks_resets",
+               "extract clock and reset top-level input names") {}
+
+    void execute(std::vector<std::string> args, RTLIL::Design *design) override {
+        std::string output_file;
+        for (size_t i = 1; i < args.size(); i++) {
+            if (args[i] == "-o" && i + 1 < args.size()) {
+                output_file = args[++i];
+            }
+        }
+        if (output_file.empty())
+            log_error("extract_clocks_resets: -o <file> is required\n");
+
+        // Pick the top module
+        RTLIL::Module *top = nullptr;
+        for (auto mod : design->modules())
+            if (mod->get_bool_attribute(ID::top)) { top = mod; break; }
+        if (!top) {
+            // Fall back to the only / last design module
+            for (auto mod : design->modules()) top = mod;
+        }
+        if (!top)
+            log_error("extract_clocks_resets: no module in design\n");
+
+        // Build a map of wire -> name for top-level input ports so we can
+        // detect when a clock/reset connection directly reaches one.
+        std::set<RTLIL::IdString> top_inputs;
+        for (auto wire : top->wires())
+            if (wire->port_input) top_inputs.insert(wire->name);
+
+        std::set<RTLIL::IdString> clocks;
+        std::map<RTLIL::IdString, bool> resets; // active-high?
+
+        auto cell_is_dff = [](RTLIL::IdString t) {
+            // RTLIL-level FF cells
+            if (t == ID($dff) || t == ID($dffe) ||
+                t == ID($adff) || t == ID($adffe) ||
+                t == ID($sdff) || t == ID($sdffe) || t == ID($sdffce) ||
+                t == ID($dffsr) || t == ID($dffsre))
+                return true;
+            // Internal "$_DFF_*_" cell library (post-techmap).  After a
+            // synthesised netlist has been written with `write_verilog`
+            // and re-read, the cell type comes back as a *public*
+            // identifier `\$_DFF_PP0_` etc. — match both.
+            std::string s = t.str();
+            auto match = [&](const std::string &pfx) {
+                return starts_with(s, pfx) || starts_with(s, "\\" + pfx);
+            };
+            return match("$_DFF_") || match("$_SDFF_") ||
+                   match("$_DFFE_") || match("$_DFFSR_") ||
+                   match("$_SDFFE_") || match("$_SDFFCE_");
+        };
+
+        auto record_top_port = [&](const RTLIL::SigSpec &sig,
+                                    std::set<RTLIL::IdString> *clk_out,
+                                    std::map<RTLIL::IdString, bool> *rst_out,
+                                    bool active_high) {
+            for (auto chunk : sig.chunks()) {
+                if (!chunk.is_wire()) continue;
+                if (top_inputs.count(chunk.wire->name)) {
+                    if (clk_out) clk_out->insert(chunk.wire->name);
+                    if (rst_out) (*rst_out)[chunk.wire->name] = active_high;
+                }
+            }
+        };
+
+        for (auto cell : top->cells()) {
+            if (!cell_is_dff(cell->type)) continue;
+
+            // Clock — try common port names
+            RTLIL::SigSpec clk_sig;
+            if (cell->hasPort(ID::CLK))      clk_sig = cell->getPort(ID::CLK);
+            else if (cell->hasPort(ID::C))   clk_sig = cell->getPort(ID::C);
+            record_top_port(clk_sig, &clocks, nullptr, false);
+
+            // Async reset
+            if (cell->hasPort(ID::ARST)) {
+                bool ah = cell->hasParam(ID::ARST_POLARITY)
+                              ? cell->getParam(ID::ARST_POLARITY).as_bool()
+                              : true;
+                record_top_port(cell->getPort(ID::ARST), nullptr, &resets, ah);
+            }
+            // For internal $_DFF_PP0_ / $_DFF_PN0_ etc, the active-low/high
+            // flag is encoded in the cell type name.  Encoding:
+            //   $_DFF_<clk-edge><rst-polarity><reset-value>_
+            //   <clk-edge>: P or N
+            //   <rst-polarity>: P (active-high) or N (active-low)
+            //   <reset-value>: 0 or 1
+            // The cell type may also come back as a backslash-prefixed
+            // public Verilog identifier (`\$_SDFF_PP0_`) after a
+            // round-trip through `write_verilog` / `read_verilog`.
+            auto type_str = [&]() {
+                std::string s = cell->type.str();
+                if (!s.empty() && s[0] == '\\') return s.substr(1);
+                return s;
+            };
+            if (cell->hasPort(ID::R)) {
+                std::string s = type_str();
+                bool ah = true;
+                size_t prefix_len = 0;
+                if (starts_with(s, "$_DFF_") || starts_with(s, "$_SDFF_")) {
+                    prefix_len = starts_with(s, "$_SDFF_") ? 7 : 6;
+                    if (s.size() >= prefix_len + 2)
+                        ah = (s[prefix_len + 1] == 'P');
+                }
+                record_top_port(cell->getPort(ID::R), nullptr, &resets, ah);
+            }
+            if (cell->hasPort(ID::S)) {
+                std::string s = type_str();
+                bool ah = true;
+                if (starts_with(s, "$_DFFSR_") && s.size() >= 9)
+                    ah = (s[6] == 'P');
+                record_top_port(cell->getPort(ID::S), nullptr, &resets, ah);
+            }
+        }
+
+        std::ofstream f(output_file);
+        if (!f.is_open())
+            log_error("extract_clocks_resets: cannot open %s\n", output_file.c_str());
+
+        // Emit all top-level ports first so the testbench knows the full
+        // interface (and their widths) without re-parsing the Verilog.
+        for (auto wire : top->wires()) {
+            if (!(wire->port_input || wire->port_output)) continue;
+            const char *dir = wire->port_input && wire->port_output ? "inout"
+                              : wire->port_input ? "input" : "output";
+            f << "PORT " << RTLIL::unescape_id(wire->name) << " "
+              << wire->width << " " << dir << "\n";
+        }
+        for (auto clk : clocks)
+            f << "CLOCK " << RTLIL::unescape_id(clk) << "\n";
+        for (auto &r : resets)
+            f << "RESET " << RTLIL::unescape_id(r.first) << " "
+              << (r.second ? "1" : "0") << "\n";
+        f.close();
+
+        log("extract_clocks_resets: module=%s, ports=%d, clocks=%d, resets=%d -> %s\n",
+            log_id(top->name), (int)top->ports.size(),
+            (int)clocks.size(), (int)resets.size(), output_file.c_str());
+    }
+} ExtractClocksResetsPass;
+
+PRIVATE_NAMESPACE_END

--- a/test/test_sim_equivalence.py
+++ b/test/test_sim_equivalence.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Verilator-based simulation equivalence check for UHDM-only tests.
+
+When the Yosys Verilog frontend can't parse the SystemVerilog the test
+uses, we have no reference netlist to formally equivalence-check
+against.  Instead, we use Verilator as the reference:
+
+  RTL form  — the original `dut.sv` simulated directly by Verilator
+  Netlist   — UHDM-frontend output, post-`synth -auto-top`
+
+A SystemVerilog testbench instantiates both side by side, drives
+shared clocks/resets/random inputs, and compares outputs cycle by
+cycle.  A mismatch indicates a bug in the UHDM-frontend output or in
+the synthesis flow driven by our generated RTLIL.
+
+Pipeline:
+  1. Generate the synthesized netlist Verilog (Yosys + UHDM frontend),
+     renaming the top module to `dut_netlist`.
+  2. Extract clocks / resets / port list from the netlist using the
+     `extract_clocks_resets` Yosys plugin.
+  3. Emit a SystemVerilog wrapper that aliases the original SV top
+     module to `dut_rtl`, plus a testbench that instantiates `dut_rtl`
+     and `dut_netlist`, drives shared inputs, and compares outputs.
+  4. Build with Verilator and run; non-zero exit on mismatch.
+"""
+
+from __future__ import annotations
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def sh(cmd: list[str], cwd: Path | None = None, check: bool = True) -> str:
+    """Run a command, return stdout.  Print stderr on failure."""
+    p = subprocess.run(cmd, cwd=cwd, check=False, text=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if check and p.returncode != 0:
+        sys.stderr.write(f"$ {' '.join(cmd)}\n{p.stdout}\n{p.stderr}\n")
+        sys.exit(p.returncode)
+    return p.stdout
+
+
+def find_paths(project_root: Path) -> dict[str, Path]:
+    paths = {
+        "yosys":          project_root / "out/current/bin/yosys",
+        "uhdm_plugin":    project_root / "build/uhdm2rtlil.so",
+        "cr_plugin":      project_root / "build/extract_clocks_resets.so",
+        "simcells":       project_root / "out/current/share/yosys/simcells.v",
+        "simlib":         project_root / "out/current/share/yosys/simlib.v",
+    }
+    for k, p in paths.items():
+        if not p.exists():
+            sys.exit(f"❌ missing {k}: {p}")
+    return paths
+
+
+def find_top_module(dut_path: Path) -> str:
+    """Heuristic: the SV top module is the LAST `module <name>` declaration
+    that isn't `endmodule`.  In tests using inner+outer wrappers this is
+    typically the outer wrapper that takes the runtime stimulus."""
+    last = None
+    for line in dut_path.read_text().splitlines():
+        m = re.match(r"\s*module\s+([A-Za-z_][A-Za-z0-9_]*)", line)
+        if m:
+            last = m.group(1)
+    if last is None:
+        sys.exit(f"❌ no `module` declaration in {dut_path}")
+    return last
+
+
+def synth_to_netlist(yosys: Path, uhdm_plugin: Path,
+                     uhdm: Path, out_v: Path) -> None:
+    # `$check` cells (concurrent / immediate assertions) and `$print`
+    # cells ($display) have no Verilator-compatible behavioural model,
+    # and they're not the subject of the equivalence check anyway.
+    # Delete them before writing the netlist.
+    script = (
+        f"read_uhdm {uhdm}\n"
+        f"synth -auto-top\n"
+        f"delete t:$check t:$print\n"
+        f"flatten\n"
+        f"opt_clean\n"
+        f"rename -top dut_netlist\n"
+        f"write_verilog -noattr -noexpr {out_v}\n"
+    )
+    sh([str(yosys), "-q", "-m", str(uhdm_plugin), "-p", script])
+
+
+def extract_ports(yosys: Path, cr_plugin: Path, simcells: Path,
+                  netlist_v: Path, out_txt: Path) -> None:
+    script = (
+        f"read_verilog -nolatches {simcells} {netlist_v}\n"
+        f"hierarchy -top dut_netlist\n"
+        f"extract_clocks_resets -o {out_txt}\n"
+    )
+    sh([str(yosys), "-q", "-m", str(cr_plugin), "-p", script])
+
+
+def parse_ports(path: Path) -> tuple[list[tuple[str, int, str]],
+                                     list[str],
+                                     dict[str, bool]]:
+    ports: list[tuple[str, int, str]] = []
+    clocks: set[str] = set()
+    resets: dict[str, bool] = {}
+    for line in path.read_text().splitlines():
+        toks = line.split()
+        if not toks:
+            continue
+        if toks[0] == "PORT":
+            ports.append((toks[1], int(toks[2]), toks[3]))
+        elif toks[0] == "CLOCK":
+            clocks.add(toks[1])
+        elif toks[0] == "RESET":
+            resets[toks[1]] = toks[2] == "1"
+    return ports, sorted(clocks), resets
+
+
+def emit_wrapper_and_tb(dut_path: Path,
+                       orig_top: str,
+                       ports: list[tuple[str, int, str]],
+                       clocks: list[str],
+                       resets: dict[str, bool],
+                       out_dir: Path) -> None:
+    """Write `tb.sv` (wraps both DUTs as a non-clocking pass-through) and
+    `tb_main.cpp` (drives the simulation cycle by cycle).
+
+    We avoid `--timing` so the testbench is compatible with older
+    Verilator releases.  Clocks and reset are advanced from C++ via
+    `eval()` calls; the SV side is purely structural."""
+
+    inputs = [(n, w) for (n, w, d) in ports
+              if d in ("input", "inout")
+              and n not in clocks and n not in resets]
+    outputs = [(n, w) for (n, w, d) in ports if d == "output"]
+    if not outputs:
+        sys.exit("❌ no output ports — nothing to compare")
+
+    # Wrapper: instantiate the original SV top under the name dut_rtl.
+    port_decl = []
+    for n, w, d in ports:
+        rng = f" [{w-1}:0]" if w > 1 else ""
+        port_decl.append(f"  {d}{rng} {n}")
+    wrapper_lines = [
+        "// Auto-generated: wraps the original SV top as `dut_rtl`.",
+        f"module dut_rtl (\n" + ",\n".join(port_decl) + "\n);",
+        f"  {orig_top} u_orig (",
+        ",\n".join(f"    .{n}({n})" for (n, _w, _d) in ports),
+        "  );",
+        "endmodule",
+        "",
+    ]
+    (out_dir / "wrapper.sv").write_text("\n".join(wrapper_lines))
+
+    # Top SV testbench: pure structural — exposes the union of ports so
+    # the C++ driver can poke clocks, resets, and inputs directly.
+    L = ["// Auto-generated tb: exposes both DUTs as a flat interface.",
+         "module tb ("]
+    sigs = []
+    for c in clocks:
+        sigs.append(f"  input  logic {c}")
+    for r in resets:
+        sigs.append(f"  input  logic {r}")
+    for n, w in inputs:
+        rng = f" [{w-1}:0]" if w > 1 else ""
+        sigs.append(f"  input  logic{rng} {n}")
+    for n, w in outputs:
+        rng = f" [{w-1}:0]" if w > 1 else ""
+        sigs.append(f"  output logic{rng} rtl_{n}")
+        rng = f" [{w-1}:0]" if w > 1 else ""
+        sigs.append(f"  output logic{rng} nl_{n}")
+    L.append(",\n".join(sigs))
+    L.append(");")
+
+    def inst(mod, prefix):
+        L.append("")
+        L.append(f"  {mod} u_{prefix.strip('_')} (")
+        conn = []
+        for n, _w, d in ports:
+            conn.append(f"    .{n}({prefix}{n})" if d == "output"
+                        else f"    .{n}({n})")
+        L.append(",\n".join(conn))
+        L.append("  );")
+    inst("dut_rtl",     "rtl_")
+    inst("dut_netlist", "nl_")
+    L.append("endmodule")
+    (out_dir / "tb.sv").write_text("\n".join(L))
+
+    # C++ driver
+    seed = 42
+    cycles = 200
+    reset_cycles = 5
+
+    cpp = []
+    cpp += [
+        "#include <cstdio>",
+        "#include <cstdint>",
+        "#include <cstdlib>",
+        "#include \"Vtb.h\"",
+        "",
+        "int main(int argc, char** argv) {",
+        "    Vtb tb;",
+        "    int mismatches = 0;",
+    ]
+    # Init all driven inputs
+    for c in clocks:
+        cpp.append(f"    tb.{c} = 0;")
+    for r, ah in resets.items():
+        cpp.append(f"    tb.{r} = {1 if ah else 0};  // assert reset")
+    for n, _w in inputs:
+        cpp.append(f"    tb.{n} = 0;")
+    cpp.append("    tb.eval();")
+
+    if clocks:
+        clk = clocks[0]
+        cpp.append("    // Reset phase: hold reset asserted for several clock cycles")
+        cpp.append(f"    for (int i = 0; i < {reset_cycles}; ++i) {{")
+        cpp.append(f"        tb.{clk} = 0; tb.eval();")
+        cpp.append(f"        tb.{clk} = 1; tb.eval();")
+        cpp.append("    }")
+        for r, ah in resets.items():
+            cpp.append(f"    tb.{r} = {0 if ah else 1};  // de-assert reset")
+        cpp.append(f"    tb.eval();")
+        cpp.append(f"    srand({seed});")
+        cpp.append(f"    for (int cycle = 0; cycle < {cycles}; ++cycle) {{")
+        # Drive inputs before negedge / posedge
+        for n, w in inputs:
+            if w <= 32:
+                cpp.append(f"        tb.{n} = (uint32_t)rand();")
+            else:
+                cpp.append(f"        tb.{n} = ((uint64_t)rand() << 32) | (uint32_t)rand();")
+        cpp.append(f"        tb.{clk} = 0; tb.eval();")
+        cpp.append(f"        tb.{clk} = 1; tb.eval();")
+        for n, _w in outputs:
+            cpp.append(f"        if (tb.rtl_{n} != tb.nl_{n}) {{")
+            cpp.append(f"            std::printf(\"MISMATCH cycle %d: {n}: rtl=0x%llx nl=0x%llx\\n\","
+                       f" cycle, (unsigned long long)tb.rtl_{n}, (unsigned long long)tb.nl_{n});")
+            cpp.append("            mismatches++;")
+            cpp.append("        }")
+        cpp.append("    }")
+    else:
+        cpp.append(f"    srand({seed});")
+        cpp.append(f"    for (int cycle = 0; cycle < {cycles}; ++cycle) {{")
+        for n, w in inputs:
+            if w <= 32:
+                cpp.append(f"        tb.{n} = (uint32_t)rand();")
+            else:
+                cpp.append(f"        tb.{n} = ((uint64_t)rand() << 32) | (uint32_t)rand();")
+        cpp.append("        tb.eval();")
+        for n, _w in outputs:
+            cpp.append(f"        if (tb.rtl_{n} != tb.nl_{n}) {{")
+            cpp.append(f"            std::printf(\"MISMATCH cycle %d: {n}: rtl=0x%llx nl=0x%llx\\n\","
+                       f" cycle, (unsigned long long)tb.rtl_{n}, (unsigned long long)tb.nl_{n});")
+            cpp.append("            mismatches++;")
+            cpp.append("        }")
+        cpp.append("    }")
+    cpp += [
+        f"    if (mismatches == 0)",
+        f"        std::printf(\"PASS: {cycles} cycles, 0 mismatches\\n\");",
+        "    else",
+        f"        std::printf(\"FAIL: {cycles} cycles, %d mismatches\\n\", mismatches);",
+        "    return mismatches == 0 ? 0 : 1;",
+        "}",
+        "",
+    ]
+    (out_dir / "tb_main.cpp").write_text("\n".join(cpp))
+
+
+def run_verilator(work: Path, paths: dict[str, Path], dut_path: Path) -> tuple[int, str]:
+    cmd = [
+        "verilator", "--cc", "--exe", "--build", "-j", "4",
+        "-Wno-fatal", "-Wno-WIDTH", "-Wno-UNUSED", "-Wno-UNOPTFLAT",
+        "-Wno-CASEINCOMPLETE", "-Wno-MULTIDRIVEN",
+        "--top-module", "tb",
+        # simcells.v contains the $_DFF_*/$_MUX_/... gate-level cells;
+        # simlib.v has higher-level primitives (and a `tran` that older
+        # Verilator can't parse) — synth doesn't emit those, so skip.
+        str(paths["simcells"]),
+        str(dut_path), "wrapper.sv", "dut_netlist.v", "tb.sv",
+        "tb_main.cpp",
+    ]
+    p = subprocess.run(cmd, cwd=work, text=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if p.returncode != 0:
+        return p.returncode, "[verilator build failed]\n" + p.stdout
+    p2 = subprocess.run(["./obj_dir/Vtb"], cwd=work, text=True,
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return p2.returncode, p2.stdout
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("test_name", help="test directory under test/")
+    args = ap.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    project_root = script_dir.parent
+    test_dir = Path(args.test_name) if Path(args.test_name).is_absolute() \
+        else Path.cwd() / args.test_name
+
+    if not test_dir.is_dir():
+        sys.exit(f"❌ test dir not found: {test_dir}")
+
+    paths = find_paths(project_root)
+    uhdm = test_dir / "slpp_all/surelog.uhdm"
+    if not uhdm.exists():
+        sys.exit(f"❌ no UHDM at {uhdm} — run the standard workflow first")
+
+    dut = test_dir / "dut.sv"
+    if not dut.exists():
+        dut = test_dir / "dut.v"
+    if not dut.exists():
+        sys.exit(f"❌ no dut.sv / dut.v in {test_dir}")
+
+    work = test_dir / "sim_equiv"
+    if work.exists():
+        for f in work.iterdir():
+            if f.is_dir():
+                import shutil
+                shutil.rmtree(f)
+            else:
+                f.unlink()
+    work.mkdir(exist_ok=True)
+
+    orig_top = find_top_module(dut)
+    print(f"▶ original SV top: {orig_top}")
+
+    print("▶ Generating synthesized netlist from UHDM")
+    synth_to_netlist(paths["yosys"], paths["uhdm_plugin"],
+                     uhdm, work / "dut_netlist.v")
+
+    print("▶ Extracting clocks/resets/ports")
+    extract_ports(paths["yosys"], paths["cr_plugin"],
+                  paths["simcells"], work / "dut_netlist.v",
+                  work / "ports.txt")
+    ports, clocks, resets = parse_ports(work / "ports.txt")
+    print(f"  ports={len(ports)} clocks={clocks} resets={list(resets)}")
+
+    print("▶ Emitting wrapper + testbench")
+    emit_wrapper_and_tb(dut, orig_top, ports, clocks, resets, work)
+
+    print("▶ Running Verilator co-sim")
+    rc, out = run_verilator(work, paths, dut)
+    # Trim Verilator noise so the PASS/FAIL line is easy to find
+    for line in out.splitlines()[-15:]:
+        print(line)
+    if "PASS:" in out and "MISMATCH" not in out and "FAIL:" not in out:
+        return 0
+    print("❌ simulation reported a mismatch or did not complete")
+    return 1 if rc == 0 else rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
When the Yosys Verilog frontend cannot parse a test SV, we have no reference netlist to formally equivalence-check against. Use Verilator as the reference: RTL form is the original dut.sv; netlist is the UHDM frontend output after synth. A small SV testbench instantiates both side by side, a C++ driver advances clocks/resets/random inputs each cycle, and outputs are compared every cycle.

New pieces:
- src/plugins/extract_clocks_resets/ — Yosys plugin that finds FF cells, traces clock and async reset/set inputs back to top-level ports, and writes a ports.txt file. Wired into CMake via yosys-config --build.
- test/test_sim_equivalence.py — pipeline: synth via UHDM frontend, extract ports, emit wrapper.sv + tb.sv + tb_main.cpp, verilator --cc --exe --build, run.

Smoke test: passes on setundef, struct_pattern_loop, hier_undriven_port. SVA tests need a newer Verilator (system 4.038 cannot parse SVA); unpacked-array port tests need wrapper-side flattening — both follow-ups.