### PR TITLE
uhdm: positional connection to an undefined module binds by index (fi…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -999,16 +999,27 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                 // Import port connections
                 if (uhdm_module->Ports()) {
                     int positional_port_idx = 0;
+                    // An UNDEFINED module (blackbox; Surelog scopes its type as
+                    // "parent::name") has no port list, so a POSITIONAL
+                    // connection must bind by index.  Surelog leaves VpiName
+                    // empty for an expression arg (`~i`) but mis-populates it
+                    // with the connected SIGNAL name for a simple-ref arg
+                    // (`unknown u(~i, w)` -> port VpiName "w"), which would emit
+                    // `.w(w)` where the Verilog frontend emits the positional
+                    // `$2` (various/abc9 abc9_test028).  Detect that (VpiName ==
+                    // the connected signal's name) and bind by index — but keep
+                    // a genuine NAMED connection like bug3670's `.DOADO(o1)`
+                    // (VpiName "DOADO" != signal "o1").
+                    bool undefined_cell = cell_type.find("::") != std::string::npos;
                     for (auto port : *uhdm_module->Ports()) {
                         std::string port_name = std::string(port->VpiName());
-                        // Blackbox cells with positional args (e.g.
-                        // `unknown u(~i, w);` in
-                        // yosys/tests/various/abc9.v abc9_test028) get
-                        // ports with empty VpiName.  Yosys's IdString
-                        // asserts on empty names — fall back to
-                        // `$<index>` like the Verilog frontend.
                         positional_port_idx++;
-                        if (port_name.empty()) {
+                        bool positional = port_name.empty();
+                        if (!positional && undefined_cell && port->High_conn() &&
+                            port->High_conn()->UhdmType() == uhdmref_obj &&
+                            std::string(port->High_conn()->VpiName()) == port_name)
+                            positional = true;
+                        if (positional) {
                             port_name = "$" + std::to_string(positional_port_idx);
                         }
                         if (port->High_conn()) {

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -79,8 +79,6 @@ verilog/mem_bounds.sv
 arch/fabulous/custom_map.v
 techmap/mem_simple_4x1_map.v
 techmap/recursive_map.v
-# --- other pre-existing gaps (abc9 mapping) ---
-various/abc9.v
 
 # --- confirmed UHDM-frontend co-sim bugs (see cosim_uhdm_bugs.txt) ---
 # Expected Miter-Formal failures: UHDM-synth != Verilog-synth, falsely pass


### PR DESCRIPTION
…xes abc9)

`unknown u(~i, w);` (various/abc9 abc9_test028) connects positionally to an undefined module.  Surelog leaves the port VpiName empty for an expression arg (`~i`) but mis-populates it with the connected SIGNAL name for a simple-ref arg (`w` -> port VpiName "w"), so UHDM emitted `.w(w)` where the Yosys Verilog frontend emits the positional `$2`, and the two blackbox netlists mismatched.

For an undefined-module (blackbox) cell, treat a connection whose port VpiName equals the connected ref_obj's own name as positional and bind by `$<index>`. A genuine NAMED connection like bug3670's `.DOADO(o1)` (VpiName "DOADO" != signal "o1") is left untouched.

abc9_test028 now produces byte-identical netlists to the Verilog frontend; various/abc9 passes formal equivalence + co-sim (the harness auto-tops to abc9_test032, also proven; abc9_test027's `o<=~o` comb loop is proven too). Removed from failing_tests.  bug3670 still passes (named ports preserved); no regression on a 60-test sample.