### PR TITLE
run_yosys_tests: preserve `.v` extension so Surelog stays in V2001 mode

### DIFF
--- a/test/run_yosys_tests.sh
+++ b/test/run_yosys_tests.sh
@@ -179,16 +179,28 @@ run_test() {
     # Record test start time
     local test_start_time=$(date +%s.%N)
     
-    # Copy the test file
-    cp "$test_file" "$test_dir/dut.sv"
-    
+    # Preserve the source extension so Surelog picks the right language
+    # mode — `.v` enters Verilog-2001 mode (where `ref` etc. are not
+    # reserved); `.sv` enters SystemVerilog mode.  Without this,
+    # upstream Verilog-2001 tests (e.g. yosys/tests/various/
+    # port_sign_extend.v with `module ref(...)`) failed Surelog parse.
+    # Yosys's verilog frontend stays in `-sv` for both — it's lenient
+    # enough to accept either, and many `.v` files in the yosys tree
+    # do rely on a few `-sv` parser conveniences.
+    local src_ext="${test_file##*.}"
+    local dut_ext="sv"
+    if [ "$src_ext" = "v" ]; then
+        dut_ext="v"
+    fi
+    cp "$test_file" "$test_dir/dut.${dut_ext}"
+
     # Preprocess the test file to fix SystemVerilog constructs
-    preprocess_test_file "$test_dir/dut.sv"
-    
+    preprocess_test_file "$test_dir/dut.${dut_ext}"
+
     # Create Yosys scripts
     cat > "$test_dir/test_verilog_read.ys" << EOF
 # Test script to read Verilog file directly in Yosys
-read_verilog -sv dut.sv
+read_verilog -sv dut.${dut_ext}
 write_rtlil ${test_name}_from_verilog_nohier.il
 hierarchy -auto-top
 stat
@@ -226,10 +238,11 @@ EOF
         verilog_success=true
     fi
     
-    # Run Surelog to generate UHDM
+    # Run Surelog to generate UHDM.  Surelog picks SV vs Verilog-2001
+    # from the file extension — see the `dut_ext` choice above.
     # Note: Surelog may return non-zero for elaboration warnings/errors (e.g. $error
     # assertions) but still produce a valid UHDM file, so check for the file instead
-    $SURELOG_BIN -parse -nobuiltin -nocache -d uhdm dut.sv > surelog.log 2>&1 || true
+    $SURELOG_BIN -parse -nobuiltin -nocache -d uhdm dut.${dut_ext} > surelog.log 2>&1 || true
 
     # Run UHDM frontend
     uhdm_success=false


### PR DESCRIPTION
run_yosys_tests.sh always copied the upstream source as `dut.sv`, which made Surelog pick SystemVerilog mode regardless of the source's real language.  For Verilog-2001 sources that use identifiers reserved in IEEE 1800-2017 — e.g. `module ref(...)` in yosys/tests/various/port_sign_extend.v — Surelog correctly rejected the file and the test landed as a hard FAILED even though the same source parses cleanly in plain-Verilog mode.

Fix: detect `${test_file##*.}` and copy as `dut.v` for `.v` sources (Surelog picks the language from the extension), keep `dut.sv` for `.sv` sources.  Yosys's verilog frontend stays on `read_verilog -sv` either way — it's lenient enough to accept both forms.

Verified locally:
  ./run_yosys_tests.sh port_sign_extend → PASSED (was: FAILED).
  ./run_yosys_tests.sh load_and_derive → still Expected failure
    (.sv source, `ref` still rejected, as listed in
    failing_tests.txt).
  ./run_yosys_tests.sh svinterface1_syn → still Expected failure
    (.v source, but Yosys-emitted `#~@...#~@` attribute literals
    can't be tokenised by Surelog).