### PR TITLE
sim_equivalence: skip self-checking DUTs instead of warning

### DIFF
--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -108,11 +108,19 @@ run_sim_equivalence_softwarn() {
         return 0  # silently skip if the optional tooling isn't built
     fi
     local log="$test_dir/sim_equiv.log"
-    if "$script" "$test_dir" >"$log" 2>&1; then
-        if grep -q '^PASS:' "$log"; then
-            echo "    ✅ Verilator co-sim PASSED"
-            return 0
-        fi
+    "$script" "$test_dir" >"$log" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ] && grep -q '^PASS:' "$log"; then
+        echo "    ✅ Verilator co-sim PASSED"
+        return 0
+    fi
+    # Exit code 77 = autotools "skip" convention.  Used by the harness
+    # for self-checking testbenches that have no observable outputs
+    # (everything is asserted internally) — not a failure, just not
+    # applicable to co-simulation.
+    if [ $rc -eq 77 ]; then
+        echo "    ⏭  Verilator co-sim SKIPPED (no outputs / self-checking)"
+        return 0
     fi
     echo "    ⚠️  Verilator co-sim WARNING (see $(basename "$test_dir")/sim_equiv.log)"
     SIM_EQUIV_WARN_TESTS=$((SIM_EQUIV_WARN_TESTS + 1))

--- a/test/test_sim_equivalence.py
+++ b/test/test_sim_equivalence.py
@@ -136,7 +136,11 @@ def emit_wrapper_and_tb(dut_path: Path,
               and n not in clocks and n not in resets]
     outputs = [(n, w) for (n, w, d) in ports if d == "output"]
     if not outputs:
-        sys.exit("❌ no output ports — nothing to compare")
+        # Self-checking testbench: input-only DUT with internal asserts.
+        # Nothing for an external co-sim to compare — not a failure, just
+        # not applicable.  Exit 77 (the autotools convention for "skip").
+        print("⏭  no output ports — self-checking DUT, sim-equiv N/A")
+        sys.exit(77)
 
     # Wrapper: instantiate the original SV top under the name dut_rtl.
     port_decl = []


### PR DESCRIPTION
11 of the 18 sim-equiv warnings were misleading — they fired on self-checking testbench-style DUTs that genuinely have no observable outputs (only assert property / always assert internally). Every one of them declares input-only ports at its SV top module: the top IS the testbench. A co-sim can not compare what is not exposed, so this is not a failure, it is not applicable.

Two small changes: test_sim_equivalence.py exits 77 (autotools skip convention) when outputs is empty; run_all_tests.sh recognises return code 77 as a clean skip instead of a warning.

Warning count drops from 18 to 7. Remaining 7 are wrapper port-shape reconciliation (5: gen_struct_access, nested_struct, simple_package, typedef_unpacked_input, plus one) and Verilator-side SV grammar gaps (2: sva_basic03 stop, sva_counter, sva_not).