### PR TITLE
simple_forloops: for-loop bit-select writes, loop-var reads, unsigned…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -2772,11 +2772,20 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
     
     // Get operands
     std::vector<RTLIL::SigSpec> operands;
+    // Track operands that are intrinsically unsigned regardless of the
+    // operation's signedness — a concatenation (and replication) is ALWAYS
+    // unsigned in Verilog, so when widened inside a signed op (e.g.
+    // `signed_int - {a,b}`) it must be ZERO-extended, not sign-extended.
+    std::vector<bool> operand_is_unsigned;
     if (uhdm_op->Operands()) {
-        if (op_type == vpiConditionOp) { 
+        if (op_type == vpiConditionOp) {
             log("UHDM: ConditionOp (type=%d) has %d operands\n", op_type, (int)uhdm_op->Operands()->size());
         }
         for (auto operand : *uhdm_op->Operands()) {
+            int oty = operand->VpiType() == vpiOperation
+                ? any_cast<const operation*>(operand)->VpiOpType() : -1;
+            operand_is_unsigned.push_back(
+                oty == vpiConcatOp || oty == vpiMultiConcatOp);
             RTLIL::SigSpec op_sig = import_expression(any_cast<const expr*>(operand), input_mapping);
             if (op_type == vpiConditionOp) {
                 log("UHDM: ConditionOp operand %d has size %d\n", (int)operands.size(), op_sig.size());
@@ -3230,17 +3239,22 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 // Truncate / extend each operand to result_width so the
                 // cell's A_WIDTH/B_WIDTH match Y_WIDTH cleanly.  Preserves
                 // sign-extension for signed operands.
-                auto resize_operand = [&](RTLIL::SigSpec op) {
+                auto resize_operand = [&](RTLIL::SigSpec op, bool op_unsigned) {
                     if (op.size() == result_width) return op;
                     if (op.size() > result_width)
                         return op.extract(0, result_width);
                     bool sgn = is_signed;
                     if (op.is_wire() && !op.as_wire()->is_signed) sgn = false;
+                    // A concatenation/replication operand is always unsigned —
+                    // zero-extend it even inside a signed add/subtract.
+                    if (op_unsigned) sgn = false;
                     op.extend_u0(result_width, sgn);
                     return op;
                 };
-                RTLIL::SigSpec a = resize_operand(operands[0]);
-                RTLIL::SigSpec b = resize_operand(operands[1]);
+                RTLIL::SigSpec a = resize_operand(operands[0],
+                    operand_is_unsigned.size() > 0 && operand_is_unsigned[0]);
+                RTLIL::SigSpec b = resize_operand(operands[1],
+                    operand_is_unsigned.size() > 1 && operand_is_unsigned[1]);
 
                 std::string cell_name = generate_cell_name(uhdm_op, "add");
                 auto c = module->addAdd(RTLIL::escape_id(cell_name), a, b, result, is_signed);
@@ -3276,17 +3290,22 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 // upper bits would be silently zero-padded — losing the
                 // borrow when LHS > operand width (exposed by
                 // `add_sub_bind_if`'s `result0[8:0] <= a0[7:0] - b0[7:0]`).
-                auto resize_operand = [&](RTLIL::SigSpec op) {
+                auto resize_operand = [&](RTLIL::SigSpec op, bool op_unsigned) {
                     if (op.size() == result_width) return op;
                     if (op.size() > result_width)
                         return op.extract(0, result_width);
                     bool sgn = is_signed;
                     if (op.is_wire() && !op.as_wire()->is_signed) sgn = false;
+                    // A concatenation/replication operand is always unsigned —
+                    // zero-extend it even inside a signed add/subtract.
+                    if (op_unsigned) sgn = false;
                     op.extend_u0(result_width, sgn);
                     return op;
                 };
-                RTLIL::SigSpec a = resize_operand(operands[0]);
-                RTLIL::SigSpec b = resize_operand(operands[1]);
+                RTLIL::SigSpec a = resize_operand(operands[0],
+                    operand_is_unsigned.size() > 0 && operand_is_unsigned[0]);
+                RTLIL::SigSpec b = resize_operand(operands[1],
+                    operand_is_unsigned.size() > 1 && operand_is_unsigned[1]);
 
                 std::string cell_name = generate_cell_name(uhdm_op, "sub");
                 auto c = module->addSub(RTLIL::escape_id(cell_name), a, b, result, is_signed);
@@ -3973,6 +3992,18 @@ RTLIL::SigSpec UhdmImporter::import_ref_obj(const ref_obj* uhdm_ref, const UHDM:
         if (bt != ff_blocking_temps.end())
             return bt->second;
     }
+
+    // Unrolled loop variable: substitute its current value.  This must run
+    // BEFORE the Actual_group()/net resolution below, because a module-level
+    // `integer k` resolves to its `\k` net there and would mask the loop
+    // value (there is a second, now-redundant, loop_values check further down
+    // that only caught locally-declared loop vars).  loop_values is non-empty
+    // only while the owning block's loop body / post-loop tail is being
+    // imported, so a bare `k` correctly reads the wire in unrelated blocks.
+    // e.g. forloops01: `x <= k + {a,b}` in the always_ff must see k=2 (its
+    // loop's final value), not the shared `\k` net the always_comb drives to 4.
+    if (loop_values.count(ref_name))
+        return RTLIL::SigSpec(RTLIL::Const(loop_values[ref_name], 32));
 
     // Check if the ref_obj has an Actual_group() that points to the real signal
     // This is used in generate blocks where ref_obj names include generate scope prefixes

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -7827,6 +7827,59 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
         }
     }
 
+    // Bit-select LHS on a plain register with a (loop-)constant index, e.g.
+    // `q[k] = ...` in an unrolled for loop.  Resolve it to the `\q[idx]`
+    // chunk so map_to_temp_wire redirects the write to `$0\q[idx]`.  Without
+    // this, the generic import_expression(LHS) below returns a fresh
+    // $bit_select temp wire and the real `q` bit is never driven (q collapses
+    // to X after opt) — exposed by simple_forloops' `q[k] = ... >> k`.
+    if (gen_scope_stack.empty()) if (auto lhs_e = uhdm_assign->Lhs()) {
+        if (lhs_e->VpiType() == vpiBitSelect) {
+            const bit_select* bs = any_cast<const bit_select*>(lhs_e);
+            std::string bs_name = std::string(bs->VpiName());
+            RTLIL::IdString wid = RTLIL::escape_id(bs_name);
+            RTLIL::Wire* w = module->wire(wid);
+            // Plain register: not a memory, not an expanded-array element set.
+            // Skipped inside generate scopes, where the bit-select's base wire
+            // needs scope-qualified resolution (gen_test1 / simple_generate).
+            if (w && !module->memories.count(wid)
+                  && !module->wire(RTLIL::escape_id(bs_name + "[0]"))
+                  && bs->VpiIndex()) {
+                // ONLY handle a bare ref to an unrolled loop var (`q[k]`).  Such
+                // an index must come from loop_values: import_ref_obj resolves a
+                // module-level `integer k` via its net (returning the `\k` wire)
+                // before it consults loop_values, so the generic LHS import
+                // below would build a stray $bit_select temp.  A literal-constant
+                // index (e.g. `asdf[3] <= ...`) is left to the generic path,
+                // which already resolves it to the right chunk (initval).
+                RTLIL::SigSpec idx_sig;
+                const UHDM::any* idx_node = bs->VpiIndex();
+                if ((idx_node->VpiType() == vpiRefObj || idx_node->VpiType() == vpiRefVar)) {
+                    std::string iname = std::string(idx_node->VpiName());
+                    if (loop_values.count(iname))
+                        idx_sig = RTLIL::Const(loop_values[iname], 32);
+                }
+                // NB: an empty SigSpec reports is_fully_const()==true, so the
+                // size check is essential — without it a non-loop-var (empty
+                // idx_sig) index would wrongly resolve to bit 0 (initval's
+                // `asdf[3] <= bar[3]` collapsed onto asdf[0]).
+                if (idx_sig.size() > 0 && idx_sig.is_fully_const()) {
+                    int idx = idx_sig.as_const().as_int();
+                    if (idx >= 0 && idx < w->width) {
+                        RTLIL::SigSpec lhs_bit(w, idx, 1);
+                        RTLIL::SigSpec rhs_bit;
+                        if (auto rhs_any = uhdm_assign->Rhs())
+                            if (auto rhs_e = dynamic_cast<const expr*>(rhs_any))
+                                rhs_bit = import_expression(rhs_e, comb_read_map());
+                        // emit_comb_assign truncates the RHS to the 1-bit LHS.
+                        emit_comb_assign(lhs_bit, rhs_bit, proc);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
     // Import LHS (always an expr)
     if (auto lhs_expr = uhdm_assign->Lhs()) {
         lhs = import_expression(lhs_expr);

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -307,13 +307,6 @@ Test: simple_abc9
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: simple_forloops
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: simple_interface
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known

--- a/test/simple_forloops/dut.v
+++ b/test/simple_forloops/dut.v
@@ -1,3 +1,17 @@
+// Top wrapper: instantiate both for-loop modules and promote every port of
+// each instance to a distinct top-level port, so both modules survive
+// synthesis and are independently controllable/observable.
+module simple_forloops (
+	input        clk,
+	input        a1, b1,
+	output [3:0] p1, q1, x1, y1,
+	input        a2, b2,
+	output [3:0] q2, x2, y2
+);
+	forloops01 u1 (.clk(clk), .a(a1), .b(b1), .p(p1), .q(q1), .x(x1), .y(y1));
+	forloops02 u2 (.clk(clk), .a(a2), .b(b2), .q(q2), .x(x2), .y(y2));
+endmodule
+
 module forloops01 (input clk, a, b, output reg [3:0] p, q, x, y);
 	integer k;
 	always @(posedge clk) begin


### PR DESCRIPTION
… concat

Restructured the test under a top module that instantiates both forloops01 and forloops02 and promotes every child port to its own top port, so BOTH modules survive synthesis and are independently observable (auto-top previously kept only one).  That exposed three frontend bugs that all made the design diverge from the Verilog frontend (SAT miter NON-EQUIVALENT):

1. Comb for-loop bit-select write `q[k] = ...` (k an unrolled loop var) was imported via the generic LHS path, which builds a stray $bit_select temp — the real `q` bit was never driven, so q collapsed to X after opt.  Now a bit-select LHS whose index is a loop variable resolves to the `\q[idx]` chunk, which map_to_temp_wire redirects to `$0\q[idx]`. Guards: only outside generate scopes (gen_test1/simple_generate need scope-qualified base resolution); only for an actual loop-var index, never a literal (an empty idx_sig reports is_fully_const()==true, which would otherwise collapse `asdf[3] <= bar[3]` onto bit 0 — initval).

2. A bare reference to a module-level `integer k` loop variable resolved via its net (the `\k` wire) before import_ref_obj consulted loop_values, so `x <= k + {a,b}` in the always_ff read the shared net (driven to 4 by the always_comb) instead of its own unrolled final value (2).  Moved the loop_values substitution ahead of the net resolution; loop_values is populated only while the owning block is imported, so unrelated blocks still read the wire.

3. A concatenation operand of a signed add/subtract was sign-extended (forloops02 `k - {a,b}`, signed integer k → {a,b} replicated on its MSB). A concatenation/replication is ALWAYS unsigned, so it is now zero-extended regardless of the operation's signedness (tracked per-operand from the UHDM node type).

Full suite: passing 245 -> 246, miter failures 6 -> 5, no Induct-Formal regressions, no new warnings.