### PR TITLE
full_case_latch: honour (* full_case *) attr on case_stmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This project bridges the gap between SystemVerilog source code and Yosys synthes
 This enables full SystemVerilog synthesis capability in Yosys, including advanced features not available in Yosys's built-in Verilog frontend.
 
 ### Test Suite Status
-- **Total Tests**: 283 tests covering comprehensive SystemVerilog features
-- **Success Rate**: 99.6% (282/283 tests functional, 1 known failure)
-- **Passing**: 237 tests with formal equivalence verified between UHDM and Verilog frontends
+- **Total Tests**: 284 tests covering comprehensive SystemVerilog features
+- **Success Rate**: 99.6% (283/284 tests functional, 1 known failure)
+- **Passing**: 238 tests with formal equivalence verified between UHDM and Verilog frontends
 - **UHDM-Only Success**: 45 tests demonstrating UHDM's superior SystemVerilog support — tests in this category use SystemVerilog features the Verilog frontend can't parse, so formal equivalence against it is not possible. They are instead verified end-to-end against Verilator with random constraint generation: the original `dut.sv` (RTL) and the UHDM-frontend's post-`synth -auto-top` gate-level netlist are instantiated side-by-side in a SystemVerilog testbench driven by shared clocks/resets and randomized inputs, and their outputs are compared cycle by cycle:
   - `nested_struct` - Complex nested structures
   - `simple_instance_array` - Instance array support

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10,6 +10,7 @@
 #include <uhdm/sys_func_call.h>
 #include <uhdm/parameter.h>
 #include <uhdm/variables.h>
+#include <uhdm/attribute.h>
 #include "kernel/fmt.h"
 #include <algorithm>
 #include <functional>
@@ -8615,6 +8616,23 @@ void UhdmImporter::import_case_stmt_comb(const case_stmt* uhdm_case, RTLIL::Proc
         sw->attributes[ID::full_case] = RTLIL::Const(1);
     }
 
