### PR TITLE
uhdm: reduce a multi-bit clock edge expression to its LSB (memlib_clo…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -724,6 +724,12 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                             log("      Importing clock signal from posedge\n");
                             log_flush();
                             clock_sig = import_expression(any_cast<const expr*>((*op->Operands())[0]));
+                            // An edge expression triggers on its LSB (IEEE 1800);
+                            // a wider result (e.g. `CLK ^ (POL || OPT=="POS")`
+                            // mis-sized to 64 bits via a string compare in
+                            // memlib_clock_sdp) would make an invalid multi-bit
+                            // $dff clock.
+                            if (clock_sig.size() > 1) clock_sig = clock_sig.extract(0, 1);
                             current_ff_clock_sig = clock_sig; // Store for assertions
                             current_ff_edges = {{clock_sig, clock_posedge}};
                             log("      Clock signal imported: %s\n", log_signal(clock_sig));
@@ -735,6 +741,10 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                             log("      Importing clock signal from negedge\n");
                             log_flush();
                             clock_sig = import_expression(any_cast<const expr*>((*op->Operands())[0]));
+                            // Edge triggers on the LSB — reduce a mis-sized
+                            // multi-bit clock expression (memlib_clock_sdp's
+                            // `negedge (CLK ^ (POL || OPT=="POS"))`).
+                            if (clock_sig.size() > 1) clock_sig = clock_sig.extract(0, 1);
                             current_ff_clock_sig = clock_sig; // Store for assertions
                             current_ff_edges = {{clock_sig, clock_posedge}};
                             log("      Clock signal imported: %s\n", log_signal(clock_sig));

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -47,7 +47,6 @@ verific/ext_ramnet_err.sv
 # --- memory inference (write-enable / byte-enable / SDP / init / bounds) ---
 arch/nanoxplore/meminit.v
 arch/xilinx/bug3670.v
-memlib/memlib_clock_sdp.v
 
 # --- X-semantics / $countbits elaboration test (not a synthesis-equivalence
 # test) ---


### PR DESCRIPTION
…ck_sdp)

`always @(negedge PORT_W_CLK ^ (PORT_W_CLK_POL || OPTION_WCLK == "POS"))` imported the edge expression at its full width: the string compare `OPTION_WCLK == "POS"` widened the `^` result to 64 bits, so the clock signal fed to the FF was 64-bit. synth then aborted with "Found error in internal cell $procdff$23 ($dff)" because a $dff CLK must be 1-bit — the whole test produced no netlist (harness reported "FUNCTIONAL - no equivalence check performed").

Per IEEE 1800 an edge-sensitive event triggers on the LSB of its expression, so reduce clock_sig to bit 0 when import_expression returns a wider result (both the posedge and negedge import sites).

memlib_clock_sdp now passes formal equivalence (equiv_induct) AND Verilator co-sim.  No regression on a 70-test sample plus the clocked suite (simple_counter, mem2reg_test2, fsm, and the always_ff backlog).