### PR TITLE
uhdm: async-reset FF for each element of a dynamically-written mem2re…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -955,6 +955,39 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                         std::remove_if(assigned_signals.begin(), assigned_signals.end(),
                             [&](const AssignedSignal& s){ return loop_vars.count(s.name) > 0; }),
                         assigned_signals.end());
+
+                // A `(* mem2reg *)` memory written with a DYNAMIC index inside an
+                // async-reset always_ff (mem_arst's `Mem[Addr]<=Data` plus the
+                // reset clear `for(i) Mem[i]<=0`) is expanded to per-element
+                // wires \Mem[0..N-1], and extract_assigned_signals SKIPS the
+                // dynamic write (the comb mux path handles it).  But in the
+                // async-reset path each element needs its own async-reset FF, or
+                // the writes stay combinational and MEMORY_COLLECT re-gathers
+                // them into a $mem with NO reset (the clear is lost).  Register
+                // every element wire so the temp-wire + sync-rule machinery below
+                // gives each \Mem[k] a $0\Mem[k] temp; the reset for-loop fills
+                // case_true and emit_dynamic_unpacked_array_write fills case_false
+                // (it already targets the $0\ temps).  Mirrors how the Verilog
+                // frontend mem2regs such a memory into per-element FFs.
+                std::set<std::string> expanded_arrays;
+                collect_dynamic_expanded_array_writes(stmt, expanded_arrays, module);
+                for (const auto& base : expanded_arrays) {
+                    int n = 0;
+                    while (module->wire(RTLIL::escape_id(
+                               base + "[" + std::to_string(n) + "]"))) n++;
+                    for (int k = 0; k < n; k++) {
+                        AssignedSignal es;
+                        es.name = base + "[" + std::to_string(k) + "]";
+                        es.is_part_select = false;
+                        es.lhs_expr = nullptr;
+                        // Avoid duplicates (a constant-index write may already
+                        // have recorded the same element).
+                        bool dup = false;
+                        for (const auto& a : assigned_signals)
+                            if (a.name == es.name) { dup = true; break; }
+                        if (!dup) assigned_signals.push_back(es);
+                    }
+                }
             }
 
             // Async-reset always_ff that ALSO writes a memory (issue #326):

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -1212,6 +1212,72 @@ void UhdmImporter::scan_for_memory_writes(const any* stmt, std::set<std::string>
     }
 }
 
