### PR TITLE
failing_tests.txt: track verific/ext_ramnet_err.sv

### DIFF
--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -20,3 +20,13 @@ svinterfaces/resolve_types.sv
 # matrix stays exhaustive.  The matching .sv source
 # (svinterfaces/svinterface1.sv) is covered by test/svinterface1/.
 svinterfaces/svinterface1_syn.v
+
+# Verific-specific test that *requires* Verific to emit a specific
+# error message about a cross-module memory reference
+# (`u_sub_rom.mem[f_addr]` in an `assume` from the parent module).
+# The upstream `.ys` script asserts that error via
+# `logger -expect error`; Surelog accepts the SV without diagnostics
+# (legal IEEE-1800 hierarchical access — the error is a Verific
+# limitation, not a language issue), so the test is irrelevant to our
+# Surelog/UHDM flow.  Documented here for upstream-matrix parity.
+verific/ext_ramnet_err.sv


### PR DESCRIPTION
The upstream `verific/ext_ramnet_err.sv` is a Verific-specific diagnostic test: the matching `.ys` script asserts that Verific emits a `Memory net '...' missing` error for a cross-module hierarchical memory reference in an `assume`
(`u_sub_rom.mem[f_addr]` accessed from the parent module).

Surelog accepts the same SV without diagnostics — the access is legal hierarchical IEEE-1800 — so the test has no meaningful synthesis outcome on our flow.  Adding the entry so the upstream tracking matrix stays exhaustive; the `run_yosys_tests.sh` runner now reports the run as `⚠️ Expected failure` instead of a hard FAILED.