### PR TITLE
uhdm: break/continue/return in the compile-time function evaluator

### DIFF
--- a/src/frontends/uhdm/functions.cpp
+++ b/src/frontends/uhdm/functions.cpp
@@ -37,6 +37,7 @@
 #include <uhdm/for_stmt.h>
 #include <uhdm/while_stmt.h>
 #include <uhdm/repeat.h>
+#include <uhdm/return_stmt.h>
 #include <uhdm/range.h>
 #include <uhdm/parameter.h>
 
@@ -50,6 +51,9 @@ RTLIL::Const UhdmImporter::evaluate_function_call(const UHDM::function* func_def
         log_error("Function definition is null in evaluate_function_call\n");
         return RTLIL::Const();
     }
+    // Clear any stale loop-control flags from a prior evaluation.
+    func_loop_break_ = false;
+    func_loop_continue_ = false;
 
     // Recursion depth limit to prevent infinite loops
     static int recursion_depth = 0;
@@ -533,8 +537,11 @@ RTLIL::Const UhdmImporter::evaluate_function_stmt(const UHDM::any* stmt,
                 RTLIL::Const last_result;
                 for (auto s : *stmts) {
                     last_result = evaluate_function_stmt(s, block_vars, func_name);
+                    // A break/continue stops executing the rest of this block;
+                    // the enclosing loop consumes the flag.
+                    if (func_loop_break_ || func_loop_continue_) break;
                 }
-                
+
                 // Copy any updates to non-local variables back to the parent scope
                 // Local variables declared in this block should not affect the parent scope
                 for (auto& [name, value] : block_vars) {
@@ -579,6 +586,8 @@ RTLIL::Const UhdmImporter::evaluate_function_stmt(const UHDM::any* stmt,
                 if (cond_value.size() == 0 || cond_value.is_fully_zero()) break;
                 if (fs->VpiStmt())
                     last_result = evaluate_function_stmt(fs->VpiStmt(), local_vars, func_name);
+                if (func_loop_break_) { func_loop_break_ = false; break; }
+                if (func_loop_continue_) func_loop_continue_ = false;  // fall through to inc
                 run_init_inc(fs->VpiForIncStmt(), fs->VpiForIncStmts());
                 iterations++;
             }
@@ -615,6 +624,8 @@ RTLIL::Const UhdmImporter::evaluate_function_stmt(const UHDM::any* stmt,
                 if (ws->VpiStmt()) {
                     last_result = evaluate_function_stmt(ws->VpiStmt(), local_vars, func_name);
                 }
+                if (func_loop_break_) { func_loop_break_ = false; break; }
+                if (func_loop_continue_) func_loop_continue_ = false;
                 iterations++;
             }
 
@@ -651,9 +662,38 @@ RTLIL::Const UhdmImporter::evaluate_function_stmt(const UHDM::any* stmt,
                 if (rp->VpiStmt()) {
                     last_result = evaluate_function_stmt(rp->VpiStmt(), local_vars, func_name);
                 }
+                if (func_loop_break_) { func_loop_break_ = false; break; }
+                if (func_loop_continue_) func_loop_continue_ = false;
             }
 
             return last_result;
+        }
+
+        case vpiBreak:
+            func_loop_break_ = true;
+            return RTLIL::Const();
+
+        case vpiContinue:
+            func_loop_continue_ = true;
+            return RTLIL::Const();
+
+        case vpiReturn: {
+            // `return <expr>` — set the function's result variable (named after
+            // the function) so evaluate_function_call picks it up.  Was
+            // unhandled, so a function whose value comes via `return x` (rather
+            // than `func = x`) evaluated to 0 (BreakWhile/ContinueWhile/...).
+            const return_stmt* rs = any_cast<const return_stmt*>(stmt);
+            if (rs && rs->VpiCondition()) {
+                RTLIL::Const v;
+                if (rs->VpiCondition()->VpiType() == vpiOperation)
+                    v = evaluate_operation_const(
+                            any_cast<const operation*>(rs->VpiCondition()), local_vars);
+                else
+                    v = evaluate_single_operand(rs->VpiCondition(), local_vars);
+                local_vars[func_name] = v;
+                return v;
+            }
+            return RTLIL::Const();
         }
     }
 

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -452,6 +452,13 @@ struct UhdmImporter {
     // Track if we're currently processing an initial block
     bool in_initial_block = false;
 
+    // Compile-time function evaluator (evaluate_function_stmt) loop control:
+    // set by a `break`/`continue` statement, checked/cleared by the enclosing
+    // loop and begin-block so a `while`/`for`/`repeat` in a function body can
+    // exit/skip early (BreakWhile/ContinueWhile/...).
+    bool func_loop_break_ = false;
+    bool func_loop_continue_ = false;
+
     // Counter for generating unique unnamed block names
     int unnamed_block_counter = 0;
 

--- a/test/BreakContinueWhile/BreakContinueWhile_from_uhdm.il
+++ b/test/BreakContinueWhile/BreakContinueWhile_from_uhdm.il
@@ -5,5 +5,5 @@ attribute \src "dut.sv:1.1-12.10"
 module \top
   attribute \src "dut.sv:1.23-1.24"
   wire width 32 output 1 signed \a
-  connect \a 0
+  connect \a 184
 end

--- a/test/BreakContinueWhile/BreakContinueWhile_from_uhdm_nohier.il
+++ b/test/BreakContinueWhile/BreakContinueWhile_from_uhdm_nohier.il
@@ -4,14 +4,14 @@ attribute \cells_not_processed 1
 attribute \src "dut.sv:1.1-12.10"
 module \top
   attribute \src "dut.sv:1.23-1.24"
-  attribute \init 0
+  attribute \init 184
   wire width 32 output 1 signed \a
   attribute \src "dut.sv:11.4-11.30"
   process $proc$dut.sv:11$1
   end
   attribute \src "dut.sv:11.4-11.30"
-  process $auto$process.cpp:3172:operator()$2
+  process $auto$process.cpp:3230:operator()$2
     sync always
-      update \a 0
+      update \a 184
   end
 end

--- a/test/BreakContinueWhile/BreakContinueWhile_from_uhdm_synth.v
+++ b/test/BreakContinueWhile/BreakContinueWhile_from_uhdm_synth.v
@@ -6,5 +6,5 @@ module top(a);
   (* src = "dut.sv:1.23-1.24" *)
   output signed [31:0] a;
   wire signed [31:0] a;
-  assign a = 32'd0;
+  assign a = 32'd184;
 endmodule

--- a/test/BreakWhile/BreakWhile_from_uhdm.il
+++ b/test/BreakWhile/BreakWhile_from_uhdm.il
@@ -5,5 +5,5 @@ attribute \src "dut.sv:1.1-10.10"
 module \top
   attribute \src "dut.sv:1.23-1.24"
   wire width 32 output 1 signed \a
-  connect \a 0
+  connect \a 128
 end

--- a/test/BreakWhile/BreakWhile_from_uhdm_nohier.il
+++ b/test/BreakWhile/BreakWhile_from_uhdm_nohier.il
@@ -4,14 +4,14 @@ attribute \cells_not_processed 1
 attribute \src "dut.sv:1.1-10.10"
 module \top
   attribute \src "dut.sv:1.23-1.24"
-  attribute \init 0
+  attribute \init 128
   wire width 32 output 1 signed \a
   attribute \src "dut.sv:9.4-9.30"
   process $proc$dut.sv:9$1
   end
   attribute \src "dut.sv:9.4-9.30"
-  process $auto$process.cpp:3172:operator()$2
+  process $auto$process.cpp:3230:operator()$2
     sync always
-      update \a 0
+      update \a 128
   end
 end

--- a/test/BreakWhile/BreakWhile_from_uhdm_synth.v
+++ b/test/BreakWhile/BreakWhile_from_uhdm_synth.v
@@ -6,5 +6,5 @@ module top(a);
   (* src = "dut.sv:1.23-1.24" *)
   output signed [31:0] a;
   wire signed [31:0] a;
-  assign a = 32'd0;
+  assign a = 32'd128;
 endmodule

--- a/test/ContinueWhile/ContinueWhile_from_uhdm.il
+++ b/test/ContinueWhile/ContinueWhile_from_uhdm.il
@@ -5,5 +5,5 @@ attribute \src "dut.sv:1.1-10.10"
 module \top
   attribute \src "dut.sv:1.23-1.24"
   wire width 32 output 1 signed \a
-  connect \a 0
+  connect \a 128
 end

--- a/test/ContinueWhile/ContinueWhile_from_uhdm_nohier.il
+++ b/test/ContinueWhile/ContinueWhile_from_uhdm_nohier.il
@@ -4,14 +4,14 @@ attribute \cells_not_processed 1
 attribute \src "dut.sv:1.1-10.10"
 module \top
   attribute \src "dut.sv:1.23-1.24"
-  attribute \init 0
+  attribute \init 128
   wire width 32 output 1 signed \a
   attribute \src "dut.sv:9.4-9.30"
   process $proc$dut.sv:9$1
   end
   attribute \src "dut.sv:9.4-9.30"
-  process $auto$process.cpp:3172:operator()$2
+  process $auto$process.cpp:3230:operator()$2
     sync always
-      update \a 0
+      update \a 128
   end
 end

--- a/test/ContinueWhile/ContinueWhile_from_uhdm_synth.v
+++ b/test/ContinueWhile/ContinueWhile_from_uhdm_synth.v
@@ -6,5 +6,5 @@ module top(a);
   (* src = "dut.sv:1.23-1.24" *)
   output signed [31:0] a;
   wire signed [31:0] a;
-  assign a = 32'd0;
+  assign a = 32'd128;
 endmodule


### PR DESCRIPTION
A `while`/`for`/`repeat` loop inside a function body had no `break`/`continue` handling in evaluate_function_stmt, and `return <expr>` was unhandled entirely. So `function int f(int x); while (1) begin if (x>100) break; x=x<<1; end return x; endfunction` looped to the iteration cap and evaluated to 0 (BreakWhile/ContinueWhile/BreakContinueWhile).

- Add member loop-control flags func_loop_break_ / func_loop_continue_ (reset at the top of evaluate_function_call), set by new `vpiBreak`/`vpiContinue` cases and checked/cleared by the begin-block iterator and the for/while/repeat loop bodies.
- Add a `vpiReturn` case: evaluate the return expression and store it in the function's result variable (local_vars[func_name]).  Previously a function whose value came via `return x` (not `f = x`) compile-time-evaluated to 0.

Fixes BreakWhile (=128), ContinueWhile (=128), BreakContinueWhile (=184); all pass co-sim.  Existing function tests (const_func, function_nested, fib_recursion, many_functions, …) are unaffected — break/continue/return-expr were previously no-ops in this path.