### PR TITLE
uhdm: exclude for-loop counters from the async-reset register set

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -932,6 +932,19 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
             // Extract assigned signals from the statement
             if (stmt) {
                 extract_assigned_signals(stmt, assigned_signals);
+                // A for-loop control variable (`for (i=0; i<N; i=i+1) mem[i]<=0`
+                // in the reset branch) is collected as an assigned signal so the
+                // comb path can drive its post-loop value, but it is NOT a
+                // flip-flop and has no constant async-reset value — drop it from
+                // the register set (yosys/tests/simple/mem_arst.v: otherwise
+                // proc errors "Async reset yields non-constant value for \i").
+                std::set<std::string> loop_vars;
+                collect_for_loop_var_names(stmt, loop_vars);
+                if (!loop_vars.empty())
+                    assigned_signals.erase(
+                        std::remove_if(assigned_signals.begin(), assigned_signals.end(),
+                            [&](const AssignedSignal& s){ return loop_vars.count(s.name) > 0; }),
+                        assigned_signals.end());
             }
 
             // Async-reset always_ff that ALSO writes a memory (issue #326):

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -237,6 +237,48 @@ void UhdmImporter::extract_lhs_signals(const expr* lhs_expr, std::vector<Assigne
     }
 }
 
+void UhdmImporter::collect_for_loop_var_names(const any* stmt, std::set<std::string>& names) {
+    if (!stmt) return;
+    switch (stmt->VpiType()) {
+        case vpiFor: {
+            auto for_loop = any_cast<const for_stmt*>(stmt);
+            if (for_loop->VpiForInitStmts())
+                for (auto s : *for_loop->VpiForInitStmts())
+                    if (s->VpiType() == vpiAssignment)
+                        if (auto ia = any_cast<const assignment*>(s))
+                            if (ia->Lhs() && !ia->Lhs()->VpiName().empty())
+                                names.insert(std::string(ia->Lhs()->VpiName()));
+            collect_for_loop_var_names(for_loop->VpiStmt(), names);
+            break;
+        }
+        case vpiBegin:
+        case vpiNamedBegin: {
+            if (auto stmts = begin_block_stmts(stmt))
+                for (auto s : *stmts) collect_for_loop_var_names(s, names);
+            break;
+        }
+        case vpiIf: {
+            auto if_st = any_cast<const if_stmt*>(stmt);
+            collect_for_loop_var_names(if_st->VpiStmt(), names);
+            break;
+        }
+        case vpiIfElse: {
+            auto ie = any_cast<const if_else*>(stmt);
+            collect_for_loop_var_names(ie->VpiStmt(), names);
+            collect_for_loop_var_names(ie->VpiElseStmt(), names);
+            break;
+        }
+        case vpiCase: {
+            auto cs = any_cast<const case_stmt*>(stmt);
+            if (cs->Case_items())
+                for (auto item : *cs->Case_items())
+                    collect_for_loop_var_names(item->Stmt(), names);
+            break;
+        }
+        default: break;
+    }
+}
+
 void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<AssignedSignal>& signals) {
     if (!stmt) return;
 

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -718,6 +718,10 @@ struct UhdmImporter {
     RTLIL::IdString get_unique_cell_name(const std::string& base_name);
     UHDM::VectorOfany *begin_block_stmts(const any *stmt);
     void extract_assigned_signals(const any* stmt, std::vector<AssignedSignal>& signals);
+    // Collect the control-variable names of every `for` loop in a statement
+    // (e.g. `for (i=...)`) so they can be excluded from a register/reset set —
+    // a loop counter is not a flip-flop and has no constant async-reset value.
+    void collect_for_loop_var_names(const any* stmt, std::set<std::string>& names);
     void extract_lhs_signals(const UHDM::expr* lhs_expr, std::vector<AssignedSignal>& signals);
     void extract_assigned_signal_names(const any* stmt, std::set<std::string>& signal_names);
     // Collect base names of signals written via BLOCKING (`=`) assignments

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -53,7 +53,6 @@ memlib/memlib_clock_sdp.v
 memlib/memlib_wide_sdp.v
 simple/mem2reg_bounds_tern.v
 simple/mem2reg.v
-simple/mem_arst.v
 techmap/mem_simple_4x1_map.v
 verilog/mem_bounds.sv
 # --- other pre-existing gaps (techmap recursion, abc9 mapping) ---


### PR DESCRIPTION
A reset branch that clears a memory with a loop —
`for (i=0; i<Size; i=i+1) Mem[i] <= 0;` (yosys/tests/simple/mem_arst.v) — added the module-scope loop counter `i` to the always_ff async-reset register set (extract_assigned_signals collects it so the comb path can drive its post-loop value).  `i` is not a flip-flop and has no constant reset value, so Yosys's proc pass aborted: "Async reset \Reset_n_i yields non-constant value ... for signal \i".

Add collect_for_loop_var_names() and, in the async-reset path only, drop any collected for-loop control variable from the register set.  The loop still unrolls (Mem[0..N-1] <= 0) and `i` is driven combinationally; it just no longer gets a (bogus) async-reset assignment.

mem_arst now passes formal equivalence.  No regression on the async-reset / memory / loop suite (adff, adffn, issue326_packed_mem, mul_sync_reset_test, blocking_temp_ff, simple_memory, all internal mem* tests, and the passing yosys memories/* + memlib/* tests).  The remaining byte-enable failures (memlib_wren, amber23/simple_sram_byte_en) are pre-existing and unaffected (verified via stash).