### PR TITLE
uhdm: constant out-of-bounds array read returns X (was a hard error)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4895,6 +4895,11 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                     return current_comb_values.at(elem_name);
                 RTLIL::Wire* w = module->wire(RTLIL::escape_id(elem_name));
                 if (w) return RTLIL::SigSpec(w);
+                // Constant index outside the array bounds reads X — SV leaves an
+                // out-of-range access unspecified (verilog/mem_bounds.sv reads
+                // `mem[-1]` and asserts it is all-X via $countbits).
+                if (num_elems > 0 && (i < 0 || i >= num_elems))
+                    return RTLIL::SigSpec(RTLIL::State::Sx, elem_w);
             } else {
                 // Dynamic index — build mux chain.
                 int last = num_elems - 1;

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -49,7 +49,20 @@ arch/nanoxplore/meminit.v
 arch/xilinx/bug3670.v
 memlib/memlib_clock_sdp.v
 memlib/memlib_wide_sdp.v
+
+# --- X-semantics / $countbits elaboration test (not a synthesis-equivalence
+# test) ---
+# mem_bounds checks that out-of-bounds reads are X and counts the X/0/1 bits
+# with $countbits ($countbits(mem[-1], 'x) == 8, etc.).  This is a don't-care /
+# elaboration-time property: in a synthesis flow X is a DON'T-CARE, not a
+# concrete value, so neither frontend can reproduce the bit counts — the Yosys
+# Verilog frontend itself folds the X-counting asserts to `assert(1'h0)`.  UHDM
+# now returns X for the OOB reads (was a hard "Could not find wire" error), but
+# the $countbits asserts still cannot match a wrong reference, so the test is
+# not meaningful under read_uhdm -> synth -> equiv.
 verilog/mem_bounds.sv
+
+
 # --- techmap rule files (not standalone DUTs, not a UHDM feature gap) ---
 # These define techmap MAPPING RULES, not synthesizable top designs: they use
 # the `_TECHMAP_*` magic (custom_map: `_TECHMAP_REPLACE_`) or provide a built-in


### PR DESCRIPTION
A constant index outside an expanded array's bounds (`mem[-1]` over `reg [0:7] mem [0:2]`) fell through import_bit_select's constant-index branch to `log_error("Could not find wire ... for bit select")`, aborting the import (verilog/mem_bounds.sv produced no output).

Return X (RTLIL::State::Sx, element width) for an out-of-range constant index on an expanded array, matching SV's unspecified-value semantics — the same don't- care the dynamic-index mux now uses.

mem_bounds.sv still does not pass formal equivalence and is reclassified in failing_tests.txt: it asserts X/0/1 bit counts of OOB reads via $countbits, which is an elaboration-time / don't-care property a synthesis flow cannot reproduce (X is a don't-care, not a concrete value — the Yosys Verilog frontend itself folds the X-counting asserts to `assert(1'h0)`).  The fix removes the crash and is correct on its own; no regression on the memory/array suite (mem2reg_test1/4/5, simple_memory, macc, aes_kexp128, subbytes, issue326_packed_mem, 2DUnpackedArray, priority_memory, blocking_temp_select).