### PR TITLE
Do not drop SVA-only modules when the property uses unsupported ops

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2533,7 +2533,15 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
             } else if (auto prop_expr = dynamic_cast<const UHDM::expr*>(prop)) {
                 cond = import_expression(prop_expr);
             }
-            if (cond.empty()) continue;
+            // When the property expression uses SVA operators we don't yet
+            // synthesise (`|->`, `|=>`, `until`, `[*]`, `throughout`, ...),
+            // import_expression returns an empty SigSpec.  Still emit a
+            // stub `$check` cell (with .A=1'b1) so the module isn't left
+            // body-less — otherwise the blackbox-detection pass below
+            // would mark it as a blackbox and `synth -auto-top` later
+            // fails with "No top module found!" for assertion-only DUTs.
+            if (cond.empty())
+                cond = RTLIL::SigSpec(RTLIL::State::S1);
             // Reduce to 1-bit if needed
             if (cond.size() > 1) {
                 cond = module->ReduceBool(NEW_ID, cond, false);


### PR DESCRIPTION
sva_range and sva_throughout are assertion-only modules whose property expressions use vpiNonOverlapImplyOp (51), vpiConsecutiveRepeatOp (60), vpiUntilOp (92), and vpiThroughoutOp. import_expression returns an empty SigSpec for those ops, the assertion importer was skipping the assert_stmt entirely, the module ended up body-less, the blackbox detector marked it as blackbox, and synth -auto-top errored with No top module found.

Fix in src/frontends/uhdm/uhdm2rtlil.cpp Assertions() loop: when import_expression returns empty, fall back to a constant 1 b1 so we still emit the $check cell. The cell keeps the module non-empty, the blackbox detector quiet, and synth -auto-top happy. The assertion itself becomes a vacuous always-true stub which is fine since these are verification-only constructs.

After the fix the two tests reach the Verilator sim-equiv flow and degrade to the harness no output ports soft-warn (script-side limitation, not a real bug). Sim-equiv warning count unchanged at 18 but the nature of these two warnings moved from real UHDM-frontend synth bug to harness limitation — the only actual synth-bug signal in the warning list before this PR.