### PR TITLE
test: rename matrix leaderboard synth columns for clarity

### DIFF
--- a/test/FRONTEND_MATRIX.md
+++ b/test/FRONTEND_MATRIX.md
@@ -4,8 +4,10 @@ Tests: **653**  ·  cycles=100  ·  frontends=verilog,uhdm,sv2v,slang
 
 ## Leaderboard
 
-| Frontend | Synthesized | Empty | Failed | Crash | Missing | Correct | Incorrect | Unknown |
-|----------|------------:|------:|-------:|------:|--------:|--------:|----------:|--------:|
+`Read + synth(gate)` = read OK, netlist has logic gates; `Read + synth(const)` = read OK but folds to a constant netlist (0 gates). Both count toward Correct/Incorrect/Unknown.
+
+| Frontend | Read + synth(gate) | Read + synth(const) | Failed | Crash | Missing | Correct | Incorrect | Unknown |
+|----------|------------------:|--------------------:|-------:|------:|--------:|--------:|----------:|--------:|
 | `verilog` | 198 | 213 | 242 | 0 | 0 | 365 | 0 | 46 |
 | `uhdm` | 231 | 416 | 4 | 2 | 0 | 501 | 4 | 142 |
 | `sv2v` | 205 | 364 | 83 | 1 | 0 | 492 | 1 | 76 |

--- a/test/run_frontend_matrix.py
+++ b/test/run_frontend_matrix.py
@@ -235,8 +235,12 @@ def write_markdown(rows: list[dict], out_md: Path, args):
              "",
              "## Leaderboard",
              "",
-             "| Frontend | Synthesized | Empty | Failed | Crash | Missing | Correct | Incorrect | Unknown |",
-             "|----------|------------:|------:|-------:|------:|--------:|--------:|----------:|--------:|"]
+             "`Read + synth(gate)` = read OK, netlist has logic gates; "
+             "`Read + synth(const)` = read OK but folds to a constant netlist "
+             "(0 gates). Both count toward Correct/Incorrect/Unknown.",
+             "",
+             "| Frontend | Read + synth(gate) | Read + synth(const) | Failed | Crash | Missing | Correct | Incorrect | Unknown |",
+             "|----------|------------------:|--------------------:|-------:|------:|--------:|--------:|----------:|--------:|"]
     for f in ALL_FRONTENDS:
         a = agg[f]
         lines.append(


### PR DESCRIPTION
"Synthesized"/"Empty" -> "Read + synth(gate)"/"Read + synth(const)", with a one-line legend noting both count toward Correct/Incorrect/Unknown (so Correct can exceed the gate column — it also covers const-only designs). Regenerated the report snapshot.