### PR TITLE
func_upto: bit-select on parameter — don't divide non-multidim width

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This project bridges the gap between SystemVerilog source code and Yosys synthes
 This enables full SystemVerilog synthesis capability in Yosys, including advanced features not available in Yosys's built-in Verilog frontend.
 
 ### Test Suite Status
-- **Total Tests**: 280 tests covering comprehensive SystemVerilog features
-- **Success Rate**: 100% (280/280 tests functional, 0 known failures)
-- **Passing**: 235 tests with formal equivalence verified between UHDM and Verilog frontends
+- **Total Tests**: 281 tests covering comprehensive SystemVerilog features
+- **Success Rate**: 100% (281/281 tests functional, 0 known failures)
+- **Passing**: 236 tests with formal equivalence verified between UHDM and Verilog frontends
 - **UHDM-Only Success**: 45 tests demonstrating UHDM's superior SystemVerilog support — tests in this category use SystemVerilog features the Verilog frontend can't parse, so formal equivalence against it is not possible. They are instead verified end-to-end against Verilator with random constraint generation: the original `dut.sv` (RTL) and the UHDM-frontend's post-`synth -auto-top` gate-level netlist are instantiated side-by-side in a SystemVerilog testbench driven by shared clocks/resets and randomized inputs, and their outputs are compared cycle by cycle:
   - `nested_struct` - Complex nested structures
   - `simple_instance_array` - Instance array support

