### PR TITLE
make test: split co-sim divergences into artefacts vs potential bugs

### DIFF
--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -91,15 +91,31 @@ SIM_EQUIV_WARN_TESTS=0
 SIM_EQUIV_WARN_NAMES=()
 SIM_EQUIV_ANALYZED_TESTS=0
 SIM_EQUIV_ANALYZED_NAMES=()
+# Of the analyzed tests, split into two classes for reporting:
+#   - ARTEFACT: a confirmed sim-vs-synth difference, NOT a frontend bug
+#     (the entry's explanation contains "CONFIRMED ARTIFACT").
+#   - POTENTIAL BUG: an un-investigated divergence that may be a real
+#     frontend bug to fix.
+SIM_EQUIV_ARTEFACT_TESTS=0
+SIM_EQUIV_ARTEFACT_NAMES=()
+SIM_EQUIV_POTBUG_TESTS=0
+SIM_EQUIV_POTBUG_NAMES=()
 
 # Tests that are knowingly not made to pass sim-equiv, with a
 # documented reason in `test/sim_equiv_analyzed.txt`.  Populate the
-# set once at startup so the per-test path is just a lookup.
+# set once at startup so the per-test path is just a lookup.  Also flag
+# which entries are CONFIRMED ARTEFACTs (their explanation block contains
+# "CONFIRMED ARTIFACT") vs un-investigated potential bugs.
 declare -A SIM_EQUIV_ANALYZED_SET
+declare -A SIM_EQUIV_ARTEFACT_SET
 if [ -f "$SCRIPT_DIR/sim_equiv_analyzed.txt" ]; then
+    _cur_analyzed=""
     while IFS= read -r line; do
         if [[ "$line" =~ ^Test:[[:space:]]*([A-Za-z0-9_]+) ]]; then
-            SIM_EQUIV_ANALYZED_SET[${BASH_REMATCH[1]}]=1
+            _cur_analyzed="${BASH_REMATCH[1]}"
+            SIM_EQUIV_ANALYZED_SET[$_cur_analyzed]=1
+        elif [[ -n "$_cur_analyzed" && "$line" == *"CONFIRMED ARTIFACT"* ]]; then
+            SIM_EQUIV_ARTEFACT_SET[$_cur_analyzed]=1
         fi
     done < "$SCRIPT_DIR/sim_equiv_analyzed.txt"
 fi
