### PR TITLE
counter_in_cpu_state: skip X-default for full_case in always_ff

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This project bridges the gap between SystemVerilog source code and Yosys synthes
 This enables full SystemVerilog synthesis capability in Yosys, including advanced features not available in Yosys's built-in Verilog frontend.
 
 ### Test Suite Status
-- **Total Tests**: 285 tests covering comprehensive SystemVerilog features
-- **Success Rate**: 99.6% (284/285 tests functional, 1 known failure)
-- **Passing**: 239 tests with formal equivalence verified between UHDM and Verilog frontends
+- **Total Tests**: 286 tests covering comprehensive SystemVerilog features
+- **Success Rate**: 99.7% (285/286 tests functional, 1 known failure)
+- **Passing**: 240 tests with formal equivalence verified between UHDM and Verilog frontends
 - **UHDM-Only Success**: 45 tests demonstrating UHDM's superior SystemVerilog support — tests in this category use SystemVerilog features the Verilog frontend can't parse, so formal equivalence against it is not possible. They are instead verified end-to-end against Verilator with random constraint generation: the original `dut.sv` (RTL) and the UHDM-frontend's post-`synth -auto-top` gate-level netlist are instantiated side-by-side in a SystemVerilog testbench driven by shared clocks/resets and randomized inputs, and their outputs are compared cycle by cycle:
   - `nested_struct` - Complex nested structures
   - `simple_instance_array` - Instance array support

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -8564,13 +8564,23 @@ bool UhdmImporter::apply_case_qualifier_attrs(const case_stmt* uhdm_case, RTLIL:
     return has_full_case;
 }
 
