### PR TITLE
test: formally classify 8 miter-EQUIVALENT cosim warnings as artefacts

### DIFF
--- a/test/cosim_warnings_plan.md
+++ b/test/cosim_warnings_plan.md
@@ -25,10 +25,10 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [?] BitSelectOfParameterPassedToSubmoduleInGenForOfSubmodule
 - [x] BitSelectPartSelectInFunction — FIXED: packed multi-dim local element/part-select read+write in const-eval (register inner_w; bit_select returns full element; var_select+part_select range read/write; io_decl typespec), AND a cast bug — `int'(2'b11)` self-replicated all-ones as if a fill literal; now only UNSIZED (`'1`, VpiSize==-1) literals self-replicate, sized constants zero/sign-extend.
 - [A] ConcatWidth — ARTIFACT: miter EQUIVALENT; co-sim diff is uninitialised `counter_upd` X-init.
-- [?] ConstSizes
+- [A] ConstSizes — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); classified in sim_equiv_analyzed.txt
 - [?] ContinueNested
 - [?] DotMultirange
-- [?] DotRange
+- [B] DotRange — CONFIRMED REAL UHDM BUG (UHDM-vs-RTL FAIL, Verilog PASS), but DEFERRED. `bar.l[2][1] = foo.k[2]` on packed structs is dropped entirely (no assignment emitted). A first fix (LHS hier_path var_select on a struct-field typespec_member → bit i*inner_w+j; RHS bit_select falling back to the base wire) made it produce the exact-correct `bar[15]=foo[2]` and pass co-sim, BUT regressed 6 multi-field/3D struct tests (struct_3d_packed_array, multidim_hier_path7/8, svtypes_struct_array, struct_unpacked_array_member, struct_little_endian_bit_array) because it ignores the field's OFFSET inside a multi-field struct and intercepts cases other handlers handle. Reverted. Needs offset-aware handling that only fires where existing handlers don't.
 - [?] EnumBases — verilator build-fail
 - [?] EnumFirstInInitial
 - [?] FunctionCallsFunctionWithIndexedPartSelectAsArgument
@@ -86,8 +86,8 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [?] TypedefInModule
 - [?] TypedefedFunctionArgument
 - [?] TypedefedRangedFunctionReturn
-- [?] UnsizedConstant
-- [?] UnsizedConstantParameter
+- [A] UnsizedConstant — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); classified in sim_equiv_analyzed.txt
+- [A] UnsizedConstantParameter — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); classified in sim_equiv_analyzed.txt
 - [?] VarPassedTo2Submodules
 - [?] VoidFunction2Returns
 - [?] assignment-pattern
@@ -97,14 +97,14 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [?] const_fold_func
 - [?] counter_unbased
 - [?] fmt_always_comb
-- [?] fsm_using_always
+- [A] fsm_using_always — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); X-init co-sim diff; classified
 - [?] func_output_arg
 - [?] func_tern_hint
 - [?] function_arith
 - [?] int_types_blk1
 - [?] load_and_derive
 - [?] mem2reg_test1
-- [?] mixed_sign_ops
+- [A] mixed_sign_ops — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); X-init co-sim diff; classified
 - [?] mriscv_bind_sva
 - [?] param_int_types
 - [?] param_no_default

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -333,6 +333,39 @@ Test: wandwor
 # frontends synthesise to equivalent netlists (SAT miter EQUIVALENT from
 # reset), so the divergence affects gold and gate identically.
 
+Test: ConcatWidth
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Co-sim diff is the uninitialised
+    `counter_upd` X-init; both frontends synthesise to equivalent netlists.
+
+Test: fsm_single_always
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  FSM with an uninitialised state
+    register: random-stimulus X-init drift vs RTL, identical on both frontends.
+
+Test: fsm_using_always
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Same FSM X-init drift; SAT miter
+    proves UHDM-synth == Verilog-synth from reset.
+
+Test: fsm_using_function
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Same FSM X-init drift (next-state
+    computed by a function); netlists proven equivalent.
+
+Test: mixed_sign_ops
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Mixed-sign arithmetic; co-sim
+    divergence is X-init / under-exercised output, not a frontend difference.
+
+Test: ConstSizes
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Co-sim diverges (X-init / low
+    activity) identically on both frontends; the SAT miter proves the UHDM-synth
+    and Verilog-synth netlists equivalent from reset.  Not a UHDM bug.
+
+Test: UnsizedConstant
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Verilator-vs-synth co-sim diff
+    only; both frontends synthesise to equivalent netlists.  Not a UHDM bug.
+
+Test: UnsizedConstantParameter
+    Artefact: miter EQUIVALENT (UHDM==Verilog).  Verilator-vs-synth co-sim diff
+    only; both frontends synthesise to equivalent netlists.  Not a UHDM bug.
+
 Test: counter_in_cpu_state
     Artefact: miter EQUIVALENT (UHDM==Verilog).  Vacuous/low-activity output
     under random stimulus; no value divergence vs the Verilog frontend.


### PR DESCRIPTION
Ran the SAT-from-reset formal miter (triage_cosim.py) over the current cosim warnings to move provable ones from "warning/unknown" to a documented KNOWN state.  The miter's EQUIVALENT verdict is a proof that UHDM-synth == Verilog- synth, so the co-sim divergence is a Verilator-vs-gate X-init artefact, not a UHDM-frontend bug.

Classify the 8 miter-EQUIVALENT warnings not already analyzed:
  ConstSizes, UnsizedConstant, UnsizedConstantParameter,
  ConcatWidth, fsm_single_always, fsm_using_always, fsm_using_function,
  mixed_sign_ops
in sim_equiv_analyzed.txt — each now reports 🔬 ARTEFACT (auto-classified by the miter) instead of ⚠️ WARNING.

The sweep also CONFIRMS two real UHDM bugs (UHDM-vs-RTL co-sim FAIL while the Verilog frontend PASSES): DotRange (miter INCONCLUSIVE) and simple_memory (miter NON-EQUIVALENT) — left as warnings, tracked in the backlog.  And it corrects a stale plan marking: DotRange was prematurely marked FIXED; the fix regressed 6 multi-field/3D struct tests and was reverted, so it is now [B] (deferred real bug) again.

No source changes; test tracking-files only.