### PR TITLE
Wire sim-equivalence into run_all_tests.sh + CI/README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
           libfl-dev \
           libunwind-dev \
           libgoogle-perftools-dev \
-          ccache 
+          ccache \
+          verilator
     
     - name: Setup GCC-9
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,10 +130,12 @@ install(TARGETS uhdm2rtlil DESTINATION ${INSTALL_DIR}/share/yosys/plugins)
 set(EXTRACT_CR_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/extract_clocks_resets/extract_clocks_resets.cc)
 set(EXTRACT_CR_SO ${CMAKE_CURRENT_BINARY_DIR}/extract_clocks_resets.so)
+# yosys-config lives in the in-tree Yosys checkout (it's a shell script
+# that knows where its own include/lib live) — use that directly.
+set(YOSYS_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/third_party/yosys/yosys-config)
 add_custom_command(
     OUTPUT ${EXTRACT_CR_SO}
-    COMMAND ${CMAKE_BINARY_DIR}/yosys_install/bin/yosys-config
-            --build ${EXTRACT_CR_SO} ${EXTRACT_CR_SRC}
+    COMMAND ${YOSYS_CONFIG} --build ${EXTRACT_CR_SO} ${EXTRACT_CR_SRC}
     DEPENDS ${EXTRACT_CR_SRC} yosys
     COMMENT "Building extract_clocks_resets Yosys plugin"
 )

--- a/README.md
+++ b/README.md
@@ -453,6 +453,19 @@ SystemVerilog (.sv) → [Surelog] → UHDM (.uhdm) → [UHDM Frontend] → RTLIL
 - CMake 3.16+
 - Python 3.6+
 - Standard development tools (make, bison, flex)
