### PR TITLE
skip Yosys tests with \$__-prefixed module names (non-SV-compliant)

### DIFF
--- a/test/skipped_tests.txt
+++ b/test/skipped_tests.txt
@@ -7,3 +7,15 @@
 
 # Yosys tests that are skipped due to runtime issues
 arch/xilinx/priority_memory.v  # Skipped due to excessive runtime
+
+# Yosys tests using `$__`-prefixed module names (Yosys-internal
+# `$__SHREG_DFF_P_` / `$__XILINX_SHREG_` techmap targets).  These
+# are Yosys-specific identifiers — the `$` prefix is not part of
+# the SystemVerilog grammar.  Surelog rejects the declaration with
+# "mismatched input 'always' expecting <EOF>", so we can't take
+# them through our UHDM path.  Yosys's own Verilog frontend
+# accepts them because it auto-escapes any leading `$` in
+# identifiers, but that's not standards-conformant.  Analyzed and
+# skipped — not bugs in the UHDM frontend.
+arch/xilinx/xilinx_srl.v  # `module $__XILINX_SHREG_`
+various/shregmap.v        # `module $__SHREG_DFF_P_` and `module $__XILINX_SHREG_`


### PR DESCRIPTION
Two tests in the Yosys regression set declare modules with `\$__`-prefixed names — Yosys-internal techmap targets that are *not* valid SystemVerilog identifiers (the SV grammar reserves the leading `$` for system tasks/functions, not user identifiers).  Surelog rejects them with:

  Syntax error: mismatched input 'always' expecting <EOF>

at the line following the `module \$__SHREG_DFF_P_(...)` header. Yosys's own Verilog frontend accepts these because it auto-escapes any leading `$` in identifiers, but that's a non-standards-conformant extension.

Affected tests:
  * `arch/xilinx/xilinx_srl.v` — declares `module \$__XILINX_SHREG_`
  * `various/shregmap.v` — declares `module \$__SHREG_DFF_P_` and `module \$__XILINX_SHREG_`

Analyzed: not a UHDM-frontend bug; the test files are themselves not standards-compliant.  Added both to `test/skipped_tests.txt` with a documenting block.  The `run_yosys_tests.sh` runner now reports them as `Skipped` instead of `Failed`.