### PR TITLE
indexed part-select: compute the base index at full width, not the LH…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4858,11 +4858,17 @@ RTLIL::SigSpec UhdmImporter::import_indexed_part_select(const indexed_part_selec
         base = import_expression(any_cast<const expr*>(parent), input_mapping);
     }
 
-    // Get the base index expression
+    // Get the base index and width expressions.  These are *address*
+    // operands, independent of the slice's datapath width — so the
+    // surrounding assignment's context width (e.g. the 4-bit LHS of
+    // `slice = data[offset+3 -: 4]`) must NOT cap them, or an arithmetic
+    // base like `offset+3` gets truncated (offset[3:0]) and the high
+    // address bits are lost.  Clear the context for these sub-imports.
+    int saved_ctx_width = expression_context_width;
+    expression_context_width = 0;
     RTLIL::SigSpec base_index = import_expression(uhdm_indexed->Base_expr(), input_mapping);
-
-    // Get the width expression
     RTLIL::SigSpec width_expr = import_expression(uhdm_indexed->Width_expr(), input_mapping);
+    expression_context_width = saved_ctx_width;
     
     // Both base_index and width must be constant for RTLIL
     if (base_index.is_fully_const() && width_expr.is_fully_const()) {

--- a/test/partsel_simple/partsel_simple_from_uhdm.il
+++ b/test/partsel_simple/partsel_simple_from_uhdm.il
@@ -13,17 +13,17 @@ module \partsel_simple
   wire width 4 output 4 \slice_down
   attribute \src "dut.sv:2.12-2.18"
   wire width 6 \offset
-  wire width 4 $auto$expression.cpp:2965:import_operation$5
-  wire width 4 $auto$expression.cpp:4776:import_indexed_part_select$7
+  wire width 64 $auto$expression.cpp:3006:import_operation$5
+  wire width 64 $auto$expression.cpp:4915:import_indexed_part_select$7
   attribute \src "dut.sv:4.26-4.41"
   cell $shiftx $shiftx$dut.sv:4$10
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
     parameter \A_WIDTH 32
-    parameter \B_WIDTH 4
+    parameter \B_WIDTH 64
     parameter \Y_WIDTH 4
     connect \A \data
-    connect \B $auto$expression.cpp:4776:import_indexed_part_select$7
+    connect \B $auto$expression.cpp:4915:import_indexed_part_select$7
     connect \Y \slice_down
   end
   attribute \src "dut.sv:3.24-3.35"
@@ -41,23 +41,23 @@ module \partsel_simple
   cell $add $add$dut.sv:4$6
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
-    parameter \A_WIDTH 4
-    parameter \B_WIDTH 4
-    parameter \Y_WIDTH 4
-    connect \A { \idx [1:0] 2'00 }
-    connect \B 4'0011
-    connect \Y $auto$expression.cpp:2965:import_operation$5
+    parameter \A_WIDTH 64
+    parameter \B_WIDTH 64
+    parameter \Y_WIDTH 64
+    connect \A { 59'00000000000000000000000000000000000000000000000000000000000 \idx 2'00 }
+    connect \B 64'0000000000000000000000000000000000000000000000000000000000000011
+    connect \Y $auto$expression.cpp:3006:import_operation$5
   end
   attribute \src "dut.sv:4.26-4.41"
   cell $sub $sub$dut.sv:4$8
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
-    parameter \A_WIDTH 4
-    parameter \B_WIDTH 4
-    parameter \Y_WIDTH 4
-    connect \A $auto$expression.cpp:2965:import_operation$5
-    connect \B 4'0011
-    connect \Y $auto$expression.cpp:4776:import_indexed_part_select$7
+    parameter \A_WIDTH 64
+    parameter \B_WIDTH 64
+    parameter \Y_WIDTH 64
+    connect \A $auto$expression.cpp:3006:import_operation$5
+    connect \B 64'0000000000000000000000000000000000000000000000000000000000000011
+    connect \Y $auto$expression.cpp:4915:import_indexed_part_select$7
   end
   connect \offset { 1'0 \idx 2'00 }
 end

--- a/test/partsel_simple/partsel_simple_from_uhdm_nohier.il
+++ b/test/partsel_simple/partsel_simple_from_uhdm_nohier.il
@@ -13,11 +13,11 @@ module \partsel_simple
   wire width 4 output 4 \slice_down
   attribute \src "dut.sv:2.12-2.18"
   wire width 6 \offset
-  wire width 6 $auto$expression.cpp:3152:import_operation$1
-  wire width 4 $auto$expression.cpp:4792:import_indexed_part_select$3
-  wire width 4 $auto$expression.cpp:2965:import_operation$5
-  wire width 4 $auto$expression.cpp:4776:import_indexed_part_select$7
-  wire width 4 $auto$expression.cpp:4792:import_indexed_part_select$9
+  wire width 6 $auto$expression.cpp:3196:import_operation$1
+  wire width 4 $auto$expression.cpp:4931:import_indexed_part_select$3
+  wire width 64 $auto$expression.cpp:3006:import_operation$5
+  wire width 64 $auto$expression.cpp:4915:import_indexed_part_select$7
+  wire width 4 $auto$expression.cpp:4931:import_indexed_part_select$9
   attribute \src "dut.sv:2.21-2.29"
   cell $shl $shl$dut.sv:2$2
     parameter \A_SIGNED 0
@@ -27,7 +27,7 @@ module \partsel_simple
     parameter \Y_WIDTH 6
     connect \A \idx
     connect \B 64'0000000000000000000000000000000000000000000000000000000000000010
-    connect \Y $auto$expression.cpp:3152:import_operation$1
+    connect \Y $auto$expression.cpp:3196:import_operation$1
   end
   attribute \src "dut.sv:3.24-3.35"
   cell $shiftx $shiftx$dut.sv:3$4
@@ -38,42 +38,42 @@ module \partsel_simple
     parameter \Y_WIDTH 4
     connect \A \data
     connect \B \offset
-    connect \Y $auto$expression.cpp:4792:import_indexed_part_select$3
+    connect \Y $auto$expression.cpp:4931:import_indexed_part_select$3
   end
   attribute \src "dut.sv:4.26-4.36"
   cell $add $add$dut.sv:4$6
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
-    parameter \A_WIDTH 4
-    parameter \B_WIDTH 4
-    parameter \Y_WIDTH 4
-    connect \A \offset [3:0]
-    connect \B 4'0011
-    connect \Y $auto$expression.cpp:2965:import_operation$5
+    parameter \A_WIDTH 64
+    parameter \B_WIDTH 64
+    parameter \Y_WIDTH 64
+    connect \A { 58'0000000000000000000000000000000000000000000000000000000000 \offset }
+    connect \B 64'0000000000000000000000000000000000000000000000000000000000000011
+    connect \Y $auto$expression.cpp:3006:import_operation$5
   end
   attribute \src "dut.sv:4.26-4.41"
   cell $sub $sub$dut.sv:4$8
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
-    parameter \A_WIDTH 4
-    parameter \B_WIDTH 4
-    parameter \Y_WIDTH 4
-    connect \A $auto$expression.cpp:2965:import_operation$5
-    connect \B 4'0011
-    connect \Y $auto$expression.cpp:4776:import_indexed_part_select$7
+    parameter \A_WIDTH 64
+    parameter \B_WIDTH 64
+    parameter \Y_WIDTH 64
+    connect \A $auto$expression.cpp:3006:import_operation$5
+    connect \B 64'0000000000000000000000000000000000000000000000000000000000000011
+    connect \Y $auto$expression.cpp:4915:import_indexed_part_select$7
   end
   attribute \src "dut.sv:4.26-4.41"
   cell $shiftx $shiftx$dut.sv:4$10
     parameter \A_SIGNED 0
     parameter \B_SIGNED 0
     parameter \A_WIDTH 32
-    parameter \B_WIDTH 4
+    parameter \B_WIDTH 64
     parameter \Y_WIDTH 4
     connect \A \data
-    connect \B $auto$expression.cpp:4776:import_indexed_part_select$7
-    connect \Y $auto$expression.cpp:4792:import_indexed_part_select$9
+    connect \B $auto$expression.cpp:4915:import_indexed_part_select$7
+    connect \Y $auto$expression.cpp:4931:import_indexed_part_select$9
   end
-  connect \offset $auto$expression.cpp:3152:import_operation$1
-  connect \slice_up $auto$expression.cpp:4792:import_indexed_part_select$3
-  connect \slice_down $auto$expression.cpp:4792:import_indexed_part_select$9
+  connect \offset $auto$expression.cpp:3196:import_operation$1
+  connect \slice_up $auto$expression.cpp:4931:import_indexed_part_select$3
+  connect \slice_down $auto$expression.cpp:4931:import_indexed_part_select$9
 end

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -297,13 +297,6 @@ Test: named_cover_assert
     DUT's behaviour is defined only under the formal solver, so a random
     Verilator co-sim is not meaningful.  Validated via synth/formal.
 
-Test: partsel_simple
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: power_state
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known


### PR DESCRIPTION
…S width

`import_operation` caps an add's result to `expression_context_width` (the assignment LHS width) so a stray 64-bit unsized-literal operand can't blow the cell up.  That cap is correct for datapath operands, but it was also applied to the *base index* of an indexed part-select, which is an address expression independent of the slice's datapath width.

For `slice_down = data[offset+3 -: 4]` (offset is 6 bits), the 4-bit LHS context truncated the `offset+3` base to `offset[3:0]`, dropping the high address bits for idx >= 4 — so `data[offset+3 -: 4]` read the wrong bits (it must equal `data[offset +: 4]`).  Formal missed it (the truncated bits happened to be don't-cares in the equiv encoding); the Verilator co-sim caught it (partsel_simple slice_down mismatch).

Fix: in `import_indexed_part_select`, save/clear `expression_context_width` around the `Base_expr()` / `Width_expr()` sub-imports so the base index is built at its natural width, then restore it.

partsel_simple now passes co-sim and is removed from sim_equiv_analyzed.txt. Full suite green: 296/296, 0 equivalence failures, 0 co-sim warnings, analyzed backlog 42 -> 41.