### PR TITLE
dynslice: truncate dynamic part-select index to its self-determined w…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -2591,6 +2591,67 @@ static void mark_result_signed(RTLIL::SigSpec& result) {
     }
 }
 
+// LRM (IEEE 1800 Table 11-21) self-determined bit-length of an expression.
+// Returns 0 when it cannot be determined structurally (caller leaves the
+// imported width untouched).  Crucially, arithmetic (+ - * / %) and bitwise
+// (& | ^ ~^) ops use max(L, R) here — NOT the full-precision sum that
+// import_operation falls back to without an assignment context.  This is what
+// the Verilog frontend uses for self-determined positions like a part-select
+// index, so `dout[ctrl*sel +: 16]` truncates the index to max(width(ctrl),
+// width(sel)) rather than width(ctrl)+width(sel).
+int UhdmImporter::self_determined_width(const UHDM::any* node) {
+    if (!node)
+        return 0;
+    if (node->VpiType() == vpiOperation) {
+        const operation* op = any_cast<const operation*>(node);
+        std::vector<const UHDM::any*> ops;
+        if (op->Operands())
+            for (auto o : *op->Operands())
+                ops.push_back(o);
+        auto W = [&](size_t i) -> int {
+            return i < ops.size() ? self_determined_width(ops[i]) : 0;
+        };
+        switch (op->VpiOpType()) {
+            // Arithmetic and bitwise binary: max(L, R).
+            case vpiAddOp: case vpiSubOp: case vpiMultOp: case vpiDivOp:
+            case vpiModOp: case vpiBitAndOp: case vpiBitOrOp:
+            case vpiBitXorOp: case vpiBitXnorOp:
+                return std::max(W(0), W(1));
+            // Unary arithmetic / bitwise negation: width of the operand.
+            case vpiMinusOp: case vpiPlusOp: case vpiBitNegOp:
+                return W(0);
+            // Shifts: width of the left (shifted) operand.
+            case vpiLShiftOp: case vpiRShiftOp:
+            case vpiArithLShiftOp: case vpiArithRShiftOp:
+                return W(0);
+            // Conditional: max of the two result operands (1=then, 2=else).
+            case vpiConditionOp:
+                return std::max(W(1), W(2));
+            case vpiConcatOp: {
+                int s = 0;
+                for (auto o : ops)
+                    s += self_determined_width(o);
+                return s;
+            }
+            // Comparisons, logical, reductions: 1 bit.
+            case vpiEqOp: case vpiNeqOp: case vpiLtOp: case vpiLeOp:
+            case vpiGtOp: case vpiGeOp: case vpiLogAndOp: case vpiLogOrOp:
+            case vpiNotOp: case vpiUnaryAndOp: case vpiUnaryNandOp:
+            case vpiUnaryOrOp: case vpiUnaryNorOp: case vpiUnaryXorOp:
+            case vpiUnaryXNorOp:
+                return 1;
+            default:
+                return 0;  // unknown form -> "don't truncate"
+        }
+    }
+    // Leaf (ref / net / var / constant / select): width of the imported value.
+    // For these, import_expression resolves to an existing wire or a Const and
+    // creates no new logic, so this is side-effect-free.
+    if (auto e = dynamic_cast<const UHDM::expr*>(node))
+        return import_expression(e).size();
+    return 0;
+}
+
 // Import operation
 RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UHDM::scope* inst, const std::map<std::string, RTLIL::SigSpec>* input_mapping) {
     int op_type = uhdm_op->VpiOpType();

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -6856,6 +6856,14 @@ void UhdmImporter::import_assignment_sync(const assignment* uhdm_assign, RTLIL::
         // Width must be constant; offset may be dynamic.
         RTLIL::SigSpec width_sig = import_expression(ips->Width_expr());
         RTLIL::SigSpec offset_sig = import_expression(ips->Base_expr());
+        // The index is self-determined (LRM Table 11-21): truncate it to that
+        // width so e.g. `ctrl*sel` uses max(L,R) bits, matching the Verilog
+        // frontend.  Without this the multiply keeps full-precision (sum-of-
+        // widths) bits, so a large product that should wrap (and write at the
+        // low end) instead shifts entirely out of range.
+        if (int sdw = self_determined_width(ips->Base_expr());
+            sdw > 0 && sdw < offset_sig.size())
+            offset_sig = offset_sig.extract(0, sdw);
         if (width_sig.is_fully_const() && !offset_sig.is_fully_const()) {
             // Resolve the base wire by name.
             std::string base_name;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -489,6 +489,13 @@ struct UhdmImporter {
     RTLIL::SigSpec import_expression(const UHDM::expr* uhdm_expr, const std::map<std::string, RTLIL::SigSpec>* input_mapping = nullptr);
     
     RTLIL::SigSpec import_constant(const UHDM::constant* uhdm_const);
+    // LRM (IEEE 1800 Table 11-21) self-determined bit-length of an expression.
+    // Returns 0 when the width can't be determined structurally (caller should
+    // then leave the imported width unchanged).  Used to size self-determined
+    // contexts such as a part-select index, where arithmetic uses max(L,R)
+    // (NOT the full-precision sum the assignment-context importer falls back
+    // to).
+    int self_determined_width(const UHDM::any* node);
     RTLIL::SigSpec import_operation(const UHDM::operation* uhdm_op, const UHDM::scope* inst = nullptr, const std::map<std::string, RTLIL::SigSpec>* input_mapping = nullptr);
     RTLIL::SigSpec import_ref_obj(const UHDM::ref_obj* uhdm_ref, const UHDM::scope* inst = nullptr, const std::map<std::string, RTLIL::SigSpec>* input_mapping = nullptr);
     


### PR DESCRIPTION
…idth

`dout[ctrl*sel +: 16] <= din` was non-equivalent to the Verilog frontend (SAT miter NON-EQUIVALENT, confirmed by Verilator co-sim: the UHDM netlist diverged from RTL while the Verilog one matched).

Root cause: the index expression `ctrl*sel` is self-determined (IEEE 1800 Table 11-21), so its width is max(width(ctrl), width(sel)) = max(10,4) = 10 bits — exactly what the Verilog frontend uses ($mul Y_WIDTH=10).  The UHDM importer imported the base index with no assignment context, so the multiply fell into its full-precision fallback (sum of operand widths = 14 bits).  A product >= 1024 that should wrap into the low 10 bits (writing at the bottom of dout) instead stayed large enough to shift the data entirely out of the 128-bit word, writing nothing.

Fix:
- Add UhdmImporter::self_determined_width() implementing the LRM Table 11-21 bit-length rules (arith/bitwise binary -> max(L,R); unary/shift -> L; concat -> sum; compare/logical/reduction -> 1; leaf -> imported width).
- In import_assignment_sync()'s indexed-part-select handler, truncate the imported offset to that self-determined width before using it as the shift amount.  Only narrows (never widens) and only in well-understood forms, so it can't regress other tests.

Result: SAT miter now EQUIVALENT (UHDM == Verilog); dynslice's remaining Verilator divergence is a benign sim/synth artefact (out-of-range dynamic write is X in Verilator, defined in synthesis) shared by both frontends.

Full suite: passing 242 -> 243, miter failures 9 -> 8, no regressions.