### PR TITLE
concat_lhs_signext: sign-extend & FF-infer concat LHS in always_ff

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This project bridges the gap between SystemVerilog source code and Yosys synthes
 This enables full SystemVerilog synthesis capability in Yosys, including advanced features not available in Yosys's built-in Verilog frontend.
 
 ### Test Suite Status
-- **Total Tests**: 281 tests covering comprehensive SystemVerilog features
-- **Success Rate**: 100% (281/281 tests functional, 0 known failures)
-- **Passing**: 236 tests with formal equivalence verified between UHDM and Verilog frontends
+- **Total Tests**: 283 tests covering comprehensive SystemVerilog features
+- **Success Rate**: 99.6% (282/283 tests functional, 1 known failure)
+- **Passing**: 237 tests with formal equivalence verified between UHDM and Verilog frontends
 - **UHDM-Only Success**: 45 tests demonstrating UHDM's superior SystemVerilog support — tests in this category use SystemVerilog features the Verilog frontend can't parse, so formal equivalence against it is not possible. They are instead verified end-to-end against Verilator with random constraint generation: the original `dut.sv` (RTL) and the UHDM-frontend's post-`synth -auto-top` gate-level netlist are instantiated side-by-side in a SystemVerilog testbench driven by shared clocks/resets and randomized inputs, and their outputs are compared cycle by cycle:
   - `nested_struct` - Complex nested structures
   - `simple_instance_array` - Instance array support

