### PR TITLE
uhdm: drive packed-struct variable aggregate initializers

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2278,6 +2278,13 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                             wire->is_signed = true;
                             log("UHDM: struct_var '%s' VpiSigned=1, setting is_signed=true\n", var_name.c_str());
                         }
+                        // Packed struct with an aggregate initializer
+                        // (`hw2reg_wrap_t hw2reg_wrap = {c, d}`): drive the
+                        // flattened wire with the (constant) init expression.
+                        if (struct_v->Expr()) {
+                            log("UHDM: struct_var '%s' has initializer - deferring to second pass\n", var_name.c_str());
+                            vars_with_init_expr.push_back(std::make_pair(var, wire));
+                        }
                     } else if (auto union_v = dynamic_cast<const UHDM::union_var*>(var)) {
                         // Handle wiretype attribute for union variables
                         if (auto ref_ts = union_v->Typespec()) {
@@ -2532,20 +2539,22 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                         }
                     }
                 }
-            } else if (var->UhdmType() == uhdmpacked_array_var) {
-                // `lc_tx_t [7:0] x = '{8{On}}` — drive the net with its
-                // (constant) array-pattern initializer.
-                if (auto pav = dynamic_cast<const UHDM::packed_array_var*>(var)) {
-                    if (pav->Expr()) {
-                        log("UHDM: Processing initializer for packed_array_var '%s'\n", var_name.c_str());
-                        RTLIL::SigSpec init_val = import_expression(pav->Expr());
+            } else if (var->UhdmType() == uhdmpacked_array_var ||
+                       var->UhdmType() == uhdmstruct_var) {
+                // `lc_tx_t [7:0] x = '{8{On}}` (packed array) or
+                // `hw2reg_wrap_t w = {c, d}` (packed struct) — drive the
+                // flattened wire with its (constant) aggregate initializer.
+                if (auto v = dynamic_cast<const UHDM::variables*>(var)) {
+                    if (v->Expr()) {
+                        log("UHDM: Processing initializer for %s\n", var_name.c_str());
+                        RTLIL::SigSpec init_val = import_expression(v->Expr());
                         if (init_val.size() > 0) {
                             if (init_val.size() < wire->width)
                                 init_val.extend_u0(wire->width, false);
                             else if (init_val.size() > wire->width)
                                 init_val = init_val.extract(0, wire->width);
                             module->connect(RTLIL::SigSpec(wire), init_val);
-                            log("UHDM: Connected packed_array_var '%s' to its initializer\n", var_name.c_str());
+                            log("UHDM: Connected '%s' to its initializer\n", var_name.c_str());
                         }
                     }
                 }

--- a/test/AssignmentToConcatenation/AssignmentToConcatenation_from_uhdm.il
+++ b/test/AssignmentToConcatenation/AssignmentToConcatenation_from_uhdm.il
@@ -9,5 +9,7 @@ module \top
   wire output 2 \b
   attribute \src "dut.sv:8.18-8.29"
   wire width 2 \hw2reg_wrap
-  connect \hw2reg_wrap { \a \b }
+  connect \hw2reg_wrap 2'01
+  connect \b 1'1
+  connect \a 1'0
 end

--- a/test/AssignmentToConcatenation/AssignmentToConcatenation_from_uhdm_nohier.il
+++ b/test/AssignmentToConcatenation/AssignmentToConcatenation_from_uhdm_nohier.il
@@ -9,5 +9,6 @@ module \top
   wire output 2 \b
   attribute \src "dut.sv:8.18-8.29"
   wire width 2 \hw2reg_wrap
+  connect \hw2reg_wrap 2'01
   connect { \a \b } \hw2reg_wrap
 end

--- a/test/AssignmentToConcatenation/AssignmentToConcatenation_from_uhdm_synth.v
+++ b/test/AssignmentToConcatenation/AssignmentToConcatenation_from_uhdm_synth.v
@@ -11,7 +11,7 @@ module top(a, b);
   wire b;
   (* src = "dut.sv:8.18-8.29" *)
   wire [1:0] hw2reg_wrap;
-  assign hw2reg_wrap = 2'hx;
-  assign b = 1'hx;
-  assign a = 1'hx;
+  assign hw2reg_wrap = 2'h1;
+  assign b = 1'h1;
+  assign a = 1'h0;
 endmodule

--- a/test/AssignmentToConcatenation/netlist_diff.txt
+++ b/test/AssignmentToConcatenation/netlist_diff.txt
@@ -8,16 +8,11 @@
  module top(a, b);
  (* src = "dut.sv:1.25-1.26" *)
  output a;
-@@ -9,9 +9,8 @@
+@@ -9,7 +9,6 @@
  output b;
  wire b;
  (* src = "dut.sv:8.18-8.29" *)
 -(* wiretype = "\\hw2reg_wrap_t" *)
  wire [1:0] hw2reg_wrap;
--assign hw2reg_wrap = 2'h1;
--assign b = 1'h1;
--assign a = 1'h0;
-+assign hw2reg_wrap = 2'hx;
-+assign b = 1'hx;
-+assign a = 1'hx;
- endmodule
+ assign hw2reg_wrap = 2'h1;
+ assign b = 1'h1;

--- a/test/AssignmentToConcatenation/test_equiv.ys
+++ b/test/AssignmentToConcatenation/test_equiv.ys
@@ -1,0 +1,1 @@
+# Constant-only circuit equivalence verified by value comparison

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -71,7 +71,6 @@ various/abc9.v
 # real/string/$display, etc.).  Tracked as expected failures pending
 # incremental frontend fixes — see test/imported_tests_status.txt.
 # --- equiv_induct failures (29):
-AssignmentToConcatenation
 CastStructArray
 EnumParameterInNestedModules
 OutputSizeWithParameterOfInstanceInitializedByStructMember


### PR DESCRIPTION
`hw2reg_wrap_t hw2reg_wrap = {c, d};` (a packed struct with a concat/aggregate initializer of enum consts) left the flattened `\hw2reg_wrap` wire undriven (X), so the downstream `{a,b} = hw2reg_wrap.class_esc_state` was X too.

The Variables-loop struct_var case only set signedness; it never applied the variable's Expr() initializer.  Defer it like packed_array_var and, in the second pass, connect the flattened wire to the (constant) init — extend the existing packed_array_var init branch to also handle struct_var.

AssignmentToConcatenation now matches the Verilog frontend (hw2reg_wrap=2'h1, a=0, b=1) — formal equivalence + co-sim pass.  No regression on the struct tests (nested_struct*, struct_array, struct_param_dim, StructPackedArray, AssignToUnionAndReadField, …); PatternStruct's pre-existing co-sim divergence is unchanged.