### PR TITLE
rotate: evaluate part-select RHS in compile-time functions (in[wrap(j…

### DIFF
--- a/src/frontends/uhdm/functions.cpp
+++ b/src/frontends/uhdm/functions.cpp
@@ -325,7 +325,11 @@ RTLIL::Const UhdmImporter::evaluate_function_stmt(const UHDM::any* stmt,
                     const func_call* fc = any_cast<const func_call*>(assign->Rhs());
                     rhs_value = evaluate_recursive_function_call(fc, local_vars);
                 } else if (assign->Rhs()->VpiType() == vpiBitSelect ||
-                           assign->Rhs()->VpiType() == vpiVarSelect) {
+                           assign->Rhs()->VpiType() == vpiVarSelect ||
+                           assign->Rhs()->VpiType() == vpiPartSelect) {
+                    // vpiPartSelect handles `wrap = out[4:0]` (rotate's compile-
+                    // time index function); evaluate_single_operand slices the
+                    // tracked local-var constant.
                     rhs_value = evaluate_single_operand(assign->Rhs(), local_vars);
                 }
             }
@@ -744,6 +748,25 @@ RTLIL::Const UhdmImporter::evaluate_single_operand(const any* operand,
             const RTLIL::Const& target = local_vars.at(nm);
             if (src >= 0 && src < target.size())
                 val = RTLIL::Const(std::vector<RTLIL::State>{target[src]});
+        }
+    } else if (operand->VpiType() == vpiPartSelect) {
+        // `out[4:0]` read on a function-local var — extract the bit range from
+        // the tracked constant (needed for `wrap = out[4:0]` in rotate's
+        // compile-time index function).  Without this the part-select returns 0.
+        const part_select* ps = any_cast<const part_select*>(operand);
+        std::string nm = std::string(ps->VpiName());
+        if (local_vars.count(nm) && ps->Left_range() && ps->Right_range()) {
+            RTLIL::Const lv = evaluate_single_operand(
+                any_cast<const expr*>(ps->Left_range()), local_vars);
+            RTLIL::Const rv = evaluate_single_operand(
+                any_cast<const expr*>(ps->Right_range()), local_vars);
+            int lo = std::min(lv.as_int(), rv.as_int());
+            int hi = std::max(lv.as_int(), rv.as_int());
+            const RTLIL::Const& target = local_vars.at(nm);
+            std::vector<RTLIL::State> bits;
+            for (int b = lo; b <= hi; b++)
+                bits.push_back((b >= 0 && b < target.size()) ? target[b] : RTLIL::S0);
+            val = RTLIL::Const(bits);
         }
     }
     return val;

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -69,7 +69,6 @@ svtypes/logic_rom.sv
 svtypes/typedef_memory.sv
 techmap/mem_simple_4x1_map.v
 verilog/mem_bounds.sv
-# --- other pre-existing gaps (techmap recursion, abc9 mapping, rotate miter) ---
+# --- other pre-existing gaps (techmap recursion, abc9 mapping) ---
 techmap/recursive_map.v
 various/abc9.v
-simple/rotate.v

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -271,13 +271,6 @@ Test: reg_wire_error
     removed from this file one isolated change at a time (cf. alu_sub,
     fixed by the always_ff blocking-temp part/bit-select redirect).
 
-Test: rotate
-    co-sim backlog: the Verilator co-sim detects a real RTL-vs-netlist
-    divergence that the equiv_induct formal flow does NOT catch (known
-    blind spot).  Tracked here so the suite stays green; to be fixed and
-    removed from this file one isolated change at a time (cf. alu_sub,
-    fixed by the always_ff blocking-temp part/bit-select redirect).
-
 Test: signed_partsel_ext
     CONFIRMED ARTIFACT (not a UHDM bug).  `(* parallel_case *) case(1'b1)`
     over one-hot `sel`.  Directed test: 0 mismatches for all one-hot sel


### PR DESCRIPTION
…,i)])

rotate's generate-based barrel shifter indexes a net with a compile-time function: `out[j] = in[j] & A | in[wrap(j,i)] & B`, where `function [4:0] wrap; ... out = pos-(1<<level); wrap = out[4:0]; endfunction`. Every `in[wrap(j,i)]` term collapsed to `in[0]` — so the whole rotate output was wrong (SAT miter NON-EQUIVALENT; equiv_induct missed it).

evaluate_function_call evaluated `wrap` to 0 for all arguments because the function-body assignment evaluator (evaluate_function_stmt) dispatched the RHS only for vpiOperation / vpiConstant / vpiRefObj / vpiFuncCall / vpiBitSelect / vpiVarSelect — NOT vpiPartSelect.  So `wrap = out[4:0]` (RHS is a part-select) left the return value 0, hence wrap()==0 and in[wrap]==in[0].

Fix:
- Add a vpiPartSelect case to evaluate_single_operand: slice [left:right] bits out of the tracked local-var constant (e.g. out[4:0] of a 32-bit `out`).
- Dispatch a vpiPartSelect RHS to evaluate_single_operand in evaluate_function_stmt's assignment handler (the missing link — without this the new case is never reached for `wrap = out[4:0]`).

Fixes BOTH the internal `rotate` test and the upstream simple/rotate.v; removed them from sim_equiv_analyzed.txt / failing_tests.txt.

Full suite: passing 249 -> 250, miter backlog 2 -> 1 (only always03 left), no regressions.