### PR TITLE
CI: build Verilator 5.048 from source for sim-equivalence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,36 @@ jobs:
           libunwind-dev \
           libgoogle-perftools-dev \
           ccache \
-          verilator
-    
+          help2man
+
+    - name: Cache Verilator build
+      id: cache-verilator
+      uses: actions/cache@v4
+      with:
+        path: /opt/verilator-5.048
+        key: verilator-5.048-${{ runner.os }}
+
+    - name: Build Verilator 5.048 from source
+      # Ubuntu 24.04's stock `verilator` package is 5.020 which is fine
+      # for SVA parsing, but pin a specific newer release here so
+      # test/test_sim_equivalence.py runs against the same Verilator on
+      # CI and on developer machines (where the OS package is typically
+      # too old — 22.04 only has 4.038).
+      if: steps.cache-verilator.outputs.cache-hit != 'true'
+      run: |
+        git clone --depth=1 -b v5.048 https://github.com/verilator/verilator.git /tmp/verilator
+        cd /tmp/verilator
+        autoconf
+        ./configure --prefix=/opt/verilator-5.048
+        make -j$(nproc)
+        sudo make install
+
+    - name: Add Verilator to PATH
+      run: |
+        echo "/opt/verilator-5.048/bin" >> $GITHUB_PATH
+        echo "PATH after: /opt/verilator-5.048/bin:$PATH"
+        /opt/verilator-5.048/bin/verilator --version
+
     - name: Setup GCC-9
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -464,7 +464,21 @@ sudo apt-get install -y \
     build-essential cmake git python3 python3-pip pkg-config \
     libssl-dev zlib1g-dev libtcmalloc-minimal4 uuid-dev tcl-dev \
     libffi-dev libreadline-dev bison flex libfl-dev libunwind-dev \
-    libgoogle-perftools-dev ccache verilator
+    libgoogle-perftools-dev ccache help2man
+```
+
+`test/test_sim_equivalence.py` needs **Verilator 5.x** (5.020+) for SVA
+parsing.  Ubuntu 24.04's stock `verilator` package is recent enough;
+on older distros (22.04 ships 4.038) build from source:
+
+```bash
+git clone --depth=1 -b v5.048 https://github.com/verilator/verilator.git
+cd verilator
+autoconf
+./configure --prefix=/usr/local
+make -j$(nproc)
+sudo make install
+verilator --version  # confirm: "Verilator 5.048 ..."
 ```
 
 ### Build

--- a/test/test_sim_equivalence.py
+++ b/test/test_sim_equivalence.py
@@ -233,12 +233,19 @@ def emit_wrapper_and_tb(dut_path: Path,
                 cpp.append(f"        tb.{n} = ((uint64_t)rand() << 32) | (uint32_t)rand();")
         cpp.append(f"        tb.{clk} = 0; tb.eval();")
         cpp.append(f"        tb.{clk} = 1; tb.eval();")
-        for n, _w in outputs:
-            cpp.append(f"        if (tb.rtl_{n} != tb.nl_{n}) {{")
+        for n, w in outputs:
+            # Verilator C++ codegen returns sub-byte signals as uint8_t with
+            # uninitialised upper bits, so mask to the declared port width
+            # before comparing.  For >64-bit ports we'd need __VlWide
+            # handling; cap at 64 for now and skip the test if wider.
+            mask = "((1ULL << %d) - 1)" % w if w < 64 else "~0ULL"
+            cpp.append(f"        {{ unsigned long long r = (unsigned long long)tb.rtl_{n} & {mask};")
+            cpp.append(f"          unsigned long long s = (unsigned long long)tb.nl_{n}  & {mask};")
+            cpp.append(f"          if (r != s) {{")
             cpp.append(f"            std::printf(\"MISMATCH cycle %d: {n}: rtl=0x%llx nl=0x%llx\\n\","
-                       f" cycle, (unsigned long long)tb.rtl_{n}, (unsigned long long)tb.nl_{n});")
+                       f" cycle, r, s);")
             cpp.append("            mismatches++;")
-            cpp.append("        }")
+            cpp.append("          } }")
         cpp.append("    }")
     else:
         cpp.append(f"    srand({seed});")
@@ -249,12 +256,15 @@ def emit_wrapper_and_tb(dut_path: Path,
             else:
                 cpp.append(f"        tb.{n} = ((uint64_t)rand() << 32) | (uint32_t)rand();")
         cpp.append("        tb.eval();")
-        for n, _w in outputs:
-            cpp.append(f"        if (tb.rtl_{n} != tb.nl_{n}) {{")
+        for n, w in outputs:
+            mask = "((1ULL << %d) - 1)" % w if w < 64 else "~0ULL"
+            cpp.append(f"        {{ unsigned long long r = (unsigned long long)tb.rtl_{n} & {mask};")
+            cpp.append(f"          unsigned long long s = (unsigned long long)tb.nl_{n}  & {mask};")
+            cpp.append(f"          if (r != s) {{")
             cpp.append(f"            std::printf(\"MISMATCH cycle %d: {n}: rtl=0x%llx nl=0x%llx\\n\","
-                       f" cycle, (unsigned long long)tb.rtl_{n}, (unsigned long long)tb.nl_{n});")
+                       f" cycle, r, s);")
             cpp.append("            mismatches++;")
-            cpp.append("        }")
+            cpp.append("          } }")
         cpp.append("    }")
     cpp += [
         f"    if (mismatches == 0)",


### PR DESCRIPTION
Pin a specific Verilator release (v5.048) in CI so test/test_sim_equivalence.py runs against the same Verilator everywhere.

Changes:
- .github/workflows/ci.yml: drop the apt verilator package, add help2man, clone Verilator at v5.048, configure/make/install to /opt/verilator-5.048, cache the install via actions/cache, prepend bin to GITHUB_PATH. Cache makes the build a one-off cost.
- README.md: drop verilator from the apt one-liner; add a Verilator 5.x required block with a source-build snippet since stock package versions diverge widely across Ubuntu releases.
- test/test_sim_equivalence.py: mask each output to its declared port width before comparing. Verilator returns sub-byte signals as uint8_t with uninitialised upper bits, so the previous raw comparison fired spuriously on every 1-bit output. After this, sva_basic00 and simple_instance_array now pass co-sim cleanly.

With Verilator 5.048 locally the suite reports 18 soft-warns down from 20. Remaining warnings split between harness limitations and a few real UHDM-frontend gaps in SVA op support (vpiOpType 51, 92) — follow-ups.