-// Ensure a `full_case` switch has a default branch that assigns X to
-// every signal written anywhere in the case body.  The always_comb /
-// always_ff temp-wire setup emits hold defaults (`$0\sig = \sig`)
-// BEFORE the switch, so an empty/absent default branch leaves
-// `$0\sig` driven by the previous value of `\sig` → `proc_dlatch`
-// still infers a latch even with `\full_case` set.  Matches what
-// Yosys's Verilog frontend emits for `(* full_case *)`.
+// Ensure a `full_case` switch has a default branch.
+//
+// `always_comb` context:  surrounding hold defaults (`$0\sig = \sig`)
+//   create a combinational loop that `proc_dlatch` lowers to a latch
+//   even with `\full_case` set.  Override the hold by assigning X to
+//   every signal written in the case body — the attribute is the
+//   contract that the default branch is unreachable, so X is a safe
+//   don't-care for `proc_mux`/`opt` to collapse the latch path.
+//
+// `always_ff` context:  hold defaults are exactly what we want (FF
+//   holds its value when no case branch matches), and an X-default
+//   would forward X through the sync rule onto the FF's D input —
+//   `opt` then sees `D = X` and collapses the entire output to
+//   `assign sig = X` (e.g. picorv32's `case (cpu_state)` with
+//   `(* parallel_case, full_case *)` listing all 8 states collapsed
+//   `count_instr` to all-X).  Emit an empty default instead;
+//   `proc_dlatch` honours `\full_case` and skips latch inference.
 void UhdmImporter::emit_full_case_default(const case_stmt* uhdm_case, RTLIL::SwitchRule* sw) {
     RTLIL::CaseRule* default_case = nullptr;
     for (auto c : sw->cases) {
@@ -8580,6 +8590,13 @@ void UhdmImporter::emit_full_case_default(const case_stmt* uhdm_case, RTLIL::Swi
         default_case = new RTLIL::CaseRule;
         sw->cases.push_back(default_case);
     }
+
+    // Only emit X-overrides in always_comb context.  The two
+    // always_ff paths (comb-style switch via `in_always_ff_body_mode`,
+    // and the async-reset path) both want a plain empty default — the
+    // surrounding sync rule already holds the FF value, and an X-on-D
+    // would propagate through `opt` to the FF Q.
+    if (in_always_ff_context) return;
 
     std::vector<AssignedSignal> body_signals;
     if (auto case_items = uhdm_case->Case_items()) {

--- a/test/counter_in_cpu_state/dut.sv
+++ b/test/counter_in_cpu_state/dut.sv
@@ -1,0 +1,54 @@
+// Tighter picorv32-like reproducer: wraps the count_instr if-else chain
+// inside an outer `case (cpu_state)` like picorv32.v lines 1397-1572.
+module counter_in_cpu_state #(
+    parameter [0:0] ENABLE_IRQ      = 0,
+    parameter [0:0] ENABLE_COUNTERS = 1
+) (
+    input  wire        clk,
+    input  wire        resetn,
+    input  wire        decoder_trigger,
+    input  wire        irq_active,
+    input  wire        irq_delay,
+    input  wire        irq_state_bit,
+    input  wire [31:0] irq_pending,
+    input  wire [31:0] irq_mask,
+    input  wire [7:0]  cpu_state,
+    output reg  [63:0] count_instr
+);
+    localparam [7:0] cpu_state_trap   = 8'b10000000;
+    localparam [7:0] cpu_state_fetch  = 8'b01000000;
+    localparam [7:0] cpu_state_ld_rs1 = 8'b00100000;
+    localparam [7:0] cpu_state_ld_rs2 = 8'b00010000;
+    localparam [7:0] cpu_state_exec   = 8'b00001000;
+    localparam [7:0] cpu_state_shift  = 8'b00000100;
+    localparam [7:0] cpu_state_stmem  = 8'b00000010;
+    localparam [7:0] cpu_state_ldmem  = 8'b00000001;
+
+    always @(posedge clk) begin
+        if (!resetn) begin
+            if (ENABLE_COUNTERS)
+                count_instr <= 0;
+        end else begin
+            (* parallel_case, full_case *)
+            case (cpu_state)
+                cpu_state_trap:   ;
+                cpu_state_fetch: begin
+                    if (ENABLE_IRQ && ((decoder_trigger && !irq_active && !irq_delay && |(irq_pending & ~irq_mask)) || irq_state_bit)) begin
+                        // dead with ENABLE_IRQ=0
+                    end else
+                    if (decoder_trigger) begin
+                        if (ENABLE_COUNTERS) begin
+                            count_instr <= count_instr + 1;
+                        end
+                    end
+                end
+                cpu_state_ld_rs1: ;
+                cpu_state_ld_rs2: ;
+                cpu_state_exec:   ;
+                cpu_state_shift:  ;
+                cpu_state_stmem:  ;
+                cpu_state_ldmem:  ;
+            endcase
+        end
+    end
+endmodule


### PR DESCRIPTION
`emit_full_case_default` was unconditionally appending `\sig <= X` assignments to the default branch of every `\full_case` switch — the right call in `always @*` (overrides the comb-loop hold default that would otherwise become a latch), but the wrong call inside `always @(posedge clk)`.  In the FF context, the sync rule maps `$0\sig` straight to the FF D input, and an X-on-D propagates through `opt` to the FF Q.  With picorv32-style `case (cpu_state)` carrying `(* parallel_case, full_case *)` and listing all 8 reachable states (out of 256 possible 8-bit values), the X-default forced the FF cone to collapse to `assign count_instr = 64'hxxxxxxxxxxxxxxxx`.

Fix: keep the default branch but emit no actions when `in_always_ff_context` is set.  `proc_dlatch` already honours `\full_case` and skips latch inference for the empty default; the sync rule's hold default keeps the FF stable.

`test/counter_in_cpu_state/` reproduces the picorv32 pattern: outer `case (cpu_state)` with `(* parallel_case, full_case *)`, inner else-if chain incrementing `count_instr` only under the `cpu_state_fetch` branch.  Before the fix: UHDM=0 gates and `assign count_instr = 64'hxxxxxxxxxxxxxxxx`; after the fix: UHDM=198 gates matching the Verilog frontend, equivalence PASSES.

The picorv32 build itself recovers ~66 gates (9178 → 9244) toward the Verilog frontend's 9337 but the 126 unproven count_cycle / count_instr equiv cells remain — that's a separate residual issue still tracked under `failing_tests.txt`.