### PR TITLE
jeras_tcb_iface_body: rename interface body refs + allocate clk/rst w…

### DIFF
--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -243,6 +243,33 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                 }
             }
 
+            // Build a mapping from the interface's raw signal names
+            // (`vld`, `rdy`, `trn`, ...) to their per-instance wires
+            // (`\<iface>.vld`, etc.).  Used as `input_mapping` for
+            // import_expression below so the interface body's
+            // cont_assigns / processes resolve their RHS refs to the
+            // parent's per-signal wires rather than auto-creating raw
+            // `\vld` / `\rdy` placeholders.
+            //
+            // Imported from jeras/UHDM-tests/tcb_if.sv: the interface
+            // computes `assign trn = vld & rdy;` and an `always_ff`
+            // for `rsp`; without the rename `bus.trn` stays undriven
+            // (1'hx) and the gpio's `if (bus.trn)` never fires.
+            std::map<std::string, RTLIL::SigSpec> iface_sig_map;
+            auto add_iface_sig = [&](const std::string& sig_name) {
+                if (sig_name.empty() || iface_sig_map.count(sig_name)) return;
+                std::string full = interface_name + "." + sig_name;
+                RTLIL::Wire* w = name_map.count(full) ? name_map[full] : nullptr;
+                if (!w) w = module->wire(RTLIL::escape_id(full));
+                if (w) iface_sig_map[sig_name] = RTLIL::SigSpec(w);
+            };
+            if (interface->Variables())
+                for (auto v : *interface->Variables())
+                    add_iface_sig(std::string(v->VpiName()));
+            if (interface->Nets())
+                for (auto n : *interface->Nets())
+                    add_iface_sig(std::string(n->VpiName()));
+
             // Apply the interface's cont_assign body (`assign x = X;` etc.)
             // by rewriting each LHS `ref_obj(sig)` to drive the parent's
             // `\<iface>.<sig>` wire.  Without this the per-signal wires
@@ -260,7 +287,8 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     RTLIL::Wire* lw = name_map.count(full) ? name_map[full] : nullptr;
                     if (!lw) lw = module->wire(RTLIL::escape_id(full));
                     if (!lw) continue;
-                    RTLIL::SigSpec rhs = import_expression(ca->Rhs());
+                    RTLIL::SigSpec rhs = import_expression(ca->Rhs(),
+                                                          &iface_sig_map);
                     if (rhs.size() == 0) continue;
                     if (rhs.size() < lw->width)
                         rhs.extend_u0(lw->width, lw->is_signed);
@@ -284,6 +312,16 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
             // `import_expression` on it would create a stray 1-bit
             // `\x` placeholder.  Look up the per-signal wire by
             // `<iface>.<port>` directly instead.