--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4407,32 +4407,37 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                 if (index.is_fully_const()) {
                     int idx = index.as_const().as_int();
                     // Compute the element width from the parameter's
-                    // typespec ranges.  For a logic_typespec the OUTER
-                    // range count divides the total width; the
-                    // remainder is the element width that `P[i]`
-                    // extracts.
+                    // typespec ranges.  For a packed multi-range
+                    // logic_typespec the OUTER range count divides the
+                    // total width to give the slot width that `P[i]`
+                    // extracts.  For a plain 1-D parameter (single
+                    // range or int_typespec) `P[i]` is just bit `i`.
                     int elem_w = 1;
-                    int outer_size = 1;
                     int outer_low = 0;
+                    bool packed_multidim = false;
                     if (auto rts = param->Typespec()) {
                         if (auto ats = rts->Actual_typespec()) {
                             if (ats->UhdmType() == uhdmlogic_typespec) {
                                 auto lt = dynamic_cast<const UHDM::logic_typespec*>(ats);
-                                if (lt && lt->Ranges() && !lt->Ranges()->empty()) {
+                                if (lt && lt->Ranges() && !lt->Ranges()->empty() &&
+                                    (lt->Ranges()->size() > 1 ||
+                                     lt->Elem_typespec() != nullptr)) {
+                                    packed_multidim = true;
                                     auto r0 = (*lt->Ranges())[0];
                                     RTLIL::SigSpec ls = import_expression(r0->Left_expr());
                                     RTLIL::SigSpec rs2 = import_expression(r0->Right_expr());
                                     if (ls.is_fully_const() && rs2.is_fully_const()) {
                                         int l = ls.as_int(), r = rs2.as_int();
-                                        outer_size = std::abs(l - r) + 1;
+                                        int outer_size = std::abs(l - r) + 1;
                                         outer_low = std::min(l, r);
+                                        if (outer_size > 0 && total % outer_size == 0)
+                                            elem_w = total / outer_size;
                                     }
                                 }
                             }
                         }
                     }
-                    if (outer_size > 0 && total % outer_size == 0)
-                        elem_w = total / outer_size;
+                    (void)packed_multidim;
                     int slot = idx - outer_low;
                     int off = slot * elem_w;
                     if (off >= 0 && off + elem_w <= total) {

--- a/test/func_upto/dut.sv
+++ b/test/func_upto/dut.sv
@@ -1,0 +1,77 @@
+`default_nettype none
+
+module evil;
+    parameter HI = 3;
+    parameter LO = 0;
+    parameter SPAN = 1;
+    parameter [HI:LO] A_VAL = 4'b0110;
+    parameter [HI:LO] B_VAL = 4'b1100;
+    parameter [2:0] SWAPS = 0;
+
+    localparam D_LEFT  = !(SWAPS[0]) ? HI : LO;
+    localparam D_RIGHT =  (SWAPS[0]) ? HI : LO;
+    localparam E_LEFT  = !(SWAPS[1]) ? HI : LO;
+    localparam E_RIGHT =  (SWAPS[1]) ? HI : LO;
+    localparam F_LEFT  = !(SWAPS[2]) ? HI : LO;
+    localparam F_RIGHT =  (SWAPS[2]) ? HI : LO;
+
+    localparam [HI:LO] A_CONST = A_VAL;
+    localparam [HI:LO] B_CONST = B_VAL;
+    localparam [HI:LO] C_CONST = F(A_CONST, B_CONST);
+
+    reg [HI:LO] C_WIRE, C_FUNC;
+    always @* begin
+        assert (C_CONST == C_WIRE);
+        assert (C_CONST == C_FUNC);
+    end
+
+    initial begin : blk
+        reg [HI:LO] A_WIRE;
+        reg [HI:LO] B_WIRE;
+        reg [D_LEFT:D_RIGHT] D;
+        reg [E_LEFT:E_RIGHT] E;
+        reg [F_LEFT:F_RIGHT] F_WIRE;
+        reg [31:0] i;
+        A_WIRE = A_VAL;
+        B_WIRE = B_VAL;
+        D = A_WIRE;
+        E = B_WIRE;
+        F_WIRE = 0;
+        for (i = LO; i + SPAN < HI; i = i + SPAN)
+            if (SPAN == 1)
+                F_WIRE[i] = D[i] && E[i];
+            else
+                F_WIRE[i+:SPAN] = D[i+:SPAN] && E[i+:SPAN];
+        C_WIRE = F_WIRE;
+        C_FUNC = F(A_WIRE, B_WIRE);
+    end
+
+    function automatic [F_LEFT:F_RIGHT] F(
+        input [D_LEFT:D_RIGHT] D,
+        input [E_LEFT:E_RIGHT] E);
+        reg [31:0] i;
+        F = 0;
+        for (i = LO; i + SPAN < HI; i = i + SPAN)
+            if (SPAN == 1)
+                F[i] = D[i] && E[i];
+            else
+                F[i+:SPAN] = D[i+:SPAN] && E[i+:SPAN];
+    endfunction
+endmodule
+
+module top;
+    for (genvar hi = 0; hi < 3; hi++)
+    for (genvar lo = 0; lo <= hi; lo++)
+    for (genvar span = 1; span <= hi - lo + 1; span++)
+    for (genvar a_val = 0; a_val < 2 ** (hi - lo + 1); a_val++)
+    for (genvar b_val = 0; b_val < 2 ** (hi - lo + 1); b_val++)
+    for (genvar swaps = 0; swaps < 2 ** 3; swaps++)
+        evil #(
+            .HI(hi),
+            .LO(lo),
+            .SPAN(span),
+            .A_VAL(a_val),
+            .B_VAL(b_val),
+            .SWAPS(swaps)
+        ) e();
+endmodule


### PR DESCRIPTION
`SWAPS[2]` where `SWAPS` is a `parameter [2:0]` (or any 1-D parameter) went through the bit-select-on-parameter path in
`import_bit_select`.  That code defaults `outer_size = 1` and then unconditionally sets `elem_w = total / outer_size` when the divisor divides evenly — so for the typical case where `param_value` is the raw 64-bit constant from Surelog (`UINT:0` with `vpiSize:64`), it computed `elem_w = 64` and treated `P[i]` as a 64-bit slot.  The `off + elem_w <= total` check then failed for any `i > 0` and the handler fell through to `log_error("Could not find wire '%s' for bit select")`.

Fix: only divide when the parameter's typespec actually encodes a packed multi-dim shape — `logic_typespec` with more than one `Ranges()` entry or a non-null `Elem_typespec()`.  Otherwise keep `elem_w = 1` so `P[i]` extracts bit `i` of the constant.

Imports yosys/tests/verilog/func_upto.sv (the `evil` module's `localparam F_LEFT = !(SWAPS[2]) ? HI : LO;` was the trip-wire); 281 tests pass.

Note: the test's expanded RTLIL is huge (~200k lines per file from 288 generate-block instances of `evil`), so only the `dut.sv` is checked in; the *_from_*.il artefacts are intentionally omitted.