### PR TITLE
uhdm: concat/replication operands are self-determined width (alu flags)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -2813,6 +2813,14 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
     // unsigned in Verilog, so when widened inside a signed op (e.g.
     // `signed_int - {a,b}`) it must be ZERO-extended, not sign-extended.
     std::vector<bool> operand_is_unsigned;
+    // Concatenation / replication operands are SELF-DETERMINED in Verilog
+    // (LRM §11.8.1): the surrounding assignment's context width must NOT widen
+    // them.  Without clearing it, `tmp = {1'b0, ~B}` with a 9-bit `tmp` widens
+    // `~B` to 9 bits — turning the value into `~{1'b0, B}`, whose explicit MSB
+    // flips from 0 to 1 (alu's NOT/shift flag bits: CF/SF wrong).
+    int saved_ctx_for_concat_operands = expression_context_width;
+    if (op_type == vpiConcatOp || op_type == vpiMultiConcatOp)
+        expression_context_width = 0;
     if (uhdm_op->Operands()) {
         if (op_type == vpiConditionOp) {
             log("UHDM: ConditionOp (type=%d) has %d operands\n", op_type, (int)uhdm_op->Operands()->size());
@@ -2843,7 +2851,8 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
             operands.push_back(op_sig);
         }
     }
-    
+    expression_context_width = saved_ctx_for_concat_operands;
+
     // Check if all operands are constant - if so, we can evaluate the operation
     // But only do this when we're in a function context with loop variables
     bool all_const = true;


### PR DESCRIPTION
`reg [8:0] tmp; tmp = {1'b0, ~B};` synthesised as `tmp = ~{1'b0, B}` — the unary `~` was hoisted over the concat, so the explicit MSB flipped 0→1 and the carry/sign flags (CF=tmp[8], SF=tmp[7]) came out wrong (alu: UHDM-cosim FAIL / Verilog-cosim PASS; miter NON-EQUIVALENT).

Cause: import_operation imports every operand with the current expression_context_width (the assignment's LHS width, here 9).  For a concatenation that is wrong — concat/replication operands are SELF-DETERMINED in Verilog (LRM §11.8.1), so `~B` got widened to 9 bits (`~{1'b0,B}`) instead of staying 8 bits inside `{1'b0, ~B}`.

Fix: clear expression_context_width while importing vpiConcatOp / vpiMultiConcatOp operands, then restore it.

Fixes 5 yosys co-sim warnings with one change — alu, code_hdl_models_lfsr_updown, opt_share_cat, opt_share_cat_multiuser, opt_share_large_pmux_cat_multipart — all `{const, <op>}` concats.  Full suite: internal green 251 pass, yosys sim-equiv warnings 60->55, no regressions.