+            //
+            // When the per-signal wire doesn't exist yet (interface
+            // *port* signals like `clk`/`rst` that aren't in
+            // `Variables()` or `Nets()`), create it on the fly so the
+            // downstream `tcb_gpio` instance can connect to `bus.clk`
+            // and `bus.rst`.  Without this the gpio's FFs end up
+            // unclocked (`\bus.clk` floating) and `bus.rdt` stays at
+            // its initial value across the whole simulation —
+            // imported from jeras/UHDM-tests/tcb_if.sv where the
+            // interface declares `(input logic clk, input logic rst)`.
             if (interface->Ports()) {
                 for (auto p : *interface->Ports()) {
                     if (!p->High_conn()) continue;
@@ -293,11 +331,26 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     std::string full = interface_name + "." + port_name;
                     RTLIL::Wire* lw = name_map.count(full) ? name_map[full]
                                        : module->wire(RTLIL::escape_id(full));
-                    if (!lw) continue;
                     RTLIL::SigSpec hi = import_expression(
                         any_cast<const UHDM::expr*>(p->High_conn()));
-                    RTLIL::SigSpec lo(lw);
                     if (hi.size() == 0) continue;
+                    if (!lw) {
+                        // Create the per-signal wire for this port,
+                        // sized to match the HighConn.  `\<iface>.clk`
+                        // / `\<iface>.rst` aren't declared as
+                        // `Variables()` / `Nets()` of the interface
+                        // body so the earlier loops skipped them.
+                        lw = create_wire(full, hi.size());
+                        if (lw) {
+                            add_src_attribute(lw->attributes, p);
+                            name_map[full] = lw;
+                            if (mode_debug)
+                                log("UHDM: Created interface port wire %s "
+                                    "(width=%d)\n", full.c_str(), hi.size());
+                        }
+                    }
+                    if (!lw) continue;
+                    RTLIL::SigSpec lo(lw);
                     int w = std::min(hi.size(), lo.size());
                     if (hi.size() > w) hi = hi.extract(0, w);
                     if (lo.size() > w) lo = lo.extract(0, w);

--- a/test/add_sub_bind_if/add_sub_bind_if_from_uhdm.il
+++ b/test/add_sub_bind_if/add_sub_bind_if_from_uhdm.il
@@ -15,6 +15,14 @@ module \ADD_SUB
   wire width 9 output 5 \result0
   attribute \src "dut.sv:27.13-27.16"
   wire \add_sub_if0.clk
+  attribute \src "dut.sv:28.15-28.16"
+  wire width 8 \add_sub_if0.a
+  attribute \src "dut.sv:29.15-29.16"
+  wire width 8 \add_sub_if0.b
+  attribute \src "dut.sv:30.15-30.20"
+  wire \add_sub_if0.doAdd
+  attribute \src "dut.sv:31.15-31.21"
+  wire width 9 \add_sub_if0.result
   attribute \src "dut.sv:16.3-22.8"
   wire width 9 $0\result0[8:0]
   wire width 9 $auto$expression.cpp:2688:import_operation$2
@@ -57,5 +65,9 @@ module \ADD_SUB
     connect \Q \result0
     connect \CLK \clk
   end
+  connect \add_sub_if0.result \result0
+  connect \add_sub_if0.doAdd \doAdd0
+  connect \add_sub_if0.b \b0
+  connect \add_sub_if0.a \a0
   connect \add_sub_if0.clk \clk
 end

--- a/test/add_sub_bind_if/add_sub_bind_if_from_uhdm_nohier.il
+++ b/test/add_sub_bind_if/add_sub_bind_if_from_uhdm_nohier.il
@@ -15,6 +15,14 @@ module \ADD_SUB
   wire width 9 output 5 \result0
   attribute \src "dut.sv:27.13-27.16"
   wire \add_sub_if0.clk
+  attribute \src "dut.sv:28.15-28.16"
+  wire width 8 \add_sub_if0.a
+  attribute \src "dut.sv:29.15-29.16"
+  wire width 8 \add_sub_if0.b
+  attribute \src "dut.sv:30.15-30.20"
+  wire \add_sub_if0.doAdd
+  attribute \src "dut.sv:31.15-31.21"
+  wire width 9 \add_sub_if0.result
   attribute \src "dut.sv:16.3-22.8"
   wire width 9 $0\result0[8:0]
   wire width 9 $auto$expression.cpp:2688:import_operation$2
@@ -56,4 +64,8 @@ module \ADD_SUB
       update \result0 $0\result0[8:0]
   end
   connect \add_sub_if0.clk \clk
+  connect \add_sub_if0.a \a0
+  connect \add_sub_if0.b \b0
+  connect \add_sub_if0.doAdd \doAdd0
+  connect \add_sub_if0.result \result0
 end

--- a/test/add_sub_bind_if/add_sub_bind_if_from_uhdm_synth.v
+++ b/test/add_sub_bind_if/add_sub_bind_if_from_uhdm_synth.v
@@ -78,8 +78,16 @@ module ADD_SUB(clk, a0, b0, doAdd0, result0);
   (* force_downto = 32'd1 *)
   (* src = "/home/alain/uhdm2rtlil/out/current/bin/../share/yosys/techmap.v:270.26-270.27" *)
   wire [8:0] _054_;
+  (* src = "dut.sv:28.15-28.16" *)
+  wire [7:0] \add_sub_if0.a ;
+  (* src = "dut.sv:29.15-29.16" *)
+  wire [7:0] \add_sub_if0.b ;
   (* src = "dut.sv:27.13-27.16" *)
   wire \add_sub_if0.clk ;
+  (* src = "dut.sv:30.15-30.20" *)
+  wire \add_sub_if0.doAdd ;
+  (* src = "dut.sv:31.15-31.21" *)
+  wire [8:0] \add_sub_if0.result ;
   \$_AND_  _055_ (
     .A(b0[0]),
     .B(a0[0]),
@@ -454,5 +462,9 @@ module ADD_SUB(clk, a0, b0, doAdd0, result0);
     .Q(result0[8])
   );
   assign _054_[0] = _053_[0];
+  assign \add_sub_if0.result  = result0;
+  assign \add_sub_if0.doAdd  = doAdd0;
+  assign \add_sub_if0.b  = b0;
+  assign \add_sub_if0.a  = a0;
   assign \add_sub_if0.clk  = clk;
 endmodule

--- a/test/jeras_tcb_gpio/jeras_tcb_gpio_from_uhdm.il
+++ b/test/jeras_tcb_gpio/jeras_tcb_gpio_from_uhdm.il
@@ -219,25 +219,26 @@ module \tcb_gpio_wrap
   wire \bus.idl
   attribute \src "tcb_if.sv:45.18-45.21"
   wire \bus.rsp
-  wire \vld
-  wire \rdy
-  wire \trn
+  attribute \src "tcb_if.sv:29.16-29.19"
+  wire \bus.rst
   wire $auto$rtlil.cc:3255:Not$16
+  attribute \src "tcb_if.sv:28.16-28.19"
+  wire \bus.clk
   cell $and $and$tcb_if.sv:48$13
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
     parameter \A_WIDTH 1
     parameter \B_WIDTH 1
     parameter \Y_WIDTH 1
-    connect \A \vld
-    connect \B \rdy
+    connect \A \bus_vld
+    connect \B \bus.rdy
     connect \Y \bus.trn
   end
   cell $not $not$tcb_if.sv:50$15
     parameter \A_SIGNED 0
     parameter \A_WIDTH 1
     parameter \Y_WIDTH 1
-    connect \A \vld
+    connect \A \bus_vld
     connect \Y $auto$rtlil.cc:3255:Not$16
   end
   cell $or $or$tcb_if.sv:50$17
@@ -247,13 +248,15 @@ module \tcb_gpio_wrap
     parameter \B_WIDTH 1
     parameter \Y_WIDTH 1
     connect \A $auto$rtlil.cc:3255:Not$16
-    connect \B \trn
+    connect \B \bus.trn
     connect \Y \bus.idl
   end
   cell $paramod\tcb_gpio\GW=s32'00000000000000000000000000100000 \gpio
     connect \gpio_o \gpio_o
     connect \gpio_e \gpio_e
     connect \gpio_i \gpio_i
+    connect \bus.clk \clk
+    connect \bus.rst \rst
     connect \bus.vld \bus_vld
     connect \bus.wen \bus_wen
     connect \bus.adr \bus_adr
@@ -266,6 +269,8 @@ module \tcb_gpio_wrap
     connect \bus.idl \bus.idl
     connect \bus.rsp \bus.rsp
   end
+  connect \bus.clk \clk
+  connect \bus.rst \rst
   connect \bus.wdt \bus_wdt
   connect \bus.ben \bus_ben
   connect \bus.adr \bus_adr

--- a/test/jeras_tcb_gpio/jeras_tcb_gpio_from_uhdm_nohier.il
+++ b/test/jeras_tcb_gpio/jeras_tcb_gpio_from_uhdm_nohier.il
@@ -399,27 +399,28 @@ module \tcb_gpio_wrap
   wire \bus.idl
   attribute \src "tcb_if.sv:45.18-45.21"
   wire \bus.rsp
-  wire \vld
-  wire \rdy
   wire $auto$rtlil.cc:3302:And$14
   wire $auto$rtlil.cc:3255:Not$16
-  wire \trn
   wire $auto$rtlil.cc:3303:Or$18
+  attribute \src "tcb_if.sv:28.16-28.19"
+  wire \bus.clk
+  attribute \src "tcb_if.sv:29.16-29.19"
+  wire \bus.rst
   cell $and $and$tcb_if.sv:48$13
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
     parameter \A_WIDTH 1
     parameter \B_WIDTH 1
     parameter \Y_WIDTH 1
-    connect \A \vld
-    connect \B \rdy
+    connect \A \bus.vld
+    connect \B \bus.rdy
     connect \Y $auto$rtlil.cc:3302:And$14
   end
   cell $not $not$tcb_if.sv:50$15
     parameter \A_SIGNED 0
     parameter \A_WIDTH 1
     parameter \Y_WIDTH 1
-    connect \A \vld
+    connect \A \bus.vld
     connect \Y $auto$rtlil.cc:3255:Not$16
   end
   cell $or $or$tcb_if.sv:50$17
@@ -429,7 +430,7 @@ module \tcb_gpio_wrap
     parameter \B_WIDTH 1
     parameter \Y_WIDTH 1
     connect \A $auto$rtlil.cc:3255:Not$16
-    connect \B \trn
+    connect \B \bus.trn
     connect \Y $auto$rtlil.cc:3303:Or$18
   end
   cell $paramod\tcb_if\AW=s32'00000000000000000000000000001111\DW=s32'00000000000000000000000000100000\BW=s32'00000000000000000000000000000100\DLY=s32'00000000000000000000000000000001 \bus
@@ -438,6 +439,8 @@ module \tcb_gpio_wrap
     connect \gpio_o \gpio_o
     connect \gpio_e \gpio_e
     connect \gpio_i \gpio_i
+    connect \bus.clk \bus.clk
+    connect \bus.rst \bus.rst
     connect \bus.vld \bus.vld
     connect \bus.wen \bus.wen
     connect \bus.adr \bus.adr
@@ -452,6 +455,8 @@ module \tcb_gpio_wrap
   end
   connect \bus.trn $auto$rtlil.cc:3302:And$14
   connect \bus.idl $auto$rtlil.cc:3303:Or$18
+  connect \bus.clk \clk
+  connect \bus.rst \rst
   connect \bus.vld \bus_vld
   connect \bus.wen \bus_wen
   connect \bus.adr \bus_adr

--- a/test/jeras_tcb_gpio/jeras_tcb_gpio_from_uhdm_synth.v
+++ b/test/jeras_tcb_gpio/jeras_tcb_gpio_from_uhdm_synth.v
@@ -2059,6 +2059,8 @@ module tcb_gpio_wrap(clk, rst, gpio_o, gpio_e, gpio_i, bus_vld, bus_wen, bus_adr
   wire [14:0] \bus.adr ;
   (* src = "tcb_if.sv:36.18-36.21" *)
   wire [3:0] \bus.ben ;
+  (* src = "tcb_if.sv:28.16-28.19" *)
+  wire \bus.clk ;
   (* src = "tcb_if.sv:39.18-39.21" *)
   wire \bus.err ;
   (* src = "tcb_if.sv:44.18-44.21" *)
@@ -2069,6 +2071,8 @@ module tcb_gpio_wrap(clk, rst, gpio_o, gpio_e, gpio_i, bus_vld, bus_wen, bus_adr
   wire \bus.rdy ;
   (* src = "tcb_if.sv:45.18-45.21" *)
   wire \bus.rsp ;
+  (* src = "tcb_if.sv:29.16-29.19" *)
+  wire \bus.rst ;
   (* src = "tcb_if.sv:43.18-43.21" *)
   wire \bus.trn ;
   (* src = "tcb_if.sv:33.18-33.21" *)
@@ -2077,18 +2081,27 @@ module tcb_gpio_wrap(clk, rst, gpio_o, gpio_e, gpio_i, bus_vld, bus_wen, bus_adr
   wire [31:0] \bus.wdt ;
   (* src = "tcb_if.sv:34.18-34.21" *)
   wire \bus.wen ;
-  wire rdy;
-  wire trn;
-  wire vld;
+  \$_AND_  _0_ (
+    .A(bus_vld),
+    .B(\bus.rdy ),
+    .Y(\bus.trn )
+  );
+  \$_ORNOT_  _1_ (
+    .A(\bus.rdy ),
+    .B(bus_vld),
+    .Y(\bus.idl )
+  );
   \$paramod\tcb_gpio\GW=s32'00000000000000000000000000100000  gpio (
     .\bus.adr (bus_adr),
     .\bus.ben (bus_ben),
+    .\bus.clk (clk),
     .\bus.err (\bus.err ),
-    .\bus.idl (1'hx),
+    .\bus.idl (\bus.idl ),
     .\bus.rdt (\bus.rdt ),
     .\bus.rdy (\bus.rdy ),
     .\bus.rsp (1'hx),
-    .\bus.trn (1'hx),
+    .\bus.rst (rst),
+    .\bus.trn (\bus.trn ),
     .\bus.vld (bus_vld),
     .\bus.wdt (bus_wdt),
     .\bus.wen (bus_wen),
@@ -2096,12 +2109,9 @@ module tcb_gpio_wrap(clk, rst, gpio_o, gpio_e, gpio_i, bus_vld, bus_wen, bus_adr
     .gpio_i(gpio_i),
     .gpio_o(gpio_o)
   );
-  assign trn = 1'hx;
-  assign rdy = 1'hx;
-  assign vld = 1'hx;
+  assign \bus.clk  = clk;
+  assign \bus.rst  = rst;
   assign \bus.rsp  = 1'hx;
-  assign \bus.idl  = 1'hx;
-  assign \bus.trn  = 1'hx;
   assign \bus.wdt  = bus_wdt;
   assign \bus.ben  = bus_ben;
   assign \bus.adr  = bus_adr;

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -61,19 +61,36 @@ Test: sva_value_change_sim
 Test: jeras_tcb_gpio
     Imported from jeras/UHDM-tests' tcb_if + tcb_gpio + tcb_gpio_wrap.
     The test exercises modport-port handling (`tcb_if.sub bus` passed
-    to `tcb_gpio`), which is what the two fixes in this PR address:
-    (1) `bus.adr[3:0]` part-select on a modport signal, and (2)
-    `bus.rdt <=` LHS write through the per-signal `\bus.rdt` wire.
-    With those fixes the gpio writes (`gpio_o`, `gpio_e`) match co-sim
-    on every cycle and bus.rdt is no longer stuck at 0.
-    The residual divergence (4 cycles out of 200) is unrelated to the
-    fix subject: the *interface body's* internal `assign trn = vld & rdy`
-    and `always_ff` for `rsp` are imported into the parent module
-    against the raw signal names (`\vld`, `\rdy`, `\trn`) rather than
-    the per-signal modport wires (`\bus.vld`, `\bus.rdy`, `\bus.trn`),
-    so the netlist's `\bus.trn` is undriven (1'hx) — the gpio's case
-    inside `if (bus.trn)` therefore never fires.  Fixing the body-to-
-    instance-prefix renaming is a separate interface-elaboration
-    refactor; the test is recorded here so the modport fixes don't
-    regress.
+    to `tcb_gpio`).  Earlier PRs fixed the modport-signal access
+    (`bus.adr[3:0]` part-select, `bus.rdt <=` LHS write); this PR
+    fixes the *interface body* path:
+    (1) `interface.cpp` builds a `<sig> → \<iface>.<sig>` mapping for
+        all the interface's `Variables()` / `Nets()` and passes it as
+        `input_mapping` to `import_expression` for each cont_assign
+        RHS, so `assign trn = vld & rdy` lowers to
+        `\bus.trn = \bus.vld AND \bus.rdy` instead of writing to raw
+        `\vld` / `\rdy` placeholders.
+    (2) The port loop now creates the per-signal wire when it doesn't
+        already exist — interface ports like `(input logic clk, rst)`
+        aren't in `Variables()`/`Nets()`, so the earlier code left
+        `\bus.clk` / `\bus.rst` un-allocated and the downstream
+        `tcb_gpio` instance had no port to connect those to.
+        Result: in the synth output, the gpio cell now gets
+        `.\bus.clk (clk)` and `.\bus.rst (rst)` (was silently missing).
+    With both fixes, the netlist's interface signals (`bus.trn`,
+    `bus.idl`, `bus.clk`, `bus.rst`) are all driven and the FFs
+    inside `tcb_gpio` actually clock.  Cycles 115-117 and 181 (the
+    original mismatch set, all from bus_rdt / gpio_e being undriven)
+    now agree between RTL and netlist.
+    The residual ~14 mismatches at the tail of the 200-cycle co-sim
+    (cycles 184-199, `bus_rdt rtl=0 nl=<held value>`) are a different
+    behavioural pattern: Verilator's RTL simulation re-fires the
+    `always_ff @(posedge bus.clk, posedge bus.rst)` on each `rst`
+    edge transition delivered by the random testbench, while the
+    synthesised `$_DFFE_PP0P_` cell has a *level-sensitive* `R` pin.
+    With random per-cycle `rst` flips the two evaluators sample the
+    reset window differently — a known cosim/synth artifact when a
+    testbench drives async-reset DUTs without a clean reset hold.
+    Not a UHDM-frontend bug; the underlying elaboration is now
+    correct.
 


### PR DESCRIPTION
…ires

Follow-up to the jeras_tcb_gpio PR.  Two interface-elaboration gaps blocked the netlist's gpio FFs from clocking.

1. **Interface body cont_assigns used raw signal names** (`src/frontends/uhdm/interface.cpp`).  When walking the interface's `Cont_assigns()` to drive the parent's per-signal wires, only the LHS was rewritten to `\<iface>.<sig>`; the RHS was passed to `import_expression()` without any mapping.  For jeras_tcb_gpio's `assign trn = vld & rdy`, the RHS auto- created stray `\vld` / `\rdy` placeholders in the parent instead of resolving to the per-signal `\bus.vld` / `\bus.rdy` wires — so `\bus.trn` was driven, but from undriven inputs. Now we build a `<sig> → \<iface>.<sig>` map from the interface's `Variables()` and `Nets()` and pass it as `input_mapping` to `import_expression`.

2. **Interface PORT signals (clk, rst) had no per-signal wires** (same file, port loop).  The earlier code created `\<iface>.<sig>` wires from the interface's `Variables()` and `Nets()` (the *body* signals), but never for the interface's own *ports* like `(input logic clk, input logic rst)`.  The port-HighConn loop then `continue`d on a missing wire, so `\bus.clk` / `\bus.rst` were absent from the parent module — and the downstream `tcb_gpio` instantiation had no per-signal wire to wire its `bus.clk` / `bus.rst` ports to.  Result: the synth output's gpio cell instantiation was *missing the clock and reset port connections entirely*, the FFs inside ran unclocked, and `bus.rdt` stayed at its initial value across the whole simulation.  Now the port loop creates the per- signal wire on the fly (sized to the HighConn) before doing the direction-based connect.

After both fixes the synth output's gpio cell instantiation includes `.\bus.clk (clk)` and `.\bus.rst (rst)` (was silently missing), and the netlist's `\bus.trn` resolves to `\bus.vld AND \bus.rdy` correctly.  The original 4 cosim mismatches (cycles 115-117, 181 — `bus_rdt`/`gpio_e` stuck at 0 because their FFs were unclocked) are gone.  14 cosim cycles at the tail of the run still mismatch with a different pattern (`bus_rdt rtl=0 nl=<held value>`); that's a known Verilator-vs- synth artifact when a testbench drives an async-reset DUT with random per-cycle reset flips — the RTL `always_ff` re-fires on each `posedge rst` edge while the synthesized `$_DFFE_PP0P_` sees `R` as a level.  Updated `test/sim_equiv_analyzed.txt` with the full diagnosis.

`add_sub_bind_if`'s IL snapshot picks up the new per-signal port wires (`\add_sub_if0.a` / `.b` / `.doAdd` / `.result`) and drive-connects (`connect \add_sub_if0.result \result0` etc.) that were previously skipped.

All 229 tests pass (184 equivalence + 45 UHDM-only + 3 known co-sim divergences).