@@ -163,9 +179,17 @@ run_sim_equivalence_softwarn() {
     # clean — surface them under a separate "analyzed" category so the
     # warning count tracks only un-investigated failures.
     if [ -n "${SIM_EQUIV_ANALYZED_SET[$base]:-}" ]; then
-        echo "    🔍 Verilator co-sim ANALYZED (see sim_equiv_analyzed.txt)"
         SIM_EQUIV_ANALYZED_TESTS=$((SIM_EQUIV_ANALYZED_TESTS + 1))
         SIM_EQUIV_ANALYZED_NAMES+=("$base")
+        if [ -n "${SIM_EQUIV_ARTEFACT_SET[$base]:-}" ]; then
+            echo "    🔬 Verilator co-sim ARTEFACT — sim/synth diff, not a bug (sim_equiv_analyzed.txt)"
+            SIM_EQUIV_ARTEFACT_TESTS=$((SIM_EQUIV_ARTEFACT_TESTS + 1))
+            SIM_EQUIV_ARTEFACT_NAMES+=("$base")
+        else
+            echo "    🐛 Verilator co-sim POTENTIAL BUG — un-investigated divergence (sim_equiv_analyzed.txt)"
+            SIM_EQUIV_POTBUG_TESTS=$((SIM_EQUIV_POTBUG_TESTS + 1))
+            SIM_EQUIV_POTBUG_NAMES+=("$base")
+        fi
         return 0
     fi
     echo "    ⚠️  Verilator co-sim WARNING (see $base/sim_equiv.log)"
@@ -815,7 +839,15 @@ if [ "$SIM_EQUIV_WARN_TESTS" -gt 0 ]; then
 fi
 if [ "$SIM_EQUIV_ANALYZED_TESTS" -gt 0 ]; then
     echo "  🔍 Verilator sim-equiv analyzed (known divergence): $SIM_EQUIV_ANALYZED_TESTS"
-    for t in "${SIM_EQUIV_ANALYZED_NAMES[@]}"; do
+    echo "       └─ split into confirmed artefacts vs un-investigated potential bugs:"
+    # Confirmed sim/synth artefacts — NOT frontend bugs.
+    echo "  🔬 Sim/synth ARTEFACTS (not bugs — Verilator-vs-synth diffs): $SIM_EQUIV_ARTEFACT_TESTS"
+    for t in "${SIM_EQUIV_ARTEFACT_NAMES[@]}"; do
+        echo "      - $t"
+    done
+    # Un-investigated divergences that may be real frontend bugs to fix.
+    echo "  🐛 POTENTIAL BUGS (un-investigated divergences to triage): $SIM_EQUIV_POTBUG_TESTS"
+    for t in "${SIM_EQUIV_POTBUG_NAMES[@]}"; do
         echo "      - $t"
     done
 fi

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -1,13 +1,22 @@
 # Tests that have been analyzed and consciously NOT made to pass the
 # Verilator co-simulation equivalence check.  Each entry has the test
 # name on a `Test:` line followed by an explanation block.  Entries
-# in this file are reported as `🔍 ANALYZED` instead of `⚠️ WARNING`
-# in the run_all_tests.sh summary — the warning is not a bug signal,
-# the reason for the mismatch is known and documented here.
+# in this file are reported under "ANALYZED" instead of "WARNING" in the
+# run_all_tests.sh summary — the mismatch is known and documented here.
+#
+# The summary further splits ANALYZED entries into two classes:
+#   ARTEFACT      — a CONFIRMED sim-vs-synth difference, NOT a frontend bug
+#                   (e.g. Verilator wand/wor handling, full_case /
+#                   parallel_case don't-cares, initial-reads-input, X-init,
+#                   multi-driver races).  Mark these by putting the exact
+#                   phrase "CONFIRMED ARTIFACT" in the explanation block.
+#   POTENTIAL BUG — an un-investigated divergence that may be a real
+#                   frontend bug to fix (no "CONFIRMED ARTIFACT" marker).
 #
 # Format:
 #   Test: <test_name>
-#       <explanation, multi-line ok, indented under the Test: line>
+#       <explanation, multi-line ok, indented under the Test: line.
+#        Include "CONFIRMED ARTIFACT" iff it is a proven sim/synth diff.>
 #   <blank line separator>
 
 Test: sva_not


### PR DESCRIPTION
The run_all_tests.sh summary lumped every documented co-sim divergence under a single "ANALYZED (known divergence)" line, so it wasn't clear which entries are real frontend bugs to chase versus confirmed Verilator-vs-synth differences that will never co-sim clean.

Split them into two clearly-labelled buckets, both per-test and in the summary:
  🔬 ARTEFACT      — a CONFIRMED sim-vs-synth difference, NOT a frontend
                     bug (wand/wor, full/parallel_case don't-cares,
                     initial-reads-input, X-init, multi-driver races, ...).
  🐛 POTENTIAL BUG — an un-investigated divergence that may be a real
                     frontend bug to fix.

An entry is classified ARTEFACT iff its explanation block in sim_equiv_analyzed.txt contains the exact phrase "CONFIRMED ARTIFACT"; everything else is a potential bug.  The header of sim_equiv_analyzed.txt documents the convention so the bucket is just a matter of including (or omitting) that marker.

Report-only change; suite still green (296/296, 0 equivalence failures, 0 warnings).  Current split: 6 artefacts, ~25-34 potential bugs (seed-dependent x-init/SVA entries pass on some runs).