+- Verilator (used by `test/test_sim_equivalence.py` to co-simulate
+  the original SV against the UHDM-derived netlist for tests where
+  the Yosys Verilog frontend can't parse the source — see
+  [Verilator-based simulation equivalence](#verilator-based-simulation-equivalence-check) below)
+
+On Debian / Ubuntu:
+```bash
+sudo apt-get install -y \
+    build-essential cmake git python3 python3-pip pkg-config \
+    libssl-dev zlib1g-dev libtcmalloc-minimal4 uuid-dev tcl-dev \
+    libffi-dev libreadline-dev bison flex libfl-dev libunwind-dev \
+    libgoogle-perftools-dev ccache verilator
+```
 
 ### Build
 ```bash
@@ -541,6 +554,34 @@ cd test
 
 # Run specific Yosys test
 ./run_all_tests.sh --yosys ../third_party/yosys/tests/arch/common/add_sub.v
+```
+
+### Verilator-based Simulation Equivalence Check
+
+UHDM-only tests have no Yosys-Verilog-frontend reference netlist to formally
+equivalence-check against, so `run_all_tests.sh` invokes
+`test/test_sim_equivalence.py` on them as a soft warning.
+
+The script co-simulates two views of the same design under Verilator:
+
+  - **RTL form**  — the original `dut.sv`, simulated directly by Verilator
+  - **Netlist**   — UHDM frontend output, post-`synth -auto-top`
+
+A small SystemVerilog testbench instantiates both side by side
+(`dut_rtl` / `dut_netlist`), and a C++ driver advances clocks, holds
+reset for a few cycles, then drives random inputs for ~50–200 cycles,
+comparing every output every cycle.  Clocks and resets are extracted
+from the netlist via the `extract_clocks_resets` Yosys plugin
+(`build/extract_clocks_resets.so`).
+
+A mismatch surfaces as a `⚠️ Verilator co-sim WARNING` line in the
+test summary and does **not** flip the test to failed.  Per-test
+output is written to `<test_dir>/sim_equiv.log`.
+
+You can also run it standalone:
+```bash
+cd test
+./test_sim_equivalence.py setundef
 ```
 
 The Yosys test runner:

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -87,6 +87,8 @@ YOSYS_FAILED=0
 YOSYS_SKIPPED=0
 YOSYS_UHDM_ONLY=0
 EQUIV_FAILED_TESTS=0
+SIM_EQUIV_WARN_TESTS=0
+SIM_EQUIV_WARN_NAMES=()
 
 FAILED_TEST_NAMES=()
 SKIPPED_TEST_NAMES=()
@@ -94,6 +96,29 @@ CRASHED_TEST_NAMES=()
 PASSED_TEST_NAMES=()
 UHDM_ONLY_TEST_NAMES=()
 EQUIV_FAILED_TEST_NAMES=()
+
+# Helper: run the Verilator simulation-equivalence check on a UHDM-only
+# test.  Always returns 0 so a failure here doesn't fail the suite —
+# it just emits a warning and counts the test in SIM_EQUIV_WARN_TESTS.
+run_sim_equivalence_softwarn() {
+    local test_dir="$1"
+    local script="$SCRIPT_DIR/test_sim_equivalence.py"
+    local plugin="$PROJECT_ROOT/build/extract_clocks_resets.so"
+    if [ ! -f "$script" ] || [ ! -f "$plugin" ]; then
+        return 0  # silently skip if the optional tooling isn't built
+    fi
+    local log="$test_dir/sim_equiv.log"
+    if "$script" "$test_dir" >"$log" 2>&1; then
+        if grep -q '^PASS:' "$log"; then
+            echo "    ✅ Verilator co-sim PASSED"
+            return 0
+        fi
+    fi
+    echo "    ⚠️  Verilator co-sim WARNING (see $(basename "$test_dir")/sim_equiv.log)"
+    SIM_EQUIV_WARN_TESTS=$((SIM_EQUIV_WARN_TESTS + 1))
+    SIM_EQUIV_WARN_NAMES+=("$(basename "$test_dir")")
+    return 0
+}
 
 # Track unexpected results
 UNEXPECTED_FAILURES=()
@@ -302,6 +327,7 @@ analyze_test_result() {
         if [ -f "${test_dir}/verilog_path.log" ] && grep -q "ERROR" "${test_dir}/verilog_path.log"; then
             echo "✅ Test $test_dir PASSED - UHDM succeeds where Verilog fails!"
             echo "    Demonstrates UHDM's superior SystemVerilog support"
+            run_sim_equivalence_softwarn "$test_dir"
             UHDM_ONLY_TESTS=$((UHDM_ONLY_TESTS + 1))
             UHDM_ONLY_TEST_NAMES+=("$test_dir")
             return 0
@@ -321,6 +347,7 @@ analyze_test_result() {
        [ -f "${test_dir}/verilog_path.log" ] && grep -q "ERROR" "${test_dir}/verilog_path.log"; then
         echo "✅ Test $test_dir PASSED - UHDM completes synth where Verilog synth errors!"
         echo "    Demonstrates UHDM's superior SystemVerilog support"
+        run_sim_equivalence_softwarn "$test_dir"
         UHDM_ONLY_TESTS=$((UHDM_ONLY_TESTS + 1))
         UHDM_ONLY_TEST_NAMES+=("$test_dir")
         return 0
@@ -701,6 +728,12 @@ echo "  🚀 UHDM-only success: $UHDM_ONLY_TESTS"
 echo "  ❌ Equivalence failures: $EQUIV_FAILED_TESTS"
 echo "  ❌ True failures: $FAILED_TESTS"
 echo "  💥 Crashes: $CRASHED_TESTS"
+if [ "$SIM_EQUIV_WARN_TESTS" -gt 0 ]; then
+    echo "  ⚠️  Verilator sim-equiv warnings: $SIM_EQUIV_WARN_TESTS"
+    for t in "${SIM_EQUIV_WARN_NAMES[@]}"; do
+        echo "      - $t"
+    done
+fi
 echo
 
 # Log the comprehensive summary to file


### PR DESCRIPTION
Three small changes to put the new Verilator-based co-simulation flow on the regular path. 1) CMakeLists.txt fixes the extract_clocks_resets build rule to use the in-tree third_party/yosys/yosys-config (the previous CMAKE_BINARY_DIR/yosys_install path did not exist), so a stock make now produces build/extract_clocks_resets.so. 2) run_all_tests.sh soft-warns for UHDM-only tests: both UHDM-only branches call test_sim_equivalence.py and record a Verilator sim-equiv warnings line in the summary if the co-sim does not end with PASS, without flipping the test pass/fail status (SVA tests and unpacked-array ports are expected to warn until follow-ups). 3) CI installs verilator; README documents it as a prerequisite plus a new Verilator-based Simulation Equivalence Check subsection.