### PR TITLE
ci: install orderedmultidict in the build job

### DIFF
--- a/.github/workflows/frontend-matrix.yml
+++ b/.github/workflows/frontend-matrix.yml
@@ -74,6 +74,10 @@ jobs:
         key: frontend-matrix-build
         max-size: 2G
 
+    - name: Install Python dependencies
+      # Surelog/UHDM's CMake configure needs this Python package.
+      run: pip3 install orderedmultidict
+
     - name: Build project (Surelog + Yosys + uhdm2rtlil plugin)
       run: |
         sudo ln -sf /usr/bin/g++-9 /usr/bin/g++


### PR DESCRIPTION
Surelog/UHDM's CMake configure imports the Python `orderedmultidict` package; the split into build/shard jobs left the pip-install step only in the shard job, so the build job failed at configure with ModuleNotFoundError.