### PR TITLE
ci: make the frontend-matrix workflow survive a hosted runner

### DIFF
--- a/.github/workflows/frontend-matrix.yml
+++ b/.github/workflows/frontend-matrix.yml
@@ -5,10 +5,16 @@ name: Frontend Matrix
 # synthesize? + correct? (formal equiv vs the verilog golden AND Verilator
 # co-sim vs the original RTL).  See test/FRONTEND_MATRIX_README.md.
 #
-# This is a HEAVY sweep (hundreds of tests x 4 frontends x formal+co-sim), so it
-# is NOT wired into the per-push/PR CI.  It runs nightly (and on manual
-# workflow_dispatch).  GitHub-hosted runners give ~4 usable cores, so the matrix
-# runs with --jobs 4.
+# This is a HEAVY sweep (1000+ tests x 4 frontends), so it is NOT wired into the
+# per-push/PR CI.  It runs nightly and on manual workflow_dispatch.
+#
+# GitHub-hosted runners are resource-constrained (4 vCPU, 16 GB RAM, ~14 GB disk).
+# A full --all sweep WITH Verilator co-sim exhausts the runner (it OOM/disk-fills
+# and "loses communication" partway through).  So:
+#   * the nightly runs FORMAL-ONLY (--no-cosim): synth coverage + formal
+#     equivalence vs the verilog golden for every test — fast and reliable.
+#   * full co-sim is opt-in via the `cosim` workflow_dispatch input, with reduced
+#     parallelism (--jobs 2) and per-test pruning to bound disk.
 
 on:
   workflow_dispatch:
@@ -17,10 +23,15 @@ on:
         description: "Test scope: --all (internal+Yosys), --yosys, or '' (internal only)"
         required: false
         default: "--all"
-      jobs:
-        description: "Parallel jobs (runner has ~4 cores)"
+      cosim:
+        description: "Run Verilator co-sim too (heavy; may exhaust the runner)"
+        type: boolean
         required: false
-        default: "4"
+        default: false
+      jobs:
+        description: "Parallel jobs (runner has ~4 cores; use 2 with co-sim)"
+        required: false
+        default: "2"
       cycles:
         description: "Verilator co-sim cycles per test"
         required: false
@@ -36,6 +47,15 @@ jobs:
     timeout-minutes: 360
 
     steps:
+    - name: Free up disk space
+      # The co-sim path writes per-test Verilator build dirs; the default
+      # runner image leaves only ~14 GB free.  Reclaim ~20 GB of unused
+      # toolchains so a long sweep doesn't disk-fill.
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                    /opt/hostedtoolcache/CodeQL || true
+        df -h /
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
@@ -110,25 +130,33 @@ jobs:
         make -j4 CC="ccache gcc" CXX="ccache g++" CPU_CORES=4
 
     - name: Build external frontends (sv2v + yosys-slang)
-      # yosys-slang needs gcc >= 11, so build the frontends with the default
-      # gcc-13 (ABI-compatible with the gcc-9-built Yosys for plugin loading).
-      # No Haskell Stack on the runner -> build_frontends.sh auto-falls back to
-      # the upstream prebuilt sv2v release binary.
-      env:
-        CC: gcc-13
-        CXX: g++-13
+      # sv2v: use the prebuilt release binary (SV2V_PREBUILT=1).  The runner's
+      # preinstalled GHC probes the C compiler with clang-style flags
+      # (`--target=...`, `-Werror`) that gcc rejects, so the source build is
+      # doomed and only adds noise.
+      # yosys-slang: needs gcc >= 11 -> build it with gcc-13 (ABI-compatible
+      # with the gcc-9-built Yosys for plugin loading).  Keep gcc-13 scoped to
+      # the slang build so it never touches anything else.
       run: |
         cd test
-        ./build_frontends.sh
+        SV2V_PREBUILT=1 ./build_frontends.sh sv2v
+        CC=gcc-13 CXX=g++-13 ./build_frontends.sh slang
         echo "--- versions ---"; cat ../build/frontends/versions.txt || true
 
     - name: Run 4-frontend matrix
+      # Nightly is formal-only for reliability; co-sim is opt-in.  Unbuffered
+      # (-u) so progress is visible in the live log.  --prune bounds disk.
       run: |
         cd test
-        python3 run_frontend_matrix.py \
+        COSIM_FLAG="--no-cosim"
+        if [ "${{ github.event.inputs.cosim }}" = "true" ]; then
+          COSIM_FLAG=""
+        fi
+        python3 -u run_frontend_matrix.py \
           ${{ github.event.inputs.scope || '--all' }} \
-          --jobs ${{ github.event.inputs.jobs || '4' }} \
-          --cycles ${{ github.event.inputs.cycles || '100' }}
+          --jobs ${{ github.event.inputs.jobs || '2' }} \
+          --cycles ${{ github.event.inputs.cycles || '100' }} \
+          --prune $COSIM_FLAG
 
     - name: Publish report to job summary
       if: always()

