### PR TITLE
uhdm: correct === / !== and x/z sized literals (undef_eqx_nex)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -2472,7 +2472,18 @@ RTLIL::SigSpec UhdmImporter::import_constant(const constant* uhdm_const) {
                         }
                     }
                     RTLIL::SigSpec sig(const_val);
-                    sig.extend_u0(size, is_signed);
+                    // IEEE 1800 §5.7.1 value extension: a sized literal whose
+                    // most-significant specified digit is x or z is x/z-EXTENDED,
+                    // not zero-extended.  Surelog gives `32'bx` as BIN:x with
+                    // vpiSize 32 (a single `x` digit), which must become 32 bits
+                    // of x — not `0…0x` (undef_eqx_nex's `=== 32'bx`).
+                    RTLIL::State msb = sig.size() > 0
+                        ? sig[sig.size() - 1].data : RTLIL::State::S0;
+                    if (!is_signed && (msb == RTLIL::State::Sx || msb == RTLIL::State::Sz)) {
+                        while (sig.size() < size) sig.append(RTLIL::SigBit(msb));
+                    } else {
+                        sig.extend_u0(size, is_signed);
+                    }
                     return sig;
                 } else {
                     const_val.resize(size, RTLIL::State::S0);
@@ -2773,6 +2784,27 @@ int UhdmImporter::self_determined_width(const UHDM::any* node) {
     if (auto e = dynamic_cast<const UHDM::expr*>(node))
         return import_expression(e).size();
     return 0;
+}
+
+// Width-equalise the two operands of a case-equality (=== / !==) to their max
+// width using IEEE 1800 §5.7.1 value extension: a constant whose MSB is x or z
+// is x/z-EXTENDED into the wider comparison context, not zero-extended.  Needed
+// because $eqx/$nex zero-extend the narrower operand, which would make
+// `0/0 === 32'bx` compare a 64-bit all-x (Surelog sizes the unsized `0` at 64
+// bits) against `{32'b0, 32'bx}` and wrongly return 0 (undef_eqx_nex).
+static void xz_value_extend_pair(RTLIL::SigSpec &a, RTLIL::SigSpec &b) {
+    int w = std::max(a.size(), b.size());
+    auto ext = [&](RTLIL::SigSpec &s) {
+        if (s.size() >= w) return;
+        RTLIL::State fill = RTLIL::State::S0;
+        if (s.is_fully_const() && s.size() > 0) {
+            RTLIL::State msb = s[s.size() - 1].data;
+            if (msb == RTLIL::State::Sx || msb == RTLIL::State::Sz) fill = msb;
+        }
+        while (s.size() < w) s.append(RTLIL::SigBit(fill));
+    };
+    ext(a);
+    ext(b);
 }
 
 // Import operation
@@ -3768,8 +3800,22 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
             // Case equality (===) - use $eqx which properly handles X and Z values
             if (operands.size() == 2)
                 {
+                    RTLIL::SigSpec a = operands[0], b = operands[1];
+                    xz_value_extend_pair(a, b);
                     std::string cell_name = generate_cell_name(uhdm_op, "eqx");
-                    return module->Eqx(RTLIL::escape_id(cell_name), operands[0], operands[1]);
+                    return module->Eqx(RTLIL::escape_id(cell_name), a, b);
+                }
+            break;
+        case vpiCaseNeqOp:
+            // Case inequality (!==) - use $nex, the X/Z-aware counterpart of $eqx
+            // (undef_eqx_nex's `0/1 !== 32'bx`).  Without this the op was
+            // unhandled → empty RHS → the assigned bit defaulted to 0.
+            if (operands.size() == 2)
+                {
+                    RTLIL::SigSpec a = operands[0], b = operands[1];
+                    xz_value_extend_pair(a, b);
+                    std::string cell_name = generate_cell_name(uhdm_op, "nex");
+                    return module->Nex(RTLIL::escape_id(cell_name), a, b);
                 }
             break;
         case vpiNeqOp:

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -19,7 +19,7 @@
 # Fix one isolated change at a time, then remove from all of the above.
 #
 # FIXED so far: blocking_temp_select, macc, subbytes, simple_memory,
-#   asym_ram_sdp_read_wider, simple/mem_arst.
+#   asym_ram_sdp_read_wider, simple/mem_arst, simple/undef_eqx_nex.
 #
 # ---------------------------------------------------------------------------
 # 2026-06 yosys --yosys sweep: triaged every cosim FAIL with triage_cosim.py
@@ -32,7 +32,6 @@
 # memories/wide_all                 miter NON-EQ.  wide memory read/write ports.
 # memories/firrtl_938               miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
 # asicworld/code_hdl_models_cam     miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
-# simple/undef_eqx_nex              ===/!== (case-equality) with x/z.
 # simple/i2c_master_tests           miter NON-EQ.
 # memlib/memlib_wren                Induct-Formal FAIL (byte/word write-enable).
 #   (Inconclusive — Verilog cosim build-fails: verific/range_case,


### PR DESCRIPTION
simple/undef_eqx_nex (a real cosim divergence that falsely passed equiv_induct): UHDM produced 8'b0000xx0x where the Verilog frontend and the LRM give 8'b1001xx0x.  Three independent bugs in case-equality / x-literal handling:

1. `vpiCaseNeqOp` (!==, op type 17) had NO handler — it fell through as "Unsupported operation type: 17", leaving an empty RHS so the bit defaulted to 0.  Add a handler emitting $nex (the X/Z-aware counterpart of $eqx).

2. A sized x/z literal was zero-extended: `32'bx` is BIN:x with vpiSize 32 (a single `x` digit), which import_constant grew to `32'b0…0x` via extend_u0. Per IEEE 1800 §5.7.1 a literal whose most-significant specified digit is x/z is x/z-EXTENDED — so `32'bx` is 32 bits of x.  Extend with the MSB state when it is Sx/Sz (and the value is unsigned).

3. `0/0 === 32'bx` mismatched operand widths: Surelog sizes the unsized `0` at 64 bits, so `0/0` folds to 64'bx while `32'bx` is 32-bit.  $eqx zero-extends the narrower operand, comparing 64'bx against {32'b0,32'bx} -> 0.  Add xz_value_extend_pair: width-equalise the === / !== operands using §5.7.1 value extension (x/z-extend a constant whose MSB is x/z), so the 32'bx extends to 64'bx and the comparison is correct.

UHDM now emits 8'b1001xx0x — byte-identical RTLIL to the Verilog frontend; undef_eqx_nex passes (equiv_induct + identical-output).  No regression on a 90-test sample plus x/z-heavy tests (setundef, tri_buf, values).