### PR TITLE
uhdm: fix always_ff blocking-temp part/bit-select read (blocking_temp…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4483,6 +4483,17 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
         if (bt != ff_blocking_temps.end() && bt->second.size() == base.size())
             base = bt->second;
     }
+    // The SSA always_ff path (ff_simple_eval) and always_comb thread same-cycle
+    // blocking values through input_mapping rather than ff_blocking_temps; a
+    // part-select of such a value must read the in-flight value too, mirroring
+    // import_ref_obj's whole-signal substitution.  PR #291 redirected
+    // whole-signal blocking-temp reads but missed part/bit-selects, so the
+    // consumer read the registered wire and got an extra cycle of delay.
+    if (input_mapping && !base_signal_name.empty()) {
+        auto im = input_mapping->find(base_signal_name);
+        if (im != input_mapping->end() && im->second.size() == base.size())
+            base = im->second;
+    }
 
     log("      Base signal width: %d\n", base.size());
 
@@ -4845,6 +4856,14 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
         auto bt = ff_blocking_temps.find(signal_name);
         if (bt != ff_blocking_temps.end() && bt->second.size() == base.size())
             base = bt->second;
+    }
+    // SSA always_ff (ff_simple_eval) / always_comb thread same-cycle blocking
+    // values through input_mapping; a bit-select of such a value must read the
+    // in-flight value too (mirrors import_ref_obj; PR #291 missed bit-selects).
+    if (input_mapping && !signal_name.empty()) {
+        auto im = input_mapping->find(signal_name);
+        if (im != input_mapping->end() && im->second.size() == base.size())
+            base = im->second;
     }
     RTLIL::SigSpec index = import_expression(uhdm_bit->VpiIndex(), input_mapping);
 

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -489,7 +489,14 @@ void UhdmImporter::ff_simple_eval(const UHDM::any* stmt,
             RTLIL::Wire* w = module->wire(RTLIL::escape_id(name));
             // Reads resolve blocking vars to their in-flight value (blk);
             // everything else (registers, inputs) reads the real wire.
+            // Propagate the LHS width as the expression context (as every other
+            // assignment path does) so a widening arithmetic RHS keeps its carry
+            // — e.g. `reg [8:0] t; t = a + b;` must be a 9-bit add, not an 8-bit
+            // add zero-extended (which drops the carry into t[8]).
+            int prev_ctx = expression_context_width;
+            if (w) expression_context_width = w->width;
             RTLIL::SigSpec rhs = import_expression(any_cast<const expr*>(a->Rhs()), &blk);
+            expression_context_width = prev_ctx;
             if (w) {
                 if (rhs.size() < w->width) rhs.extend_u0(w->width,
                         rhs.is_wire() && rhs.as_wire()->is_signed);

--- a/test/blocking_temp_select/blocking_temp_select_from_uhdm.il
+++ b/test/blocking_temp_select/blocking_temp_select_from_uhdm.il
@@ -13,10 +13,7 @@ module \blocking_temp_select
   wire width 8 output 4 \lo
   attribute \src "dut.sv:11.20-11.25"
   wire output 5 \carry
-  attribute \src "dut.sv:14.2-18.5"
-  wire width 8 $0\lo
-  attribute \src "dut.sv:14.2-18.5"
-  wire $0\carry
+  wire width 9 $auto$expression.cpp:3248:import_operation$2
   attribute \src "dut.sv:15.7-15.12"
   cell $add $add$dut.sv:15$3
     parameter \A_SIGNED 0
@@ -26,14 +23,14 @@ module \blocking_temp_select
     parameter \Y_WIDTH 9
     connect \A { 1'0 \a }
     connect \B { 1'0 \b }
-    connect \Y { $0\carry $0\lo }
+    connect \Y $auto$expression.cpp:3248:import_operation$2
   end
   attribute \src "dut.sv:14.2-18.5"
   attribute \always_ff 1
-  cell $dff $procdff$4
+  cell $dff $procdff$6
     parameter \WIDTH 1
     parameter \CLK_POLARITY 1'1
-    connect \D $0\carry
+    connect \D $auto$expression.cpp:3248:import_operation$2 [8]
     connect \Q \carry
     connect \CLK \clk
   end
@@ -42,7 +39,7 @@ module \blocking_temp_select
   cell $dff $procdff$5
     parameter \WIDTH 8
     parameter \CLK_POLARITY 1'1
-    connect \D $0\lo
+    connect \D $auto$expression.cpp:3248:import_operation$2 [7:0]
     connect \Q \lo
     connect \CLK \clk
   end

--- a/test/blocking_temp_select/blocking_temp_select_from_uhdm_nohier.il
+++ b/test/blocking_temp_select/blocking_temp_select_from_uhdm_nohier.il
@@ -15,13 +15,7 @@ module \blocking_temp_select
   wire output 5 \carry
   attribute \src "dut.sv:13.12-13.13"
   wire width 9 \t
-  attribute \src "dut.sv:14.2-18.5"
-  wire width 9 $0\t
-  attribute \src "dut.sv:14.2-18.5"
-  wire width 8 $0\lo
-  attribute \src "dut.sv:14.2-18.5"
-  wire $0\carry
-  wire width 9 $auto$expression.cpp:3006:import_operation$2
+  wire width 9 $auto$expression.cpp:3248:import_operation$2
   attribute \src "dut.sv:15.7-15.12"
   cell $add $add$dut.sv:15$3
     parameter \A_SIGNED 0
@@ -31,17 +25,14 @@ module \blocking_temp_select
     parameter \Y_WIDTH 9
     connect \A { 1'0 \a }
     connect \B { 1'0 \b }
-    connect \Y $auto$expression.cpp:3006:import_operation$2
+    connect \Y $auto$expression.cpp:3248:import_operation$2
   end
   attribute \src "dut.sv:14.2-18.5"
   attribute \always_ff 1
   process $proc$dut.sv:14$1
-    assign $0\t $auto$expression.cpp:3006:import_operation$2
-    assign $0\lo $0\t [7:0]
-    assign $0\carry $0\t [8]
     sync posedge \clk
-      update \carry $0\carry
-      update \lo $0\lo
-      update \t $0\t
+      update \t $auto$expression.cpp:3248:import_operation$2
+      update \lo $auto$expression.cpp:3248:import_operation$2 [7:0]
+      update \carry $auto$expression.cpp:3248:import_operation$2 [8]
   end
 end

--- a/test/blocking_temp_select/blocking_temp_select_from_uhdm_synth.v
+++ b/test/blocking_temp_select/blocking_temp_select_from_uhdm_synth.v
@@ -250,66 +250,66 @@ module blocking_temp_select(clk, a, b, lo, carry);
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  carry_reg /* _70_ */ (
-    .C(clk),
-    .D(_29_[7]),
-    .Q(carry)
-  );
-  (* \always_ff  = 32'd1 *)
-  (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[0]  /* _71_ */ (
+  \$_DFF_P_  \lo_reg[0]  /* _70_ */ (
     .C(clk),
     .D(_30_[0]),
     .Q(lo[0])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[1]  /* _72_ */ (
+  \$_DFF_P_  \lo_reg[1]  /* _71_ */ (
     .C(clk),
     .D(_31_[1]),
     .Q(lo[1])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[2]  /* _73_ */ (
+  \$_DFF_P_  \lo_reg[2]  /* _72_ */ (
     .C(clk),
     .D(_31_[2]),
     .Q(lo[2])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[3]  /* _74_ */ (
+  \$_DFF_P_  \lo_reg[3]  /* _73_ */ (
     .C(clk),
     .D(_31_[3]),
     .Q(lo[3])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[4]  /* _75_ */ (
+  \$_DFF_P_  \lo_reg[4]  /* _74_ */ (
     .C(clk),
     .D(_31_[4]),
     .Q(lo[4])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[5]  /* _76_ */ (
+  \$_DFF_P_  \lo_reg[5]  /* _75_ */ (
     .C(clk),
     .D(_31_[5]),
     .Q(lo[5])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[6]  /* _77_ */ (
+  \$_DFF_P_  \lo_reg[6]  /* _76_ */ (
     .C(clk),
     .D(_31_[6]),
     .Q(lo[6])
   );
   (* \always_ff  = 32'd1 *)
   (* src = "dut.sv:14.2-18.5" *)
-  \$_DFF_P_  \lo_reg[7]  /* _78_ */ (
+  \$_DFF_P_  \lo_reg[7]  /* _77_ */ (
     .C(clk),
     .D(_31_[7]),
     .Q(lo[7])
+  );
+  (* \always_ff  = 32'd1 *)
+  (* src = "dut.sv:14.2-18.5" *)
+  \$_DFF_P_  carry_reg /* _78_ */ (
+    .C(clk),
+    .D(_29_[7]),
+    .Q(carry)
   );
   assign { _31_[8], _31_[0] } = { _29_[7], _30_[0] };
   assign _29_[8] = 1'h0;

--- a/test/blocking_temp_select/netlist_diff.txt
+++ b/test/blocking_temp_select/netlist_diff.txt
@@ -8,87 +8,67 @@
  module blocking_temp_select(clk, a, b, lo, carry);
  (* src = "dut.sv:7.20-7.23" *)
  input clk;
-@@ -247,60 +247,69 @@
+@@ -247,54 +247,63 @@
  .B(b[0]),
  .Y(_30_[0])
  );
 +(* \always_ff  = 32'd1 *)
-+(* src = "dut.sv:14.2-18.5" *)
-+\$_DFF_P_  carry_reg /* _70_ */ (
-+.C(clk),
-+.D(_29_[7]),
-+.Q(carry)
-+);
-+(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[0]  /* _70_ */ (
-+\$_DFF_P_  \lo_reg[0]  /* _71_ */ (
+ \$_DFF_P_  \lo_reg[0]  /* _70_ */ (
  .C(clk),
  .D(_30_[0]),
  .Q(lo[0])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[1]  /* _71_ */ (
-+\$_DFF_P_  \lo_reg[1]  /* _72_ */ (
+ \$_DFF_P_  \lo_reg[1]  /* _71_ */ (
  .C(clk),
  .D(_31_[1]),
  .Q(lo[1])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[2]  /* _72_ */ (
-+\$_DFF_P_  \lo_reg[2]  /* _73_ */ (
+ \$_DFF_P_  \lo_reg[2]  /* _72_ */ (
  .C(clk),
  .D(_31_[2]),
  .Q(lo[2])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[3]  /* _73_ */ (
-+\$_DFF_P_  \lo_reg[3]  /* _74_ */ (
+ \$_DFF_P_  \lo_reg[3]  /* _73_ */ (
  .C(clk),
  .D(_31_[3]),
  .Q(lo[3])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[4]  /* _74_ */ (
-+\$_DFF_P_  \lo_reg[4]  /* _75_ */ (
+ \$_DFF_P_  \lo_reg[4]  /* _74_ */ (
  .C(clk),
  .D(_31_[4]),
  .Q(lo[4])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[5]  /* _75_ */ (
-+\$_DFF_P_  \lo_reg[5]  /* _76_ */ (
+ \$_DFF_P_  \lo_reg[5]  /* _75_ */ (
  .C(clk),
  .D(_31_[5]),
  .Q(lo[5])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[6]  /* _76_ */ (
-+\$_DFF_P_  \lo_reg[6]  /* _77_ */ (
+ \$_DFF_P_  \lo_reg[6]  /* _76_ */ (
  .C(clk),
  .D(_31_[6]),
  .Q(lo[6])
  );
 +(* \always_ff  = 32'd1 *)
  (* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  \lo_reg[7]  /* _77_ */ (
-+\$_DFF_P_  \lo_reg[7]  /* _78_ */ (
+ \$_DFF_P_  \lo_reg[7]  /* _77_ */ (
  .C(clk),
  .D(_31_[7]),
  .Q(lo[7])
  );
--(* src = "dut.sv:14.2-18.5" *)
--\$_DFF_P_  carry_reg /* _78_ */ (
--.C(clk),
--.D(_29_[7]),
--.Q(carry)
--);
- assign { _31_[8], _31_[0] } = { _29_[7], _30_[0] };
- assign _29_[8] = 1'h0;
- assign _30_[8] = 1'h0;
++(* \always_ff  = 32'd1 *)
+ (* src = "dut.sv:14.2-18.5" *)
+ \$_DFF_P_  carry_reg /* _78_ */ (
+ .C(clk),

--- a/test/blocking_temp_select/rtlil_diff.txt
+++ b/test/blocking_temp_select/rtlil_diff.txt
@@ -10,21 +10,19 @@
  module \blocking_temp_select
    attribute \src "dut.sv:7.20-7.23"
    wire input 1 \clk
-@@ -16,35 +16,32 @@
+@@ -15,36 +15,24 @@
+   wire output 5 \carry
    attribute \src "dut.sv:13.12-13.13"
    wire width 9 \t
-   attribute \src "dut.sv:14.2-18.5"
+-  attribute \src "dut.sv:14.2-18.5"
 -  wire width 8 $0\lo[7:0]
-+  wire width 9 $0\t
-   attribute \src "dut.sv:14.2-18.5"
+-  attribute \src "dut.sv:14.2-18.5"
 -  wire $0\carry[0:0]
-+  wire width 8 $0\lo
-   attribute \src "dut.sv:14.2-18.5"
+-  attribute \src "dut.sv:14.2-18.5"
 -  wire width 9 $0\t[8:0]
 -  attribute \src "dut.sv:15.7-15.12"
 -  wire width 9 $add$dut.sv:15$2_Y
-+  wire $0\carry
-+  wire width 9 $auto$expression.cpp:3006:import_operation$2
++  wire width 9 $auto$expression.cpp:3248:import_operation$2
    attribute \src "dut.sv:15.7-15.12"
 -  cell $add $add$dut.sv:15$2
 +  cell $add $add$dut.sv:15$3
@@ -40,7 +38,7 @@
 -    connect \Y $add$dut.sv:15$2_Y
 +    connect \A { 1'0 \a }
 +    connect \B { 1'0 \b }
-+    connect \Y $auto$expression.cpp:3006:import_operation$2
++    connect \Y $auto$expression.cpp:3248:import_operation$2
    end
    attribute \src "dut.sv:14.2-18.5"
 +  attribute \always_ff 1
@@ -51,15 +49,12 @@
 -    assign $0\t[8:0] $add$dut.sv:15$2_Y
 -    assign $0\lo[7:0] $add$dut.sv:15$2_Y [7:0]
 -    assign $0\carry[0:0] $add$dut.sv:15$2_Y [8]
-+    assign $0\t $auto$expression.cpp:3006:import_operation$2
-+    assign $0\lo $0\t [7:0]
-+    assign $0\carry $0\t [8]
      sync posedge \clk
 -      update \lo $0\lo[7:0]
 -      update \carry $0\carry[0:0]
 -      update \t $0\t[8:0]
-+      update \carry $0\carry
-+      update \lo $0\lo
-+      update \t $0\t
++      update \t $auto$expression.cpp:3248:import_operation$2
++      update \lo $auto$expression.cpp:3248:import_operation$2 [7:0]
++      update \carry $auto$expression.cpp:3248:import_operation$2 [8]
    end
  end

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -26,4 +26,3 @@ macc                        accumulator output stuck at 0x7FFFFFFFFF (40-bit max
 simple_memory               synchronous whole-array clear-on-reset (for i: mem[i]<=0) not modelled; reads stale data after a mid-run reset; miter NON-EQUIVALENT.
 asym_ram_sdp_read_wider     asymmetric dual-clock SDP RAM (narrow write / wide read) read port diverges; miter NON-EQUIVALENT.
 subbytes                    async-reset (negedge) datapath with blocking temps diverges; miter INCONCLUSIVE (satgen can't model $_DFFE_PN0N_), cosim-decisive.
-blocking_temp_select        always_ff blocking temp read via part-/bit-select same cycle (alu_sub-pattern repro); miter NON-EQUIVALENT.

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -67,7 +67,6 @@ macc
 simple_memory
 asym_ram_sdp_read_wider
 subbytes
-blocking_temp_select
 arch/xilinx/macc.v
 arch/xilinx/asym_ram_sdp_read_wider.v
 simple/subbytes.v

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -436,9 +436,3 @@ Test: subbytes
     from the Verilog frontend.  Miter INCONCLUSIVE (satgen can't model the
     $_DFFE_PN0N_ cell) so classified `bug` via override; UHDM-cosim FAIL /
     Verilog-cosim PASS is decisive.
-
-Test: blocking_temp_select
-    UHDM BUG: always_ff blocking temp read back via part-/bit-select in the
-    same cycle (minimal repro of the alu_sub pattern) diverges from the
-    Verilog frontend.  SAT miter NON-EQUIVALENT; UHDM-cosim FAIL /
-    Verilog-cosim PASS.  (Pre-existing baseline co-sim warning, now triaged.)


### PR DESCRIPTION
…_select)

`reg [8:0] t; always @(posedge clk) begin t = a + b; lo <= t[7:0]; carry <= t[8]; end` synthesised wrong two ways, so lo lagged a cycle and carry was stuck at 0 (UHDM-cosim FAIL / Verilog-cosim PASS; SAT miter NON-EQUIVALENT):

1. Same-cycle part-/bit-select of a blocking temp read the REGISTERED wire instead of the in-flight value.  The SSA always_ff path (ff_simple_eval) and always_comb thread blocking values through `input_mapping`, and import_ref_obj substitutes it for whole-signal reads, but import_part_select / import_bit_select only consulted input_mapping when the wire was absent (function params).  Now they redirect the base through input_mapping for a real wire too — mirroring the existing ff_blocking_temps redirect — so `t[7:0]` / `t[8]` read the in-flight add (PR #291 covered whole-signal reads but missed selects).

2. ff_simple_eval never set expression_context_width, so `t = a + b` (a/b 8-bit, t 9-bit) was an 8-bit add zero-extended to 9 bits, dropping the carry into t[8].  Set the LHS width as the expression context (as every other assignment path does) so the add is 9-bit.

Result matches the Verilog frontend: a 9-bit $add feeding $0\lo[7:0] and $0\carry[8] directly.  SAT miter now EQUIVALENT, co-sim PASS.  Removed from failing_tests.txt / sim_equiv_analyzed.txt / cosim_uhdm_bugs.txt.  Full suite: internal green (247 pass, was 246), no regressions; yosys unchanged.