--- a/test/build_frontends.sh
+++ b/test/build_frontends.sh
@@ -78,10 +78,12 @@ sv2v_prebuilt_fallback() {
         "https://github.com/zachjs/sv2v/releases/latest/download/sv2v-Linux.zip" \
         || { echo "❌ download failed" >&2; return 1; }
     ( cd "$SV2V_DIR" && unzip -o -q "$zip" ) || { echo "❌ unzip failed" >&2; return 1; }
-    local found; found="$(find "$SV2V_DIR" -name sv2v -type f -perm -u+x 2>/dev/null | head -1)"
-    [ -z "$found" ] && found="$(find "$SV2V_DIR" -name sv2v -type f 2>/dev/null | head -1)"
+    # Find the freshly-extracted binary, ignoring the destination (bin/sv2v) so a
+    # --force re-fetch doesn't pick its own target and `cp` a file onto itself.
+    local found
+    found="$(find "$SV2V_DIR" -name sv2v -type f ! -path "$SV2V_BIN" 2>/dev/null | head -1)"
     [ -z "$found" ] && { echo "❌ no sv2v binary in release zip" >&2; return 1; }
-    cp "$found" "$SV2V_BIN"; chmod +x "$SV2V_BIN"
+    cp -f "$found" "$SV2V_BIN"; chmod +x "$SV2V_BIN"
     echo "prebuilt:$found" > "$SV2V_DIR/.sv2v_prebuilt"
     echo "✓ sv2v installed from prebuilt release: $SV2V_BIN"
 }
@@ -89,6 +91,17 @@ sv2v_prebuilt_fallback() {
 build_sv2v() {
     if [ "$FORCE" -eq 0 ] && [ -x "$SV2V_BIN" ]; then
         echo "✓ sv2v already built: $SV2V_BIN (use --force to rebuild)"
+        return 0
+    fi
+    # SV2V_PREBUILT=1 skips the Haskell/Stack source build entirely and fetches
+    # the upstream prebuilt binary.  Use this on CI, where the runner's GHC
+    # toolchain probes the C compiler with clang-style flags (`--target=...`,
+    # `-Werror`) that gcc rejects — the source build is doomed and only adds
+    # noisy errors before falling back to prebuilt anyway.
+    if [ "${SV2V_PREBUILT:-0}" = "1" ]; then
+        echo "▶ SV2V_PREBUILT=1 — skipping source build, using prebuilt sv2v"
+        mkdir -p "$SV2V_DIR"
+        sv2v_prebuilt_fallback || return 1
         return 0
     fi
     if [ ! -d "$SV2V_DIR/.git" ]; then

--- a/test/run_frontend_matrix.py
+++ b/test/run_frontend_matrix.py
@@ -212,6 +212,13 @@ def process_test(test_rel: str, args) -> dict:
         cosim = golden_cosim if f == "verilog" else cosim_result(test_rel, f, args)
         row[f"{f}_correct"] = decide(f, formal, cosim, golden_cosim)
         row[f"{f}_detail"] = f"formal={formal} cosim={cosim} golden_cosim={golden_cosim}"
+
+    # Bound disk: the Verilator co-sim leaves a per-test working dir (obj_dir +
+    # build artifacts) that, across 1000+ tests, can fill a CI runner's disk.
+    if args.prune:
+        import shutil
+        for junk in (test_dir / "sim_equiv",):
+            shutil.rmtree(junk, ignore_errors=True)
     return row
 
 
@@ -314,6 +321,9 @@ def main() -> int:
                     help="comma list subset to correctness-check (default all)")
     ap.add_argument("--no-cosim", action="store_true",
                     help="skip Verilator co-sim (formal equivalence only)")
+    ap.add_argument("--prune", action="store_true",
+                    help="delete each test's sim_equiv working dir after its "
+                         "verdict (bounds disk usage on CI)")
     ap.add_argument("--out", default=str(TEST_DIR / "frontend_matrix"),
                     help="output path prefix (.csv / FRONTEND_MATRIX.md)")
     args = ap.parse_args()


### PR DESCRIPTION
The nightly run died at ~1h51m with "hosted runner lost communication" — resource exhaustion from running Verilator co-sim over 1000+ tests on a 4-vCPU/16-GB/14-GB-disk runner. Also, the sv2v source build spewed `gcc-13: --target=...` / `-Werror` / lld errors before falling back to prebuilt (the runner's GHC probes the C compiler with clang-style flags gcc rejects).

Fixes:
- build_frontends.sh: SV2V_PREBUILT=1 skips the doomed Stack build and fetches the prebuilt binary directly (no gcc/-Werror probe noise); robust to a --force re-fetch (no cp-onto-self). Build slang separately with gcc-13 so that toolchain override never touches sv2v.
- run_frontend_matrix.py: add --prune to delete each test's sim_equiv working dir after its verdict, bounding disk on CI.
- frontend-matrix.yml: free ~20 GB of unused runner toolchains; nightly is now FORMAL-ONLY (--no-cosim) for reliability, with full co-sim opt-in via the `cosim` dispatch input; default --jobs 2; run with python3 -u for live progress; pass --prune.