### PR TITLE
ci: run the full suite (internal + Yosys) via run_all_tests.sh --all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,10 @@ jobs:
       run: |
         ccache --show-stats
     
-    - name: Run tests
+    - name: Run tests (internal + Yosys)
       run: |
         cd test
-        bash run_all_tests.sh
+        bash run_all_tests.sh --all
     
     - name: Upload test results
       if: always()


### PR DESCRIPTION
The CI ran only the internal tests (`run_all_tests.sh`).  Now that the two runners are unified, run everything — internal + the upstream Yosys tests — with `--all`, so the Yosys suite gets the same formal + Verilator co-sim + SAT-miter scrutiny on every push/PR.  The runner already checks out submodules (yosys tests) and builds Verilator 5.048 (co-sim), so no other CI change is needed; known Yosys gaps are tracked in failing_tests.txt.