### PR TITLE
uhdm: apply last-wins switch-cleanup at the real CaseRule push site (…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10309,7 +10309,17 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                             
                             if (mode_debug)
                                 log("        Case assignment: %s = %s\n", log_signal(target_sig), log_signal(rhs_sig));
-                            
+
+                            // An unconditional full-wire write supersedes any
+                            // earlier conditional write to the same signal in
+                            // this case scope (later-wins).  RTLIL applies a
+                            // case's actions before its switches, so a stale
+                            // switch action would otherwise override this — drop
+                            // it (firrtl_938: `if(we_a) q_a<=data_a;
+                            // q_a<=ram[addr_a];` → q_a is ram[addr_a], not
+                            // we_a?data_a:ram[addr_a]).
+                            if (target_sig.is_wire())
+                                remove_target_from_switches(case_rule, target_sig);
                             case_rule->actions.push_back(RTLIL::SigSig(target_sig, rhs_sig));
                             if (mode_debug)
                                 log("        Assignment added to case_rule, now has %d actions\n", (int)case_rule->actions.size());

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -19,7 +19,8 @@
 # Fix one isolated change at a time, then remove from all of the above.
 #
 # FIXED so far: blocking_temp_select, macc, subbytes, simple_memory,
-#   asym_ram_sdp_read_wider, simple/mem_arst, simple/undef_eqx_nex.
+#   asym_ram_sdp_read_wider, simple/mem_arst, simple/undef_eqx_nex,
+#   memories/firrtl_938.
 #
 # ---------------------------------------------------------------------------
 # 2026-06 yosys --yosys sweep: triaged every cosim FAIL with triage_cosim.py
@@ -30,22 +31,6 @@
 # test                              symptom
 # --------------------------------  -------------------------------------------
 # memories/wide_all                 miter NON-EQ.  wide memory read/write ports.
-# memories/firrtl_938               TWO bugs.  (1) FIXED: `if(we) ram[a]<=d;
-#                                   q<=d; ... q<=ram[a];` — the unconditional
-#                                   last `q<=ram[a]` is the real driver, but
-#                                   UHDM emitted `we?d:ram[a]` (an action can't
-#                                   override a later switch in RTLIL); fixed by
-#                                   dropping a signal's dead earlier conditional
-#                                   writes when an unconditional one follows.
-#                                   (2) OPEN: memory_dff infers the registered
-#                                   read as TRANSPARENT for UHDM (RD_TRANSP=1)
-#                                   but non-transparent for Verilog, so q_a reads
-#                                   the just-written value (write-first) where
-#                                   the LRM/Verilator give read-first — confirmed
-#                                   by behavioral sim (UHDM 0x40 vs 0x11).  The
-#                                   $mem params are identical pre-memory_dff;
-#                                   the UHDM read structure makes Yosys infer a
-#                                   transparency bypass.  Still NON-EQ.
 # asicworld/code_hdl_models_cam     miter NON-EQ; UHDM cosim FAIL, Verilog PASS.
 # simple/i2c_master_tests           miter NON-EQ.
 # memlib/memlib_wren                Induct-Formal FAIL (byte/word write-enable).


### PR DESCRIPTION
…firrtl_938)

The previous last-wins fix added remove_target_from_switches in import_assignment_comb, but the memory-write always_ff path imports its body through import_statement_comb's own vpiAssignment handler, so the cleanup never fired for firrtl_938: `if(we_a) q_a<=data_a; q_a<=ram[addr_a];` still emitted `$0\q_a = we_a ? data_a : ram[addr_a]` (the unconditional last write is the real driver, just ram[addr_a]).

That leftover `we_a ? data_a : ram` mux was ALSO the "second bug": memory_dff recognised it as a transparency-bypass mux and marked the registered read TRANSPARENT (read-first became write-first — q_a returned the just-written value).  So there was only one bug.

Fix: call remove_target_from_switches before the action push in import_statement_comb (CaseRule vpiAssignment), gated on a full-wire target — an unconditional whole-signal write drops that signal's now-dead earlier conditional writes from this case's switches.

Result: memory_dff now infers the read NON-transparent (matching Verilog), firrtl_938 passes equiv_induct + Verilator co-sim + sound SAT miter (EQUIVALENT). Full local suite: 649 tests, 1 failure (CastStructArray, a pre-existing Yosys-Verilog-frontend bug) — no regression; yosys memory suite all pass.

(memories/wide_all still false-passes equiv_induct with miter NON-EQ — a separate, untouched bug; not claimed here.)