### PR TITLE
uhdm: fix N-index var_select read on packed+unpacked arrays (struct_p…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -1402,6 +1402,79 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                     }
                 }
 
+                // Fully-indexed N-dim var_select `x[i0][i1]...[ik]` on a
+                // packed+unpacked array that carries no wire metadata.  Walk the
+                // array_var typespec dimensions outer->inner (unpacked
+                // array_typespec Ranges, then packed Elem_typespec/logic_typespec
+                // Ranges) and compute the flat leaf-bit offset ourselves
+                // (struct_pattern_loop: `bit [0:0][0:0] b [0:0]; b[0][0][0]`).
+                if (exprs->size() >= 3) {
+                    RTLIL::Wire* bw = mapped_base_wire ? mapped_base_wire
+                                    : module->wire(RTLIL::escape_id(base_name));
+                    const UHDM::any* ats = nullptr;
+                    if (vs->Actual_group())
+                        if (auto e = dynamic_cast<const UHDM::expr*>(vs->Actual_group()))
+                            if (e->Typespec()) ats = e->Typespec()->Actual_typespec();
+                    if (bw && ats) {
+                        // The packed (inner) dims are not reachable from the
+                        // array_var typespec here (an empty array_typespec), but
+                        // the UNPACKED (outer) dims live on the array_var's
+                        // Ranges() and the wire is already flattened, so derive
+                        // the packed-element bit-width from the wire width.
+                        std::vector<std::pair<int,int>> udims; // (size, low) outer->inner
+                        bool dim_ok = true;
+                        auto add_ranges = [&](UHDM::VectorOfrange* rs){
+                            if (!rs) return;
+                            for (auto r : *rs) {
+                                RTLIL::SigSpec l = import_expression(r->Left_expr(), input_mapping);
+                                RTLIL::SigSpec rr = import_expression(r->Right_expr(), input_mapping);
+                                if (l.is_fully_const() && rr.is_fully_const()) {
+                                    int lv = l.as_const().as_int(), rv = rr.as_const().as_int();
+                                    udims.push_back({std::abs(lv - rv) + 1, std::min(lv, rv)});
+                                } else dim_ok = false;
+                            }
+                        };
+                        if (auto av = dynamic_cast<const UHDM::array_var*>(vs->Actual_group()))
+                            add_ranges(av->Ranges());
+                        size_t n_unp = udims.size();
+                        if (dim_ok && n_unp >= 1 && exprs->size() >= n_unp) {
+                            int unp_product = 1;
+                            for (auto& d : udims) unp_product *= d.first;
+                            if (unp_product > 0 && bw->width % unp_product == 0) {
+                                int packed_bits = bw->width / unp_product;
+                                bool ok = true;
+                                long unp_flat = 0;
+                                for (size_t d = 0; d < n_unp; d++) {
+                                    RTLIL::SigSpec is = import_expression((*exprs)[d], input_mapping);
+                                    if (!is.is_fully_const()) { ok = false; break; }
+                                    unp_flat = unp_flat * udims[d].first +
+                                               (is.as_const().as_int() - udims[d].second);
+                                }
+                                // Remaining indices select within the packed
+                                // element.  We don't have the packed dim sizes,
+                                // so only resolve the unambiguous single-bit case
+                                // (all remaining indices must be 0) — enough for
+                                // `bit [0:0][0:0] b [0:0]` (struct_pattern_loop).
+                                bool rem_zero = true;
+                                for (size_t d = n_unp; d < exprs->size(); d++) {
+                                    RTLIL::SigSpec is = import_expression((*exprs)[d], input_mapping);
+                                    if (!is.is_fully_const() || is.as_const().as_int() != 0)
+                                        rem_zero = false;
+                                }
+                                if (ok && rem_zero && packed_bits == 1) {
+                                    int bit_off = (int)unp_flat;
+                                    if (bit_off >= 0 && bit_off < bw->width) {
+                                        log("  vpiVarSelect: %dD %s[...] → %s[%d]\n",
+                                            (int)exprs->size(), base_name.c_str(),
+                                            bw->name.c_str(), bit_off);
+                                        return RTLIL::SigSpec(bw).extract(bit_off, 1);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // First expression is the array index.
                 const expr* first_idx = (*exprs)[0];
                 RTLIL::SigSpec idx_sig = import_expression(first_idx, input_mapping);

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -118,7 +118,7 @@
 #      ModuleInstantiationAndIndirectParams (expose resolved indirect param
 #      IAmConst=8 instead of `assign o='0`).
 #  - struct_pattern_loop: restructuring it for observability EXPOSED a real bug
-#      (nested pattern out=0 vs 1) — now tracked below as a confirmed bug.
+#      (nested pattern out=0 vs 1) — now FIXED (3-index var_select read path).
 #  - ARTEFACTS classified (sim_equiv_analyzed.txt + classification override):
 #      StringAssignment/StringAssignConcatenation/StringLocalParamInitByConcatenation/
 #      StringWithBackslash (non-synth `string` ports), setundef (intentional X),
@@ -126,9 +126,3 @@
 #      undriven), assignment-pattern (self-checking asserts $stop Verilator).
 #  - DotRange: confirmed bug, tracked above (LHS struct-field var_select dropped).
 # ===========================================================================
-
-# struct_pattern_loop — nested packed/unpacked array pattern assignment bug,
-#   exposed by restructuring the test for observability ('{'b0} -> '{'b1}).
-#   `bit [0:0][0:0] b [0:0]; assign b = '{'b1}; out = b[0][0][0]` gives out=0 in
-#   UHDM but 1 in the Verilator reference (rtl=1 nl=0).  Deterministic
-#   combinational bug in the nested assignment-pattern lowering.

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -446,10 +446,6 @@ Test: setundef
     Inconclusive: Verilog frontend build-fails (no reference).  Exercises
     undef handling; UHDM co-sim is vacuous, miter cannot run.
 
-Test: struct_pattern_loop
-    Inconclusive: UHDM-only (no Verilog reference).  Vacuous (constant)
-    output; nothing to formally compare.
-
 # --- 🐛 CONFIRMED UHDM-vs-Verilog BUGS (see cosim_uhdm_bugs.txt) -----------
 # UHDM-synth diverges from BOTH the behavioral RTL and the Yosys Verilog
 # frontend (UHDM-cosim FAIL while Verilog-cosim PASS).  These FALSELY pass
@@ -503,12 +499,6 @@ Test: assignment-pattern
     any UHDM comparison (the reference RTL fails its own assert).  Incompatible
     with the synth-equivalence co-sim flow; not a UHDM-frontend comparison.
 
-Test: struct_pattern_loop
-    EXPECTED MISMATCH (real UHDM bug, tracked in cosim_uhdm_bugs.txt).  After
-    restructuring the pattern to `'{'b1}` for observability, the nested packed/
-    unpacked array pattern assignment gives out=0 where the Verilator reference
-    gives out=1 (rtl=1 nl=0).  Deterministic combinational bug; left as an
-    expected mismatch until the nested-pattern lowering is fixed.
 
 
 

--- a/test/sim_equiv_classification.txt
+++ b/test/sim_equiv_classification.txt
@@ -71,4 +71,3 @@ setundef                              artefact   # intentional X parameter (2'b0
 EnumBases                             artefact   # output undriven; enum/typedef declarations only
 TaskReturn                            artefact   # procedural assign-in-task + undriven output
 assignment-pattern                    artefact   # self-checking asserts $stop the Verilator sim
-struct_pattern_loop                   bug        # nested packed/unpacked pattern: out=0 vs RTL 1 (real bug)


### PR DESCRIPTION
…attern_loop)

`out = b_internal[0][0][0]` where `bit [0:0][0:0] b_internal [0:0]` produced out=0 (the Verilator reference gives 1).  The vpiVarSelect handler only covered 1- and 2-index selects, so the 3-index read returned an empty SigSpec and the continuous-assign `$pos` got an empty A input -> out drove 0.

Add an N-index fully-indexed var_select path.  The packed (inner) dims are not reachable here (the array_var's array_typespec is empty — no Elem_typespec), but the UNPACKED (outer) dims live on `array_var->Ranges()` and the net is already flattened, so the packed-element bit-width is derived from the wire width (wire_width / product(unpacked_dim_sizes)).  For the single-bit packed element (packed_bits==1, the struct_pattern_loop shape) the flat offset is just the unpacked index fold; the path is gated to that unambiguous case so it can't mis-slice multi-bit packed elements (it falls through to the existing handling otherwise).  out=1, co-sim PASS (200 cycles).

Remove struct_pattern_loop from the bug-tracking files now that it is fixed (classification override, two stale sim_equiv_analyzed entries, plan -> [x]).

Full suite green: 652/653 (only CastStructArray), True failures: 0.