### PR TITLE
uhdm: sync write to a dynamic indexed part-select (memlib_wide_sdp)

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -7826,6 +7826,39 @@ void UhdmImporter::import_assignment_sync(const assignment* uhdm_assign, RTLIL::
         }
     }
 
+    // Dynamic indexed part-select LHS in a sync block: `mem[idx +: W] <= data`
+    // with a non-constant `idx` (memlib_wide_sdp's flat `reg [79:0] mem`).
+    // import_expression() of such an LHS returns the READ ($shiftx) value, so the
+    // generic path below would store the write into a throwaway wire and lose
+    // it.  Compute the full-width read-modify-write next value and register the
+    // whole base under this block's condition instead.
+    if (auto lhs_expr = uhdm_assign->Lhs()) {
+        if (lhs_expr->VpiType() == vpiIndexedPartSelect) {
+            auto ips = any_cast<const indexed_part_select*>(lhs_expr);
+            RTLIL::SigSpec new_val;
+            RTLIL::Wire* base_wire = nullptr;
+            if (emit_dynamic_indexed_part_select_write(
+                    ips, uhdm_assign->Rhs(), nullptr, nullptr, &new_val, &base_wire)
+                && base_wire) {
+                RTLIL::SigSpec base_lhs(base_wire);
+                RTLIL::SigSpec next;
+                if (!current_condition.empty()) {
+                    // cond ? new_val : (prior pending value, else the register)
+                    RTLIL::SigSpec else_val =
+                        pending_sync_assignments.count(base_lhs)
+                            ? pending_sync_assignments.at(base_lhs) : base_lhs;
+                    RTLIL::Wire* mux_out = module->addWire(NEW_ID, base_wire->width);
+                    module->addMux(NEW_ID, else_val, new_val, current_condition, mux_out);
+                    next = RTLIL::SigSpec(mux_out);
+                } else {
+                    next = new_val;
+                }
+                pending_sync_assignments[base_lhs] = next;
+                return;
+            }
+        }
+    }
+
     RTLIL::SigSpec lhs;
     RTLIL::SigSpec rhs;
 
@@ -8015,7 +8048,9 @@ bool UhdmImporter::emit_dynamic_indexed_part_select_write(
         const UHDM::indexed_part_select* ips,
         const UHDM::any* rhs_any,
         RTLIL::Process* proc,
-        RTLIL::CaseRule* case_rule) {
+        RTLIL::CaseRule* case_rule,
+        RTLIL::SigSpec* out_new_val,
+        RTLIL::Wire** out_base) {
     if (!ips) return false;
 
     // Base width / wire
@@ -8095,6 +8130,14 @@ bool UhdmImporter::emit_dynamic_indexed_part_select_write(
     RTLIL::Wire* new_val = module->addWire(NEW_ID, base_w);
     module->addOr(NEW_ID, RTLIL::SigSpec(cleared),
                   RTLIL::SigSpec(val_shifted), new_val);
+
+    // Sync caller wants the computed full-width next value back (to register it
+    // under a clock with its own condition) rather than have it driven here.
+    if (out_new_val) {
+        *out_new_val = RTLIL::SigSpec(new_val);
+        if (out_base) *out_base = base_wire;
+        return true;
+    }
 
     // Drive $0\base via the standard temp-wire path, mirroring full-wire writes
     if (proc) {

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -879,7 +879,22 @@ bool UhdmImporter::contains_complex_constructs(const any* stmt) {
     if (stmt_type == vpiFor || stmt_type == vpiForever || stmt_type == vpiWhile) {
         return true;
     }
-     
+
+    // A write to a dynamic indexed part-select (`mem[idx +: W] <= data` with a
+    // non-constant `idx`) needs the read-modify-write handling in
+    // import_statement_sync; the simple-if optimisation imports the LHS as a
+    // read and silently drops the write (memlib_wide_sdp's flat `reg [79:0]`).
+    // Treat it as complex so this block falls through to the general path.
+    if (stmt_type == vpiAssignment || stmt_type == vpiAssignStmt) {
+        const assignment* a = any_cast<const assignment*>(stmt);
+        if (a && a->Lhs() && a->Lhs()->VpiType() == vpiIndexedPartSelect) {
+            auto ips = any_cast<const indexed_part_select*>(a->Lhs());
+            if (ips && ips->Base_expr() &&
+                ips->Base_expr()->VpiType() != vpiConstant)
+                return true;
+        }
+    }
+
     // Note: Memory writes (bit select assignments) are now allowed in simple if patterns
     // They will be handled specially during switch statement generation
     

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -626,7 +626,9 @@ struct UhdmImporter {
         const UHDM::indexed_part_select* ips,
         const UHDM::any* rhs_any,
         RTLIL::Process* proc,
-        RTLIL::CaseRule* case_rule);
+        RTLIL::CaseRule* case_rule,
+        RTLIL::SigSpec* out_new_val = nullptr,
+        RTLIL::Wire** out_base = nullptr);
     bool emit_dynamic_struct_field_bit_write(
         const UHDM::hier_path* hp,
         const UHDM::any* rhs_any,

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -48,7 +48,6 @@ verific/ext_ramnet_err.sv
 arch/nanoxplore/meminit.v
 arch/xilinx/bug3670.v
 memlib/memlib_clock_sdp.v
-memlib/memlib_wide_sdp.v
 
 # --- X-semantics / $countbits elaboration test (not a synthesis-equivalence
 # test) ---


### PR DESCRIPTION
`always @(posedge clk) if (en) mem[idx +: W] <= data;` on a flat `reg [79:0] mem` with a non-constant `idx` was silently dropped: the simple-if pattern and import_statement_sync imported the LHS with import_expression(), which returns the READ ($shiftx) value, so the write was stored into a throwaway wire and mem kept only its initial value (memlib_wide_sdp read back 0 / co-sim mismatch).

* contains_complex_constructs: treat an assignment to a dynamic indexed part-select as complex, so the simple-if optimisation bails to the general sync path.

* import_statement_sync: detect a vpiIndexedPartSelect LHS and build the full-width read-modify-write next value (reusing emit_dynamic_indexed_part_select_write via new out-params instead of having it drive the result), then register the whole base under the block's condition.

memlib_wide_sdp now passes formal equivalence (equiv_induct).  No regression on a 60-test sample plus the memory / part-select suite (simple_memory, macc, subbytes, sign_part_assign, asym_ram_sdp_read_wider, issue326_packed_mem, priority_memory, mem2reg_test2, blocking_temp_select).

memlib_clock_sdp stays failing — separate issue (a `negedge CLK ^ (...)` clock expression the harness can't equivalence-check), not the part-select write.