### PR TITLE
defvalue: apply output-port self-initialisers (output logic cnt = ini…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1432,6 +1432,46 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
         }
     }
 
+    // Output-port self-initialisers: `output logic [3:0] cnt = initval`.
+    // The elaborated instance's port High_conn is the parent connection, so
+    // the init expression survives only on the module DEFINITION's port
+    // (AllModules).  Evaluate it here — import_ref_obj resolves a parameter
+    // ref against THIS module's parameter_default_values, so `initval` yields
+    // the per-instance value — and tag the wire with \init, matching the
+    // Verilog frontend (defvalue: foo.cnt=1, bar.cnt=2).
+    if (uhdm_design && uhdm_design->AllModules() &&
+            !uhdm_module->VpiDefName().empty()) {
+        std::string want = std::string(uhdm_module->VpiDefName());
+        for (const module_inst* def : *uhdm_design->AllModules()) {
+            if (std::string(def->VpiDefName()) != want || !def->Ports())
+                continue;
+            for (auto dp : *def->Ports()) {
+                if (dp->VpiDirection() != vpiOutput || !dp->High_conn())
+                    continue;
+                auto init_e = dynamic_cast<const expr*>(dp->High_conn());
+                if (!init_e)
+                    continue;
+                RTLIL::SigSpec iv = import_expression(init_e);
+                // Require a fully-DEFINED value (no x/z): an unresolved init
+                // such as `output integer w = bar(4)` imports as all-x, and
+                // is_fully_const() is true for x — tagging \init=x would be
+                // wrong (func_port_implied_dir).  Skip those.
+                if (iv.empty() || !iv.is_fully_def())
+                    continue;
+                RTLIL::Wire* w = module->wire(RTLIL::escape_id(std::string(dp->VpiName())));
+                if (!w)
+                    continue;
+                RTLIL::Const c = iv.as_const();
+                if (c.size() != w->width)
+                    c = c.extract(0, w->width, RTLIL::State::S0);  // zero-extend/truncate
+                w->attributes[RTLIL::ID::init] = c;
+                log("UHDM: Set \\init on output port '%s' = %s\n",
+                    std::string(dp->VpiName()).c_str(), c.as_string().c_str());
+            }
+            break;
+        }
+    }
+
     // Pre-scan: identify array variables used ONLY in combinational (always @*) blocks.
     // Such arrays must NOT be created as $memory objects; instead they get individual
     // element wires so that write-then-read semantics work correctly in the same block.

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -152,13 +152,6 @@ Test: code_tidbits_fsm_using_function
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: defvalue
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: dynslice
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known


### PR DESCRIPTION
…tval)

A parameterized register init via an output port (`output logic [3:0] cnt = initval`) was not applied — UHDM emitted no \init, so the counter started at x instead of the parameter value (foo.cnt=1, bar.cnt=2).  SAT miter NON-EQUIVALENT (equiv_induct missed it).

The init expression survives only on the module DEFINITION's port (its High_conn), because each elaborated instance's port High_conn is the parent connection (cnt1/cnt2).  After importing a module's ports, look up its AllModules definition, and for each output port that has a High_conn init expression, evaluate it in THIS instance's context — import_ref_obj resolves a parameter ref against the current module's parameter_default_values, so `initval` yields the per-instance value — and tag the wire with \init.

Guard: only set \init when the value is fully DEFINED (no x/z).  An unresolved init such as `output integer w = bar(4)` imports as all-x, and is_fully_const() is true for x, so without the is_fully_def() check it would wrongly stamp \init=x (regressed func_port_implied_dir; now guarded).

Full suite: passing 246 -> 247, miter failures 5 -> 4, no regressions.