### PR TITLE
uhdm: handle `case (x) inside` range/set items in the comb case handler

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10008,6 +10008,45 @@ void UhdmImporter::import_case_stmt_comb(const case_stmt* uhdm_case, RTLIL::Proc
             d.stmt = case_item->Stmt();
             if (auto exprs = case_item->VpiExprs()) {
                 for (auto expr : *exprs) {
+                    // `case (x) inside`: Surelog wraps each item's match-set in a
+                    // vpiInsideOp whose operands are vpiListOp members — one with
+                    // a single value `V`, or two with a `[lo:hi]` range.  The
+                    // RTLIL switch only matches by equality, so expand the set
+                    // into individual equality compare values (CaseInside).
+                    if (expr->VpiType() == vpiOperation) {
+                        auto iop = any_cast<const UHDM::operation*>(expr);
+                        if (iop && iop->VpiOpType() == vpiInsideOp && iop->Operands()) {
+                            for (auto mem : *iop->Operands()) {
+                                auto lop = dynamic_cast<const UHDM::operation*>(mem);
+                                if (lop && lop->VpiOpType() == vpiListOp && lop->Operands()) {
+                                    auto& mo = *lop->Operands();
+                                    if (mo.size() == 1) {
+                                        RTLIL::SigSpec s = import_expression(any_cast<const UHDM::expr*>(mo[0]));
+                                        ctx_width = std::max(ctx_width, s.size());
+                                        all_signed = false;
+                                        d.exprs.push_back({s, false});
+                                    } else if (mo.size() == 2) {
+                                        RTLIL::SigSpec ls = import_expression(any_cast<const UHDM::expr*>(mo[0]));
+                                        RTLIL::SigSpec hs = import_expression(any_cast<const UHDM::expr*>(mo[1]));
+                                        if (ls.is_fully_const() && hs.is_fully_const()) {
+                                            int lo = ls.as_const().as_int();
+                                            int hi = hs.as_const().as_int();
+                                            if (lo > hi) std::swap(lo, hi);
+                                            int w = std::max(ls.size(), hs.size());
+                                            // Cap to avoid pathological expansion.
+                                            for (int v = lo; v <= hi && (v - lo) < 4096; v++) {
+                                                RTLIL::SigSpec s(RTLIL::Const(v, w));
+                                                ctx_width = std::max(ctx_width, s.size());
+                                                all_signed = false;
+                                                d.exprs.push_back({s, false});
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+                    }
                     if (auto ce = any_cast<const UHDM::expr*>(expr)) {
                         RTLIL::SigSpec sig = import_expression(ce);
                         bool sgn = is_expr_signed(ce);

--- a/test/cosim_warnings_plan.md
+++ b/test/cosim_warnings_plan.md
@@ -17,7 +17,7 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 
 - [x] 2DFunctionArg — FIXED: `inline_func_body_comb` had NO `vpiReturn` case (return value dropped → X); also `var_select` ignored `input_mapping` for function params, and `elem_w` wasn't read from an `io_decl` typespec. Added all three. a=1, co-sim PASS.
 - [x] TypedefedFunctionArgument — FIXED by the same vpiReturn/var_select fix.
-- [?] CaseInside — combinational `case() inside`; co-sim `y: rtl=2 nl=1`. likely BUG.
+- [x] CaseInside — FIXED: `case(x) inside` with a `[lo:hi]` range item — Surelog wraps the match-set in vpiInsideOp/vpiListOp, which import_case_stmt_comb returned empty for (first item became default -> y=01 always). Now expand inside-set members into equality compares; ranges expand to individual values.
 - [?] 1DUnpackedArray
 - [?] 2DParameterOfInstance
 - [?] 2DUnpackedFunctionArgument — BUG (deeper): unpacked array passed to function; element-order vs read-offset inconsistency (a=0, want 1). iverilog REJECTS this construct; only Verilator accepts. Niche — deprioritised.


### PR DESCRIPTION
Fixes CaseInside.  `case (sel) inside` with a `[lo:hi]` range item produced y=01 for ALL sel (the [4:7] branch never matched): Surelog wraps each item's match-set in a vpiInsideOp whose operands are vpiListOp members (one operand = single value, two = a `[lo:hi]` range), and import_case_stmt_comb fed that whole operation to import_expression, which returned an empty SigSpec — so the first item's compare list was empty and it silently became the switch default.

The RTLIL switch matches only by equality, so expand each inside-set member into individual equality compares: a single-value vpiListOp contributes its value; a two-value `[lo:hi]` vpiListOp expands to {lo..hi} (capped).  Now sel 0..3 -> 01 and sel 4..7 -> 10; co-sim PASS (200 cycles).

Adjudicated UHDM-correct (iverilog/Yosys-Verilog frontends can't even build `case inside`; UHDM is the only one handling it).  Full local suite: 652/653 (only CastStructArray, a pre-existing Verilog-frontend bug) — no regression.