+// Collect the base names of `(* mem2reg *)`-expanded arrays written with a
+// DYNAMIC (non-constant) index anywhere in the statement tree.  Such an array
+// is flattened to per-element wires \base[0..N-1] (no $memory object), so a
+// write `base[idx] <= ...` with a variable idx is the marker.  Used by the
+// async-reset always_ff path to register every element as its own FF.
+void UhdmImporter::collect_dynamic_expanded_array_writes(
+        const any* stmt, std::set<std::string>& names, RTLIL::Module* module) {
+    if (!stmt || !module) return;
+    auto record = [&](const std::string& base, const any* idx) {
+        if (base.empty()) return;
+        bool const_idx = idx && idx->VpiType() == vpiConstant;
+        if (const_idx) return;
+        // Expanded array, not a real $memory: element wire \base[0] exists.
+        if (!module->memories.count(RTLIL::escape_id(base)) &&
+            module->wire(RTLIL::escape_id(base + "[0]")))
+            names.insert(base);
+    };
+    switch (stmt->VpiType()) {
+        case vpiAssignment:
+        case vpiAssignStmt: {
+            const assignment* assign = any_cast<const assignment*>(stmt);
+            if (auto lhs = assign->Lhs()) {
+                if (lhs->VpiType() == vpiBitSelect) {
+                    const bit_select* bs = any_cast<const bit_select*>(lhs);
+                    record(std::string(bs->VpiName()), bs->VpiIndex());
+                }
+            }
+            break;
+        }
+        case vpiBegin:
+        case vpiNamedBegin: {
+            if (VectorOfany* stmts = begin_block_stmts(stmt))
+                for (auto s : *stmts) collect_dynamic_expanded_array_writes(s, names, module);
+            break;
+        }
+        case vpiIf: {
+            const UHDM::if_stmt* s = any_cast<const UHDM::if_stmt*>(stmt);
+            if (s->VpiStmt()) collect_dynamic_expanded_array_writes(s->VpiStmt(), names, module);
+            break;
+        }
+        case vpiIfElse: {
+            const if_else* s = any_cast<const if_else*>(stmt);
+            if (s->VpiStmt()) collect_dynamic_expanded_array_writes(s->VpiStmt(), names, module);
+            if (s->VpiElseStmt()) collect_dynamic_expanded_array_writes(s->VpiElseStmt(), names, module);
+            break;
+        }
+        case vpiCase: {
+            const case_stmt* cs = any_cast<const case_stmt*>(stmt);
+            if (cs->Case_items())
+                for (auto ci : *cs->Case_items())
+                    if (ci->Stmt()) collect_dynamic_expanded_array_writes(ci->Stmt(), names, module);
+            break;
+        }
+        case vpiFor: {
+            const for_stmt* f = any_cast<const for_stmt*>(stmt);
+            if (f->VpiStmt()) collect_dynamic_expanded_array_writes(f->VpiStmt(), names, module);
+            break;
+        }
+        case vpiRepeat: {
+            const UHDM::repeat* r = any_cast<const UHDM::repeat*>(stmt);
+            if (r->VpiStmt()) collect_dynamic_expanded_array_writes(r->VpiStmt(), names, module);
+            break;
+        }
+    }
+}
+
 // Helper: return true if the statement tree contains a for loop (at any depth).
 bool UhdmImporter::has_for_loop(const any* stmt) {
     if (!stmt) return false;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -724,6 +724,7 @@ struct UhdmImporter {
     // (e.g. `for (i=...)`) so they can be excluded from a register/reset set —
     // a loop counter is not a flip-flop and has no constant async-reset value.
     void collect_for_loop_var_names(const any* stmt, std::set<std::string>& names);
+    void collect_dynamic_expanded_array_writes(const any* stmt, std::set<std::string>& names, RTLIL::Module* module);
     void extract_lhs_signals(const UHDM::expr* lhs_expr, std::vector<AssignedSignal>& signals);
     void extract_assigned_signal_names(const any* stmt, std::set<std::string>& signal_names);
     // Collect base names of signals written via BLOCKING (`=`) assignments

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -18,7 +18,36 @@
 #   - listed expected-fail in failing_tests.txt (internal name + yosys paths)
 # Fix one isolated change at a time, then remove from all of the above.
 #
-# FIXED so far: blocking_temp_select, macc, subbytes, simple_memory, asym_ram_sdp_read_wider (ALL).
+# FIXED so far: blocking_temp_select, macc, subbytes, simple_memory,
+#   asym_ram_sdp_read_wider, simple/mem_arst.
+#
+# ---------------------------------------------------------------------------
+# 2026-06 yosys --yosys sweep: triaged every cosim FAIL with triage_cosim.py
+# (sound SAT-from-reset miter + both-frontends co-sim).  ~25 were ARTEFACTS
+# (miter proves UHDM == Verilog; the diff is Verilator-vs-synth).  Real
+# divergences that FALSELY pass equiv_induct, still OPEN:
+#
+# test                              symptom
+# --------------------------------  -------------------------------------------
+# memories/wide_all                 miter NON-EQ.  wide memory read/write ports.
+# memories/firrtl_938               miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
+# asicworld/code_hdl_models_cam     miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
+# simple/undef_eqx_nex              ===/!== (case-equality) with x/z.
+# simple/i2c_master_tests           miter NON-EQ.
+# memlib/memlib_wren                Induct-Formal FAIL (byte/word write-enable).
+#   (Inconclusive — Verilog cosim build-fails: verific/range_case,
+#    memlib/memlib_block_sp, memlib/memlib_block_sp_full.)
+#
+# NOT bugs (don't re-triage): simple/mem2reg_bounds_tern (OOB read -> X
+# don't-care), asicworld/..._d_latch_gates (latch; both cosims fail).
+#
+# FIXED simple/mem_arst (this entry): a `(* mem2reg *)` memory written with a
+# dynamic index inside an async-reset always_ff was expanded to per-element
+# wires but those elements got no async-reset FF (the reset clear `for(i)
+# mem[i]<=0` was lost; MEMORY_COLLECT re-gathered a reset-less $mem).  Fix:
+# the async-reset path now registers every \mem[k] element so each gets a
+# $0\mem[k] temp + async-reset FF (matches the Verilog frontend's per-element
+# mem2reg).  miter EQUIVALENT; directed read-back confirms.
 #
 # test                      symptom
 # ------------------------  -----------------------------------------------


### PR DESCRIPTION
…g memory

simple/mem_arst (a real cosim divergence that falsely passed equiv_induct): a `(* mem2reg *) reg Mem[...]` cleared on async reset (`for(i) Mem[i]<=0`) and written with a dynamic index (`Mem[Addr]<=Data`) read back stale data.

UHDM honours mem2reg and flattens Mem to per-element wires \Mem[k], but in the async-reset always_ff path extract_assigned_signals SKIPS the dynamic-index write (the comb mux path normally handles it), so no element got an FF: the body wrote \Mem[k] combinationally, MEMORY_COLLECT re-gathered them into a $mem with NO async reset, and the reset clear was lost.  A $mem write port has CLK+EN only — it cannot express "clear all contents on async reset" — which is exactly why the Verilog frontend mem2regs such a memory into per-element FFs.

Fix: after extract_assigned_signals, the async-reset path detects a dynamically-written expanded array (new collect_dynamic_expanded_array_writes) and registers every element wire \Mem[0..N-1].  Each then gets a $0\Mem[k] temp via the existing temp-wire machinery; the reset for-loop fills case_true (reset value 0) and emit_dynamic_unpacked_array_write fills case_false (it already targets the $0\ temps), so each element becomes a proper async-reset $adff — matching the Verilog frontend.

mem_arst now passes formal equivalence (equiv_induct + sound SAT miter EQUIVALENT); a directed netlist read-back confirms write + reset-clear work. No regression on an 80-test sample plus the yosys memory suite (read_arst, implicit_en/no_implicit_en, shared_ports, wide_write, trans_sp, issue00710, and the local async/mem cluster).

(The sweep's other real divergences — wide_all, firrtl_938, cam, undef_eqx_nex, i2c, memlib_wren — are separate bugs, untouched by this fix; tracked in cosim_uhdm_bugs.txt.)