### PR TITLE
build: suppress GCC 15 false-positive -Wmaybe-uninitialized (issue #335)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ target_compile_options(uhdm2rtlil PRIVATE
     -Wno-unused-parameter # Yosys headers have many unused parameters
     -Wno-sign-compare     # Common in Yosys code
     -Wno-array-bounds     # False positive in Yosys io.h header
+    # GCC 15 (Ubuntu 25.10) emits false-positive -Wmaybe-uninitialized inside
+    # the inlined std::vector move-constructor of RTLIL::SigChunk/SigSpec (e.g.
+    # `RTLIL::SigSig(RTLIL::SigSpec(), RTLIL::SigSpec())` in functions.cpp); the
+    # code is correct, the warning is a known compiler analysis artefact, so
+    # don't let -Werror reject it.  (issue #335)
+    -Wno-maybe-uninitialized
 )
 
 # Add required Yosys defines


### PR DESCRIPTION
On Ubuntu 25.10 / GCC 15.2.0 the build fails because `-Werror` promotes a false-positive `-Wmaybe-uninitialized` to an error.  The warning fires inside the inlined `std::vector` move-constructor of `RTLIL::SigChunk`/`SigSpec` — e.g. `RTLIL::SigSig(RTLIL::SigSpec(), RTLIL::SigSpec())` in functions.cpp:1141 — where the temporaries are correctly constructed; it is a known GCC analysis artefact of the inlined move, not an uninitialized read in our code, so there is no source-level fix.

Add `-Wno-maybe-uninitialized` to the plugin's compile options, alongside the existing `-Wno-array-bounds` (a similar Yosys-header false positive), so `-Werror` no longer rejects it.  The flag is valid on GCC 11+ and accepted by Clang as a compatibility no-op; the build is unaffected on older toolchains.