### PR TITLE
aes_kexp128: array-element non-blocking reads must see the registered…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4586,10 +4586,15 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
             RTLIL::SigSpec idx = import_expression(uhdm_bit->VpiIndex(), input_mapping);
 
             if (idx.is_fully_const()) {
-                // Constant index — return current tracked value or raw wire
+                // Constant index — return current tracked value or raw wire.
+                // In always_ff body mode the tracked (in-flight `$0\`) value is
+                // suppressed so a non-blocking RHS reads the REGISTERED element
+                // (NB semantics) — e.g. aes_kexp128's `w[2] <= w[0]^w[1]^w[2]`
+                // must read the old w[0..2], not the values just queued for the
+                // next clock.  (Mirrors emit_comb_assign's scalar suppression.)
                 int i = idx.as_const().as_int();
                 std::string elem_name = signal_name + "[" + std::to_string(i) + "]";
-                if (current_comb_values.count(elem_name))
+                if (!in_always_ff_body_mode && current_comb_values.count(elem_name))
                     return current_comb_values.at(elem_name);
                 RTLIL::Wire* w = module->wire(RTLIL::escape_id(elem_name));
                 if (w) return RTLIL::SigSpec(w);

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -117,13 +117,6 @@ Test: jeras_tcb_gpio
 # Each is to be investigated and fixed (then removed here) incrementally.
 # ---------------------------------------------------------------------------
 
-Test: aes_kexp128
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: always03
     co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
     divergence that the equiv_induct formal flow does NOT catch (known


### PR DESCRIPTION
… value

`reg [3:0] w[3:0]` written in always_ff with `w[i] <= w[0]^...^w[i]` produced wrong results — w[2] computed `w[0]^w[1]` (=0) instead of `w[0]^w[1]^w[2]` (=8).  SAT miter NON-EQUIVALENT (equiv_induct missed it).

The array is expanded into element wires (\w[0..3]) because it's also read combinationally.  In import_bit_select, a constant-index read of an expanded array element returned current_comb_values[elem] (the in-flight `$0\` value) WITHOUT checking in_always_ff_body_mode.  So a non-blocking RHS read of an element written earlier in the same block saw the value queued for the NEXT clock instead of the registered one — blocking semantics where non-blocking was required.  (emit_comb_assign already suppresses this for scalars in body mode; the array path didn't.)

Fix: skip the current_comb_values lookup for const-index array reads when in_always_ff_body_mode, so the read resolves to the registered element wire.

Full suite: passing 248 -> 249, miter failures 3 -> 2, all array/memory always_ff tests pass, no regressions.