### PR TITLE
uhdm: unconditional assignment supersedes earlier conditional one (la…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -9045,6 +9045,26 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
     proc->root_case.actions.push_back(RTLIL::SigSig(lhs, rhs));
 }
 
+// Remove any action that assigns exactly `target` from every switch case
+// (recursively) of `cr`.  Used when an UNCONDITIONAL assignment to `target` is
+// emitted: an earlier conditional assignment to the same signal in this case
+// scope is now dead (later-wins), and because RTLIL applies a case's actions
+// BEFORE its switches, the stale switch action would otherwise override the
+// correct unconditional one (firrtl_938: `if(we) q<=data; q<=ram[a];` — the
+// unconditional `q<=ram[a]` is the real driver, not `we ? data : ram[a]`).
+static void remove_target_from_switches(RTLIL::CaseRule* cr,
+                                        const RTLIL::SigSpec& target) {
+    for (auto sw : cr->switches) {
+        for (auto cs : sw->cases) {
+            cs->actions.erase(
+                std::remove_if(cs->actions.begin(), cs->actions.end(),
+                    [&](const RTLIL::SigSig& a){ return a.first == target; }),
+                cs->actions.end());
+            remove_target_from_switches(cs, target);
+        }
+    }
+}
+
 // Import assignment for comb context (CaseRule variant)
 void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::CaseRule* case_rule) {
     // Dynamic indexed_part_select LHS — synthesise mask/shift/or write
@@ -9264,16 +9284,22 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
                 log("      Assigned to temp wire %s[%d:%d] <= [value]\n", 
                     signal_name.c_str(), offset + width - 1, offset);
             } else {
-                // Full signal assignment
+                // Full signal assignment.  An unconditional write to the whole
+                // signal makes any earlier conditional write to it (in a switch
+                // of this case) dead — drop those so the switch can't override
+                // this later-wins value (firrtl_938).
+                remove_target_from_switches(case_rule, temp_spec);
                 case_rule->actions.push_back(RTLIL::SigSig(temp_spec, rhs));
-                log("      Assigned to temp wire %s <= [value] (temp_wire=%s)\n", 
+                log("      Assigned to temp wire %s <= [value] (temp_wire=%s)\n",
                     signal_name.c_str(), temp_wire->name.c_str());
             }
             return;
         }
     }
-    
-    // Normal assignment
+
+    // Normal assignment — unconditional full-wire write supersedes any earlier
+    // conditional write to the same signal in this case scope (later-wins).
+    remove_target_from_switches(case_rule, lhs);
     case_rule->actions.push_back(RTLIL::SigSig(lhs, rhs));
 }
 

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -30,7 +30,22 @@
 # test                              symptom
 # --------------------------------  -------------------------------------------
 # memories/wide_all                 miter NON-EQ.  wide memory read/write ports.
-# memories/firrtl_938               miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
+# memories/firrtl_938               TWO bugs.  (1) FIXED: `if(we) ram[a]<=d;
+#                                   q<=d; ... q<=ram[a];` — the unconditional
+#                                   last `q<=ram[a]` is the real driver, but
+#                                   UHDM emitted `we?d:ram[a]` (an action can't
+#                                   override a later switch in RTLIL); fixed by
+#                                   dropping a signal's dead earlier conditional
+#                                   writes when an unconditional one follows.
+#                                   (2) OPEN: memory_dff infers the registered
+#                                   read as TRANSPARENT for UHDM (RD_TRANSP=1)
+#                                   but non-transparent for Verilog, so q_a reads
+#                                   the just-written value (write-first) where
+#                                   the LRM/Verilator give read-first — confirmed
+#                                   by behavioral sim (UHDM 0x40 vs 0x11).  The
+#                                   $mem params are identical pre-memory_dff;
+#                                   the UHDM read structure makes Yosys infer a
+#                                   transparency bypass.  Still NON-EQ.
 # asicworld/code_hdl_models_cam     miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
 # simple/i2c_master_tests           miter NON-EQ.
 # memlib/memlib_wren                Induct-Formal FAIL (byte/word write-enable).


### PR DESCRIPTION
…st-wins)

In a memory-write always_ff the body is imported into the process root_case via import_statement_comb, which turns `if (c) q<=a;` into a switch and the later unconditional `q<=b;` into a root-case action.  RTLIL applies a case's actions BEFORE its switches, so the stale switch wrongly overrode the unconditional later-wins value: firrtl_938's `if(we_a) q_a<=data_a; q_a<=ram[addr_a];` became `we_a ? data_a : ram[addr_a]` instead of just `ram[addr_a]`.  (The non-memory always_ff path already folds this correctly via value tracking; only the memory-write path used structural switches.)

Fix: when an UNCONDITIONAL full-wire assignment to a signal is emitted into a case, remove that signal's now-dead assignments from the case's earlier switches (remove_target_from_switches).  Handles both orders: an unconditional write followed by a conditional one still lets the conditional override (no prior switch to clean), and a conditional followed by an unconditional drops the dead conditional.

No regression on a 90-test sample plus the memory suite (simple_memory, macc, issue326_packed_mem, mem2reg_test2, priority_memory, subbytes, …).

This is a correct, general fix but does NOT fully close firrtl_938: that test has a SECOND, independent bug — memory_dff infers the registered read as transparent for UHDM (write-first) where Verilog/the LRM give read-first (confirmed by behavioral sim).  Tracked in cosim_uhdm_bugs.txt.