+    // `(* full_case *)` / `(* parallel_case *)` Verilog attribute
+    // syntax shows up as a `vpiAttribute` child on the case_stmt.
+    // Same intent as the SV qualifier above — used by picorv32.v's
+    // `mem_la_wdata`/`mem_rdata_word` combinational case.
+    bool has_full_case_attr = false;
+    if (auto attrs = uhdm_case->Attributes()) {
+        for (auto a : *attrs) {
+            std::string nm(a->VpiName());
+            if (nm == "full_case") {
+                sw->attributes[ID::full_case] = RTLIL::Const(1);
+                has_full_case_attr = true;
+            } else if (nm == "parallel_case") {
+                sw->attributes[ID::parallel_case] = RTLIL::Const(1);
+            }
+        }
+    }
+
     if (!items.empty()) {
         for (auto& d : items) {
             // Extend each case-item compare value to context width
@@ -8639,6 +8657,45 @@ void UhdmImporter::import_case_stmt_comb(const case_stmt* uhdm_case, RTLIL::Proc
         RTLIL::CaseRule* default_case = new RTLIL::CaseRule;
         add_src_attribute(default_case->attributes, uhdm_case);
         sw->cases.push_back(default_case);
+    }
+
+    // Ensure there's a default case when (* full_case *) is present and
+    // the user-written cases don't already cover every value.  The
+    // surrounding always_comb path emits hold defaults
+    // (`$0\sig = \sig`) BEFORE the switch, so an empty/absent default
+    // branch leaves `$0\sig` driven by `\sig` → `proc_dlatch` infers a
+    // latch even with `\full_case` set.  Match the Yosys Verilog
+    // frontend by emitting a default case that assigns `X` to every
+    // signal written anywhere in the case body — the attribute is the
+    // contract that the X path is unreachable, so the synthesizer can
+    // safely treat it as don't-care and collapse to pure comb logic.
+    if (has_full_case_attr) {
+        RTLIL::CaseRule* default_case = nullptr;
+        for (auto c : sw->cases) {
+            if (c->compare.empty()) { default_case = c; break; }
+        }
+        if (!default_case) {
+            default_case = new RTLIL::CaseRule;
+            sw->cases.push_back(default_case);
+        }
+
+        std::vector<AssignedSignal> body_signals;
+        if (auto case_items = uhdm_case->Case_items()) {
+            for (auto case_item : *case_items)
+                if (auto s = case_item->Stmt())
+                    extract_assigned_signals(s, body_signals);
+        }
+        std::set<std::string> seen_keys;
+        for (const auto& sig : body_signals) {
+            if (!sig.lhs_expr) continue;
+            RTLIL::SigSpec lhs = import_expression(sig.lhs_expr);
+            if (lhs.size() == 0) continue;
+            RTLIL::SigSpec mapped = map_to_temp_wire(lhs);
+            std::string key = log_signal(mapped);
+            if (!seen_keys.insert(key).second) continue;
+            default_case->actions.push_back(
+                RTLIL::SigSig(mapped, RTLIL::SigSpec(RTLIL::State::Sx, mapped.size())));
+        }
     }
 
     proc->root_case.switches.push_back(sw);

--- a/test/full_case_latch/dut.sv
+++ b/test/full_case_latch/dut.sv
@@ -1,0 +1,37 @@
+// Reproducer extracted from picorv32.v lines 401-428:
+//   always @* begin
+//     (* full_case *)
+//     case (mem_wordsize)
+//       0: begin mem_la_wdata = ...; mem_la_wstrb = ...; mem_rdata_word = ...; end
+//       1: begin ... end
+//       2: begin ... end
+//     endcase
+//   end
+//
+// The `case` covers values 0..2 of a 2-bit selector; value 3 is
+// unassigned.  Yosys's Verilog frontend honours the `(* full_case *)`
+// attribute and treats the missing 3 path as don't-care, producing
+// pure combinational logic.  The UHDM frontend drops the attribute
+// (or fails to propagate it to the resulting case_stmt) so `proc_dlatch`
+// infers `$_DLATCH_*` cells for every signal written in the case —
+// 68 such latches in the full picorv32 build.  `equiv_induct` then
+// aborts with "No SAT model available for cell ... ($_DLATCH_N_)"
+// since DLATCH primitives are not modelled by satgen.
+//
+// Expected post-synth: pure comb logic, zero DLATCH cells.
+module full_case_latch(
+    input  wire [1:0] sel,
+    input  wire [7:0] a,
+    input  wire [7:0] b,
+    output reg  [7:0] x,
+    output reg  [7:0] y
+);
+    always @* begin
+        (* full_case *)
+        case (sel)
+            2'd0: begin x = a;     y = b;     end
+            2'd1: begin x = a + 1; y = b + 1; end
+            2'd2: begin x = a + 2; y = b + 2; end
+        endcase
+    end
+endmodule


### PR DESCRIPTION
The Verilog `(* full_case *)` attribute syntax appears in UHDM as a `vpiAttribute` child on the `case_stmt` (distinct from the SV `unique`/`priority` qualifiers, which use `VpiQualifier()`). `import_case_stmt_comb` only read `VpiQualifier()`, so the attribute was silently dropped and `proc_dlatch` then inferred `$_DLATCH_*` cells for every signal written in the case body — 68 latches in the full picorv32 build, causing `equiv_induct` to abort with "No SAT model available for cell ... ($_DLATCH_N_)".

Fix in `import_case_stmt_comb`:
1. Walk `case_stmt->Attributes()` and set `\full_case` / `\parallel_case` on the SwitchRule when present.
2. When `\full_case` is set and no user-written default exists, append an empty-comparison `CaseRule` filled with `lhs = X` actions for every signal written anywhere in the case body (collected via `extract_assigned_signals` and routed through `map_to_temp_wire` so each X-assignment lands on the correct `$0\<base>` temp wire).  Without these X overrides, the surrounding `always_comb` path's hold defaults (`$0\sig = \sig`) survive into the unhandled branch and `proc_dlatch` still infers latches even with the attribute set — matches what Yosys's Verilog frontend emits.

`test/full_case_latch/` is the minimal reproducer extracted from picorv32.v's `mem_la_wdata`/`mem_rdata_word` `case (mem_wordsize)`. Both UHDM and Verilog now produce 88 gates with zero DLATCH cells and the formal equivalence check passes; picorv32 itself drops from 68 latches to 0 (gate count still differs on unrelated grounds — remains in `failing_tests.txt`).