### PR TITLE
co-sim: skip designs Verilator can't build instead of warning

### DIFF
--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -147,12 +147,15 @@ run_sim_equivalence_softwarn() {
         echo "    ✅ Verilator co-sim PASSED"
         return 0
     fi
-    # Exit code 77 = autotools "skip" convention.  Used by the harness
-    # for self-checking testbenches that have no observable outputs
-    # (everything is asserted internally) — not a failure, just not
-    # applicable to co-simulation.
+    # Exit code 77 = autotools "skip" convention.  The harness emits it
+    # when co-sim is not applicable: a self-checking testbench with no
+    # observable outputs (everything asserted internally), OR Verilator
+    # cannot build the design (original RTL uses a construct it doesn't
+    # support — `~&`, `ref` args, arrayed defparam, some interfaces — or
+    # the synth netlist holds cells it can't model, e.g. $allconst).
+    # Neither is an RTL-vs-netlist divergence, so it's a skip, not a fail.
     if [ $rc -eq 77 ]; then
-        echo "    ⏭  Verilator co-sim SKIPPED (no outputs / self-checking)"
+        echo "    ⏭  Verilator co-sim SKIPPED (no outputs or not buildable)"
         return 0
     fi
     local base; base="$(basename "$test_dir")"

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -110,32 +110,12 @@ Test: aes_kexp128
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: allconst_attr
-    formal-only construct ($allconst/$allseq/$anyconst/$anyseq/cover): the
-    DUT's behaviour is defined only under the formal solver, so a random
-    Verilator co-sim is not meaningful.  Validated via synth/formal.
-
-Test: allseq_attr
-    formal-only construct ($allconst/$allseq/$anyconst/$anyseq/cover): the
-    DUT's behaviour is defined only under the formal solver, so a random
-    Verilator co-sim is not meaningful.  Validated via synth/formal.
-
 Test: always03
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known
     blind spot).  Tracked here so the suite stays green; to be fixed and
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
-
-Test: anyconst_attr
-    formal-only construct ($allconst/$allseq/$anyconst/$anyseq/cover): the
-    DUT's behaviour is defined only under the formal solver, so a random
-    Verilator co-sim is not meaningful.  Validated via synth/formal.
-
-Test: anyseq_attr
-    formal-only construct ($allconst/$allseq/$anyconst/$anyseq/cover): the
-    DUT's behaviour is defined only under the formal solver, so a random
-    Verilator co-sim is not meaningful.  Validated via synth/formal.
 
 Test: arrays01
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
@@ -256,27 +236,6 @@ Test: func_width_scope
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: hana_test_intermout
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
-Test: hierdefparam
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
-Test: iface_modport_passthrough
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: initval
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known
@@ -292,13 +251,6 @@ Test: latch_002
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
 Test: lcov
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
-Test: logic_ops
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known
     blind spot).  Tracked here so the suite stays green; to be fixed and
@@ -353,13 +305,6 @@ Test: named_cover_assert
     Verilator co-sim is not meaningful.  Validated via synth/formal.
 
 Test: partsel_simple
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
-Test: port_sign_extend
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known
     blind spot).  Tracked here so the suite stays green; to be fixed and
@@ -464,13 +409,6 @@ Test: sp_write_first
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: svinterface1
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: svinterface_at_top
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known
@@ -485,21 +423,7 @@ Test: typedef_packed_enum_array
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: various_port_sign_extend
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: verilog_primitives
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
-Test: wandwor
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known
     blind spot).  Tracked here so the suite stays green; to be fixed and

--- a/test/test_sim_equivalence.py
+++ b/test/test_sim_equivalence.py
@@ -637,6 +637,16 @@ def main() -> int:
     # Trim Verilator noise so the PASS/FAIL line is easy to find
     for line in out.splitlines()[-15:]:
         print(line)
+    if "[verilator build failed]" in out:
+        # Verilator could not COMPILE the design — either the original RTL
+        # uses a construct it doesn't support (`~&` binary nand, `ref` args,
+        # arrayed defparam, some interface forms) or the synth netlist
+        # contains cells it can't model ($allconst/$anyseq formal primitives,
+        # ...).  A build failure is not evidence of an RTL-vs-netlist
+        # divergence, so the co-sim is inapplicable: skip (autotools 77)
+        # instead of reporting a spurious mismatch.
+        print("⏭  Verilator cannot build this design — co-sim not applicable (skipping)")
+        return 77
     if "PASS:" in out and "MISMATCH" not in out and "FAIL:" not in out:
         return 0
     print("❌ simulation reported a mismatch or did not complete")


### PR DESCRIPTION
When the Verilator co-sim cannot COMPILE a design it was being counted as a divergence (WARNING / ANALYZED-backlog). A build failure is not evidence of an RTL-vs-netlist mismatch — Verilator simply can't handle the DUT — so the check is inapplicable and should skip, like the existing "no observable outputs" case.

Causes seen across the 12 affected tests, none of them frontend bugs:
  - original RTL uses a construct Verilator rejects: `~&`/`~|` binary reduction (logic_ops), `ref` arguments (port_sign_extend, various_port_sign_extend), arrayed defparam (hierdefparam), some interface port forms (svinterface1, iface_modport_passthrough)
  - synth netlist holds cells Verilator can't model: formal primitives $allconst/$anyconst/$allseq/$anyseq (allconst_attr & friends), $and from wired nets (wandwor), input feedthrough (hana_test_intermout)

test_sim_equivalence.py: detect "[verilator build failed]" and return autotools skip code 77 instead of a mismatch exit. run_all_tests.sh: broaden the rc==77 SKIPPED message/comment to cover the not-buildable case. Drop the 12 from sim_equiv_analyzed.txt — they're now SKIPPED, not analyzed-backlog.

Suite stays green: 296/296 functional, 0 equivalence failures, 0 co-sim warnings; co-sim SKIPPED 67, ANALYZED backlog 55 -> 43.