### PR TITLE
uhdm: out-of-bounds memory access — drop OOB writes, read OOB as X

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4909,14 +4909,14 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                 RTLIL::SigSpec result;
                 int start;
                 if (oob_possible) {
-                    // An out-of-range index reads 0.  SystemVerilog calls
-                    // this X (don't-care), but emitting a literal X lets
-                    // `opt` fold the fall-through mux back to an arbitrary
-                    // element; a defined 0 both matches simulator behaviour
-                    // (Verilator reads OOB as 0) and stays a valid refinement
-                    // of the Verilog frontend's X, so formal equivalence is
-                    // preserved.
-                    result = RTLIL::SigSpec(RTLIL::State::S0, elem_w);
+                    // An out-of-range index reads X — SystemVerilog leaves it
+                    // unspecified, and that is what the Yosys Verilog frontend
+                    // and Verilator do too.  Emitting a defined 0 here was
+                    // wrong: it is a concrete value that disagrees with the
+                    // other tools' unspecified result (mem2reg_bounds_tern's
+                    // OOB read), whereas X is a don't-care that any value
+                    // refines, so formal equivalence holds against either.
+                    result = RTLIL::SigSpec(RTLIL::State::Sx, elem_w);
                     start = last;  // give EVERY element an explicit idx==i mux
                 } else {
                     std::string last_name = signal_name + "[" + std::to_string(last) + "]";

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -9862,6 +9862,24 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                             // Get address
                             RTLIL::SigSpec addr = import_expression(bit_sel->VpiIndex());
 
+                            // Drop a write whose CONSTANT address is out of
+                            // bounds — SV makes an out-of-range array write a
+                            // no-op.  An unrolled `for (i=0;i<4) mem[i]<=...`
+                            // over a 3-entry `mem[0:2]` emits a write to mem[3]
+                            // that Yosys's Verilog frontend and Verilator both
+                            // drop (mem2reg_bounds_tern).
+                            if (addr.is_fully_const() &&
+                                module->memories.count(info.mem_id)) {
+                                RTLIL::Memory* m = module->memories.at(info.mem_id);
+                                int a = addr.as_const().as_int();
+                                if (a < m->start_offset ||
+                                    a >= m->start_offset + m->size) {
+                                    log("        Dropped out-of-bounds memory write %s[%d] (size=%d)\n",
+                                        mem_name.c_str(), a, m->size);
+                                    return;
+                                }
+                            }
+
                             // Get data; propagate memory width as context
                             // so arithmetic RHS widens to it (LRM context-
                             // determined sizing) — fixes `M[0] <= rA*rB`

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -49,7 +49,6 @@ arch/nanoxplore/meminit.v
 arch/xilinx/bug3670.v
 memlib/memlib_clock_sdp.v
 memlib/memlib_wide_sdp.v
-simple/mem2reg_bounds_tern.v
 verilog/mem_bounds.sv
 # --- techmap rule files (not standalone DUTs, not a UHDM feature gap) ---
 # These define techmap MAPPING RULES, not synthesizable top designs: they use


### PR DESCRIPTION
Fixes yosys/tests/simple/mem2reg_bounds_tern (a deliberate out-of-bounds memory test: `reg [0:7] mem [0:2]`, an unrolled generate `for (i=0;i<4) mem[i]<=...`, and `line = mem[sel]` with sel up to 3).  Two OOB problems, both now matching SV / the Yosys Verilog frontend / Verilator:

* OOB WRITE: the i==3 iteration wrote mem[3].  SV makes an out-of-range write a no-op, but UHDM kept it, so synth materialised a bogus 4th element.  Fix in import_statement_comb (CaseRule memory-write path): when the bit-select write address folds to a constant outside `[start_offset, start_offset+size)`, skip the write.

* OOB READ: the dynamic-index read mux used a defined 0 as its out-of-range fall-through.  That is a concrete value that disagrees with the other tools' UNSPECIFIED result; emit X instead (import_bit_select, oob_possible branch). X is a don't-care that any value refines, so formal equivalence holds against the Verilog frontend regardless of what either picks.

Verified: the `[0:7]` element bit-order is itself correct (a clean in-bounds upto memory proves equivalent under sound SAT-from-reset); only the two OOB behaviours were wrong.  mem2reg_bounds_tern now passes formal equivalence.

No formal regression on the memory / dynamic-index suite (mem2reg_test1/2/4/5/6, simple_memory, macc, subbytes, rotate, aes_kexp128, asym_ram_sdp_read_wider, issue326_packed_mem, priority_memory, dynslice, blocking_temp_select, …).  A few OOB-read tests (mem2reg_test1, simple_memory) now emit a non-fatal Verilator co-sim WARNING instead of a clean pass, because Verilator cannot validate an X don't-care — they still pass on the sound formal gate.