--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -1588,10 +1588,27 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                 }
 
                 if (func_name == "$signed" && args.size() == 1) {
-                    // $signed just returns the argument with signed interpretation
-                    // The signedness will be handled by the operation that uses it
-                    log_debug("UHDM: $signed returning argument of size %d\n", args[0].size());
-                    return args[0];
+                    // Wrap the argument in a signed intermediate wire so
+                    // downstream resize/extend paths (assignment widening,
+                    // arithmetic cell A/B_SIGNED) pick up the signedness
+                    // from `rhs.as_wire()->is_signed`.  Without the wire
+                    // the SigSpec carries no signedness tag and a
+                    // concat-LHS sync assignment like
+                    //   {y[31:20], y[10:1], ...} <= $signed({x, 1'b0});
+                    // zero-extends instead of sign-extends
+                    // (yosys/tests/functional/picorv32.v decoded_imm_j).
+                    if (args[0].is_wire() && args[0].as_wire()->is_signed) {
+                        log_debug("UHDM: $signed argument already signed wire, passing through (size %d)\n",
+                                  args[0].size());
+                        return args[0];
+                    }
+                    RTLIL::Wire* signed_w =
+                        module->addWire(NEW_ID, args[0].size());
+                    signed_w->is_signed = true;
+                    module->connect(RTLIL::SigSpec(signed_w), args[0]);
+                    log_debug("UHDM: $signed wrapped %d-bit arg in signed intermediate\n",
+                              args[0].size());
+                    return RTLIL::SigSpec(signed_w);
                 } else if (func_name == "$unsigned" && args.size() == 1) {
                     // $unsigned just returns the argument with unsigned interpretation
                     return args[0];

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -130,9 +130,116 @@ void UhdmImporter::process_assignment_lhs_rhs(const UHDM::assignment* assign, RT
 }
 
 
+// Extract assigned signals from a single LHS expression. Handles ref_obj,
+// net_bit, part_select, indexed_part_select, bit_select, hier_path, and
+// concatenation operations (`{a, b[hi:lo], c[idx]} <= rhs`) by recursing on
+// each concat operand. Caller pushes results into `signals`.
+void UhdmImporter::extract_lhs_signals(const expr* lhs_expr, std::vector<AssignedSignal>& signals) {
+    if (!lhs_expr) return;
+
+    // Concat LHS: recurse on each operand so the temp-wire setup allocates
+    // a `$0\<base>` for each base wire written through the concat.
+    if (lhs_expr->VpiType() == vpiOperation) {
+        auto op = any_cast<const operation*>(lhs_expr);
+        if (op && op->VpiOpType() == vpiConcatOp) {
+            if (auto operands = op->Operands()) {
+                for (auto operand : *operands) {
+                    if (auto op_expr = dynamic_cast<const expr*>(operand)) {
+                        extract_lhs_signals(op_expr, signals);
+                    }
+                }
+            }
+            return;
+        }
+    }
+
+    AssignedSignal sig;
+    sig.lhs_expr = lhs_expr;
+
+    if (lhs_expr->VpiType() == vpiRefObj) {
+        auto ref = any_cast<const ref_obj*>(lhs_expr);
+        sig.name = std::string(ref->VpiName());
+        sig.is_part_select = false;
+        signals.push_back(sig);
+    } else if (lhs_expr->VpiType() == vpiNetBit) {
+        auto net_bit = any_cast<const UHDM::net_bit*>(lhs_expr);
+        sig.name = std::string(net_bit->VpiName());
+        sig.is_part_select = false;
+        signals.push_back(sig);
+    } else if (lhs_expr->VpiType() == vpiIndexedPartSelect) {
+        auto indexed_part_sel = any_cast<const indexed_part_select*>(lhs_expr);
+        sig.is_part_select = true;
+        if (!indexed_part_sel->VpiName().empty())
+            sig.name = std::string(indexed_part_sel->VpiName());
+        signals.push_back(sig);
+    } else if (lhs_expr->VpiType() == vpiPartSelect) {
+        auto part_sel = any_cast<const part_select*>(lhs_expr);
+        sig.is_part_select = true;
+        if (auto parent = part_sel->VpiParent()) {
+            if (parent->VpiType() == vpiRefObj) {
+                auto ref = any_cast<const ref_obj*>(parent);
+                sig.name = std::string(ref->VpiName());
+            } else if (!parent->VpiName().empty()) {
+                sig.name = std::string(parent->VpiName());
+            }
+        }
+        if (sig.name.empty() && !part_sel->VpiDefName().empty())
+            sig.name = std::string(part_sel->VpiDefName());
+        if (sig.name.empty() && !part_sel->VpiName().empty())
+            sig.name = std::string(part_sel->VpiName());
+        signals.push_back(sig);
+    } else if (lhs_expr->VpiType() == vpiBitSelect) {
+        auto bit_sel = any_cast<const bit_select*>(lhs_expr);
+        sig.is_part_select = true;
+        if (!bit_sel->VpiName().empty()) {
+            sig.name = std::string(bit_sel->VpiName());
+        } else if (auto parent = bit_sel->VpiParent()) {
+            if (parent->VpiType() == vpiRefObj) {
+                auto ref = any_cast<const ref_obj*>(parent);
+                sig.name = std::string(ref->VpiName());
+            } else if (!parent->VpiName().empty()) {
+                sig.name = std::string(parent->VpiName());
+            }
+        }
+        if (!sig.name.empty()) {
+            auto idx = bit_sel->VpiIndex();
+            bool is_const_idx = idx && idx->VpiType() == vpiConstant;
+            if (!is_const_idx) {
+                RTLIL::IdString mem_id = RTLIL::escape_id(sig.name);
+                if (!module->memories.count(mem_id) &&
+                    module->wire(RTLIL::escape_id(sig.name + "[0]"))) {
+                    return;
+                }
+            }
+        }
+        signals.push_back(sig);
+    } else if (lhs_expr->VpiType() == vpiHierPath) {
+        auto hp = any_cast<const hier_path*>(lhs_expr);
+        sig.is_part_select = false;
+        std::string full_name = std::string(hp->VpiName());
+        std::string base;
+        size_t dot_pos = full_name.find('.');
+        if (dot_pos != std::string::npos)
+            base = full_name.substr(0, dot_pos);
+        else
+            base = full_name;
+        RTLIL::Wire* base_w = base.empty() ? nullptr :
+            module->wire(RTLIL::escape_id(base));
+        bool base_is_wire = base_w != nullptr &&
+            !base_w->attributes.count(RTLIL::escape_id("is_interface"));
+        bool full_is_wire = !full_name.empty() &&
+            module->wire(RTLIL::escape_id(full_name)) != nullptr;
+        if (full_is_wire && !base_is_wire)
+            sig.name = full_name;
+        else
+            sig.name = base;
+        signals.push_back(sig);
+    }
+}
+
 void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<AssignedSignal>& signals) {
     if (!stmt) return;
-    
+
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
@@ -141,9 +248,13 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                 if (auto lhs_expr = dynamic_cast<const expr*>(lhs)) {
                     AssignedSignal sig;
                     sig.lhs_expr = lhs_expr;
-                    
+
                     log("extract_assigned_signals: LHS type is %d\n", lhs_expr->VpiType());
-                    if (lhs_expr->VpiType() == vpiRefObj) {
+                    if (lhs_expr->VpiType() == vpiOperation) {
+                        // Concat LHS — delegate to extract_lhs_signals which
+                        // recurses on each operand (`{a, b[hi:lo]} <= rhs`).
+                        extract_lhs_signals(lhs_expr, signals);
+                    } else if (lhs_expr->VpiType() == vpiRefObj) {
                         auto ref = any_cast<const ref_obj*>(lhs_expr);
                         sig.name = std::string(ref->VpiName());
                         sig.is_part_select = false;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -618,6 +618,7 @@ struct UhdmImporter {
     RTLIL::IdString get_unique_cell_name(const std::string& base_name);
     UHDM::VectorOfany *begin_block_stmts(const any *stmt);
     void extract_assigned_signals(const any* stmt, std::vector<AssignedSignal>& signals);
+    void extract_lhs_signals(const UHDM::expr* lhs_expr, std::vector<AssignedSignal>& signals);
     void extract_assigned_signal_names(const any* stmt, std::set<std::string>& signal_names); 
     bool contains_complex_constructs(const any* stmt);
     bool is_memory_write(const assignment* assign, RTLIL::Module* module);

--- a/test/concat_lhs_signext/dut.sv
+++ b/test/concat_lhs_signext/dut.sv
@@ -1,0 +1,18 @@
+// Reproducer extracted from picorv32.v line 878:
+//   { y[31:20], y[10:1], y[11], y[19:12], y[0] } <= $signed({x, 1'b0});
+//
+// The concat LHS covers all 32 bits of `y` in a swizzled order; the
+// RHS is a 21-bit signed value that must sign-extend bits 21..31 of the
+// destination from RHS bit 20.  Bit position 20 of `y` (which is at
+// LHS concat-position 20) must therefore reflect the sign bit of the
+// 21-bit value (= `x[19]`), not 1'b0.
+module concat_lhs_signext(
+    input wire clk,
+    input wire [19:0] x,
+    output reg [31:0] y
+);
+    initial y = 32'h0;
+    always @(posedge clk)
+        { y[31:20], y[10:1], y[11], y[19:12], y[0] }
+            <= $signed({x, 1'b0});
+endmodule

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -30,3 +30,14 @@ svinterfaces/svinterface1_syn.v
 # limitation, not a language issue), so the test is irrelevant to our
 # Surelog/UHDM flow.  Documented here for upstream-matrix parity.
 verific/ext_ramnet_err.sv
+
+# picorv32 is a 3000-line RISC-V core that exercises many corner cases
+# of the UHDM frontend simultaneously.  Rather than ship a partial fix,
+# the bugs surfaced by picorv32 are being extracted as minimal
+# reproducers (one PR per root cause) so each fix lands isolated and
+# regression-tested.  First reproducer landed: `test/concat_lhs_signext/`
+# covers `{y[31:20], y[10:1], y[11], y[19:12], y[0]} <= $signed({x,1'b0})`
+# (sign-extension across a swizzled concat LHS in an `always @(posedge)`).
+# Remaining picorv32 issues still in progress; expect this entry to be
+# removed once the dependent fixes are merged.
+functional/picorv32.v


### PR DESCRIPTION
Two bugs prevented `always @(posedge clk) {y[hi:lo], y[mi:mj], ...} <= $signed(rhs)` from synthesising correctly (surfaces in picorv32's J-type immediate decode at picorv32.v:878).

1. `$signed(expr)` in the UHDM frontend used to return the operand's SigSpec untouched.  RTLIL signedness lives on the Wire's `is_signed` bit, not on bare chunks, so the downstream sync-assignment width adapter saw an unsigned RHS and zero-extended (`'0` instead of the sign bit) when widening into the concat LHS.  `import_expression` now allocates a 1-cycle signed intermediate wire and connects the operand to it, so `extend_u0(size, /*signed=*/true)` paths trigger.

2. `extract_assigned_signals` had no case for `vpiOperation / vpiConcatOp` on the LHS, so the comb-style switch path in `import_always_ff` allocated no `$0\<base>` temp wire and emitted no `update` action — the concat write landed in `root_case.actions` alone, `proc_dff` saw an empty sync rule and inferred no register. Result was a purely combinational `connect`, no FFs.

   Factored the existing LHS-type dispatch out of `extract_assigned_signals` into a new `extract_lhs_signals` helper that recurses on concat operands, so each base wire written through `{a[hi:lo], b[idx], ...}` is reported as an assigned signal and gets its `$0\<base>` allocated normally.  `map_to_temp_wire` already rewrites chunked LHSes via the per-base `$0\` lookup, so the downstream switch/sync structure falls out unchanged.

`test/concat_lhs_signext/` is the minimal reproducer extracted from picorv32.  Both UHDM and Verilog frontends now produce a single `$dff WIDTH=31` (bit 0 is the constant `1'b0` from the RHS concat) and the formal equivalence check passes.

picorv32 itself still fails on the remaining corner cases; tracking that in `failing_tests.txt` so each follow-up issue can be extracted as its own minimal reproducer and shipped one PR at a time.