### PR TITLE
uhdm: initial-block ROM init with a computed per-index value (meminit)

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -4498,7 +4498,16 @@ void UhdmImporter::import_statement_sync(const any* uhdm_stmt, RTLIL::SyncRule* 
             
             // Get body
             body = for_loop->VpiStmt();
-            
+            // Unwrap a single-statement begin block so the meminit / shift-reg
+            // pattern matchers below (which expect a bare assignment body) also
+            // fire when the loop body is wrapped — `for (i) begin mem[i]=...; end`
+            // (arch/*/meminit.v) vs the bare `for (i) mem[i]=...` (svtypes/logic_rom).
+            if (body && (body->VpiType() == vpiBegin || body->VpiType() == vpiNamedBegin)) {
+                if (auto stmts = begin_block_stmts(body))
+                    if (stmts->size() == 1)
+                        body = (*stmts)[0];
+            }
+
             if (!init_stmt || !condition || !inc_stmt || !body) {
                 log_warning("For loop missing required components:\n");
                 log_warning("  init_stmt: %s\n", init_stmt ? "present" : "missing");
@@ -4891,17 +4900,29 @@ void UhdmImporter::import_statement_sync(const any* uhdm_stmt, RTLIL::SyncRule* 
                             any_cast<const bit_select*>(mem_assign->Lhs())->VpiName());
                         int mem_width = module->memories.at(RTLIL::escape_id(memory_name))->width;
                         int64_t loop_end = inclusive ? end_value : end_value - 1;
-                        std::map<std::string, uint64_t> loop_vars;
-                        std::vector<std::pair<int64_t, uint64_t>> rom_words;
+                        std::vector<std::pair<int64_t, RTLIL::Const>> rom_words;
                         bool all_const = (mem_assign->Rhs() != nullptr);
+                        // Evaluate each ROM word with import_expression (loop var
+                        // substituted via loop_values), the SAME path that
+                        // computes a sibling expression like meminit.v's
+                        // `expect_val = PRIME*(read_addr*2+1)`.  Using a separate
+                        // evaluator (evaluate_expression_with_vars) mis-sized
+                        // unsized literals and produced a ROM word that disagreed
+                        // with the comparison value.  Restore loop_values after.
+                        auto saved_loop_values = loop_values;
                         for (int64_t i = start_value; all_const && i <= loop_end; i += increment) {
-                            RTLIL::SigSpec rhs_value = evaluate_expression_with_vars(
-                                any_cast<const expr*>(mem_assign->Rhs()), loop_vars, loop_var_name, i);
-                            if (rhs_value.is_fully_const())
-                                rom_words.emplace_back(i, (uint64_t)rhs_value.as_const().as_int());
-                            else
+                            loop_values[loop_var_name] = (int)i;
+                            RTLIL::SigSpec rhs_value =
+                                import_expression(any_cast<const expr*>(mem_assign->Rhs()));
+                            if (rhs_value.is_fully_const()) {
+                                RTLIL::Const c = rhs_value.as_const();
+                                if (c.size() != mem_width)
+                                    c = c.extract(0, mem_width, RTLIL::State::S0);
+                                rom_words.emplace_back(i, c);
+                            } else
                                 all_const = false;
                         }
+                        loop_values = saved_loop_values;
                         if (all_const) {
                             std::string meminit_file;
                             int meminit_line = 0;
@@ -4922,10 +4943,10 @@ void UhdmImporter::import_statement_sync(const any* uhdm_stmt, RTLIL::SyncRule* 
                                 cell->setParam(ID::WORDS, RTLIL::Const(1));
                                 cell->setParam(ID::PRIORITY, RTLIL::Const(12 + (int)i));
                                 cell->setPort(ID::ADDR, RTLIL::Const(i, 32));
-                                cell->setPort(ID::DATA, RTLIL::Const(mem_word, mem_width));
+                                cell->setPort(ID::DATA, mem_word);
                                 cell->setPort(ID::EN, RTLIL::Const(RTLIL::State::S1, mem_width));
-                                log("        Added $meminit for %s[%lld] = 0x%llx\n",
-                                    memory_name.c_str(), (long long)i, (unsigned long long)mem_word);
+                                log("        Added $meminit for %s[%lld] = %s\n",
+                                    memory_name.c_str(), (long long)i, mem_word.as_string().c_str());
                             }
                             log("        Memory initialization (single-stmt) unrolled successfully\n");
                         } else {

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -1806,28 +1806,61 @@ RTLIL::SigSpec UhdmImporter::evaluate_expression_with_vars(const expr* expr,
                 operands.push_back(evaluate_expression_with_vars(any_cast<const UHDM::expr*>(operand), vars, loop_var_name, loop_index));
             }
             
-            // Perform operation if all operands are constant
+            // Perform operation if all operands are constant.  An EMPTY operand
+            // (an unhandled sub-expression that returned no SigSpec) must count
+            // as non-const — otherwise `as_int()` reads it as 0 and silently
+            // corrupts the result (e.g. `PRIME*(i*2+1)` with `i*2+1` unhandled
+            // became `PRIME*0`).
             bool all_const = true;
             for (const auto& operand : operands) {
-                if (!operand.is_fully_const()) {
+                if (operand.empty() || !operand.is_fully_const()) {
                     all_const = false;
                     break;
                 }
             }
-            
+
             if (!all_const) {
                 return RTLIL::SigSpec();
             }
-            
+
+            // For `*`, `+`, `-` the SV self-determined result width is the max
+            // of the operand widths (LRM §11.6.1).  Truncate to that so a value
+            // assigned to a wider word zero-extends — matching how
+            // import_expression computes the same expression elsewhere (e.g. the
+            // `expect_val` wire in arch/*/meminit.v).  Without it the ROM word
+            // (full product) and the comparison value (truncated) disagree.
+            auto arith_width = [&]() -> int {
+                int w = 0;
+                for (const auto& o : operands) w = std::max(w, o.size());
+                return w > 0 ? w : 32;
+            };
+
             // Evaluate constant operations
             switch (op_type) {
                 // TODO: support all op types
                 case vpiMultOp:
                     if (operands.size() == 2) {
-                        uint64_t a = operands[0].as_const().as_int();
-                        uint64_t b = operands[1].as_const().as_int();
-                        return RTLIL::SigSpec(RTLIL::Const(a * b, 64));
+                        uint64_t a = (uint32_t)operands[0].as_const().as_int();
+                        uint64_t b = (uint32_t)operands[1].as_const().as_int();
+                        return RTLIL::SigSpec(RTLIL::Const((a * b) & 0xFFFFFFFFFFFFFFFFull,
+                                                           arith_width()));
                     }
+                    break;
+
+                case vpiAddOp:
+                    if (operands.size() == 2)
+                        return RTLIL::SigSpec(RTLIL::Const(
+                            (uint64_t)(uint32_t)operands[0].as_const().as_int() +
+                            (uint64_t)(uint32_t)operands[1].as_const().as_int(),
+                            arith_width()));
+                    break;
+
+                case vpiSubOp:
+                    if (operands.size() == 2)
+                        return RTLIL::SigSpec(RTLIL::Const(
+                            (uint64_t)(uint32_t)operands[0].as_const().as_int() -
+                            (uint64_t)(uint32_t)operands[1].as_const().as_int(),
+                            arith_width()));
                     break;
                     
                 case vpiBitXorOp: // 30

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -47,7 +47,6 @@ verific/ext_ramnet_err.sv
 # --- memory inference (write-enable / byte-enable / SDP / init / bounds) ---
 arch/fabulous/custom_map.v
 arch/nanoxplore/meminit.v
-arch/quicklogic/qlf_k6n10f/meminit.v
 arch/xilinx/bug3670.v
 memlib/memlib_clock_sdp.v
 memlib/memlib_wide_sdp.v


### PR DESCRIPTION
`initial begin for (i...) mem[i] = <expr-of-i>; end` (arch/*/meminit.v) was not converted to $meminit — the loop body is a single-statement begin block, but the ROM-init matcher only fired for a BARE assignment body, so it fell to the general sync unroll and emitted ~1024 spurious $memrd cells (read of mem[i]) per word.

* Unwrap a single-statement begin block before the meminit / shift-register pattern matchers (the bare form is svtypes/logic_rom; arch/*/meminit.v wraps it).

* evaluate_expression_with_vars: support vpiAddOp / vpiSubOp (an unhandled sub-expression like `i*2+1` returned an empty SigSpec that as_int() read as 0, so `PRIME*(i*2+1)` folded to 0); and treat an empty operand as non-constant.

* Compute each ROM word via import_expression with the loop variable set in loop_values — the SAME path that evaluates a sibling expression such as meminit.v's `expect_val` — and keep the full Const sized to the memory width (as_int() truncated to 32 bits and corrupted wide ROM words).

Fixes arch/quicklogic/qlf_k6n10f/meminit (now passes formal equivalence).  No regression on the rom/memory suite (svtypes/logic_rom, memfile/memory, blockrom, simple_memory, mem2reg_test2, issue326_packed_mem, priority_memory, and the always_ff/for-loop tests).

arch/nanoxplore/meminit still fails: its `PRIME*(i*2+1)` overflows 32 bits, and UHDM evaluates the multiplication in the 36-bit assignment context (keeping the overflow) while the Verilog frontend uses the SV self-determined 32-bit width then zero-extends, so the two $mem init contents differ — a separate self-determined-width issue, left in failing_tests.txt.