### PR TITLE
uhdm: drive output args of void function/task calls in initial blocks

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -6,6 +6,8 @@
  */
 
 #include "uhdm2rtlil.h"
+#include <uhdm/assign_stmt.h>
+#include <uhdm/begin.h>
 #include <uhdm/func_call.h>
 #include <uhdm/sys_func_call.h>
 #include <uhdm/parameter.h>
@@ -3234,8 +3236,21 @@ void UhdmImporter::import_initial(const process_stmt* uhdm_process, RTLIL::Proce
         has_local_vars = block_has_local_variables(stmt);
         has_for_decl = statement_has_for_declaration(stmt);
         has_scalar_ctrl_loop = statement_has_scalar_control_for_loop(stmt);
-        has_task_call = (stmt->VpiType() == vpiTaskCall ||
-                         stmt->VpiType() == vpiMethodTaskCall);
+        // A task/func call drives its output/inout args; route to the comb
+        // (inlining) path.  The call may be the top statement OR the (only)
+        // statement inside a `begin` block, and a VOID FUNCTION call is a
+        // vpiFuncCall, not vpiTaskCall (FunctionOutputArgument / TaskOutputArgument
+        // / VoidFunction2Returns: `initial begin my_pkg::assign_1(o); end`).
+        auto is_call_stmt = [](const UHDM::any* s) {
+            int t = s->VpiType();
+            return t == vpiTaskCall || t == vpiMethodTaskCall || t == vpiFuncCall;
+        };
+        has_task_call = is_call_stmt(stmt);
+        if (!has_task_call && stmt->VpiType() == vpiBegin)
+            if (auto b = any_cast<const UHDM::begin*>(stmt))
+                if (b->Stmts())
+                    for (auto s : *b->Stmts())
+                        if (is_call_stmt(s)) { has_task_call = true; break; }
         has_partial_write = statement_has_partial_write(stmt);
     }
     bool has_compound_assign = uhdm_process->Stmt() &&
@@ -6710,9 +6725,12 @@ void UhdmImporter::import_tf_call_comb(const UHDM::tf_call* tc,
     }
 
     // Process the task body
+    bool saved_returned = tf_call_returned;
+    tf_call_returned = false;
     if (auto task_stmt = task_def->Stmt()) {
         inline_task_body_comb(task_stmt, proc, task_mapping, context, "", process_src);
     }
+    tf_call_returned = saved_returned;
 
     // Map output params to caller's variables
     for (auto& [param_name, caller_out] : output_targets) {
@@ -7008,6 +7026,7 @@ void UhdmImporter::inline_task_body_comb(const any* stmt, RTLIL::Process* proc,
             VectorOfany* stmts = begin_block_stmts(bg);
             if (stmts) {
                 for (auto s : *stmts) {
+                    if (tf_call_returned) break;  // honour an earlier `return`
                     inline_task_body_comb(s, proc, task_mapping, context, new_prefix, process_src);
                 }
             }
@@ -7025,12 +7044,25 @@ void UhdmImporter::inline_task_body_comb(const any* stmt, RTLIL::Process* proc,
         }
         case vpiAssignment:
         case vpiAssignStmt: {
-            auto assign = any_cast<const assignment*>(stmt);
-            if (!assign) break;
+            // Either a procedural `assignment` (x = y) or a quasi-continuous
+            // `assign_stmt` (`assign x = y` inside a void function/task —
+            // FunctionOutputArgument/TaskOutputArgument/VoidFunction2Returns);
+            // these are distinct UHDM classes that both carry Lhs()/Rhs(), so
+            // resolve the accessors generically (the old code cast only to
+            // `assignment` and silently dropped `assign_stmt` bodies).
+            const UHDM::expr* a_lhs = nullptr;
+            const UHDM::any* a_rhs = nullptr;
+            const UHDM::any* a_src = stmt;
+            if (auto assign = any_cast<const assignment*>(stmt)) {
+                a_lhs = assign->Lhs(); a_rhs = assign->Rhs();
+            } else if (auto as = any_cast<const UHDM::assign_stmt*>(stmt)) {
+                a_lhs = as->Lhs(); a_rhs = as->Rhs();
+            } else break;
+            if (!a_lhs || !a_rhs) break;
 
             // Import RHS with task_mapping for variable resolution
             RTLIL::SigSpec rhs;
-            if (auto rhs_any = assign->Rhs()) {
+            if (auto rhs_any = a_rhs) {
                 if (auto rhs_expr = dynamic_cast<const expr*>(rhs_any)) {
                     rhs = import_expression(rhs_expr, &task_mapping);
                 }
@@ -7056,7 +7088,7 @@ void UhdmImporter::inline_task_body_comb(const any* stmt, RTLIL::Process* proc,
             // we emit a SwitchRule instead of a single SigSig and skip the
             // normal width-match/temp-wire path below.
             bool dyn_bit_select_handled = false;
-            if (auto lhs_expr = assign->Lhs()) {
+            if (auto lhs_expr = a_lhs) {
                 int lhs_type = lhs_expr->VpiType();
                 if (lhs_type == vpiRefObj) {
                     const ref_obj* lhs_ref = any_cast<const ref_obj*>(lhs_expr);
@@ -7106,7 +7138,7 @@ void UhdmImporter::inline_task_body_comb(const any* stmt, RTLIL::Process* proc,
                                 max_cases = std::min(n, 1 << idx_w);
                             RTLIL::SwitchRule* sw = new RTLIL::SwitchRule;
                             sw->signal = idx_sig;
-                            add_src_attribute(sw->attributes, assign);
+                            add_src_attribute(sw->attributes, a_src);
                             RTLIL::SigSpec rhs_bit = rhs;
                             if (rhs_bit.size() < 1) {
                                 rhs_bit = RTLIL::SigSpec(RTLIL::State::S0, 1);
@@ -7258,6 +7290,12 @@ void UhdmImporter::inline_task_body_comb(const any* stmt, RTLIL::Process* proc,
             }
             break;
         }
+        case vpiReturn:
+            // `return;` in a void task/function body — stop processing the rest
+            // of the enclosing block (VoidFunction2Returns: keep the pre-return
+            // `assign x=1`, drop the dead `assign x=2`).
+            tf_call_returned = true;
+            break;
         default:
             log_warning("Unsupported statement type %d in task body\n", stmt->VpiType());
             break;

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -306,8 +306,17 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            auto assign = any_cast<const assignment*>(stmt);
-            if (auto lhs = assign->Lhs()) {
+            // `assignment` (x = y) and `assign_stmt` (`assign x = y` in a
+            // task/func body — TaskOutputArgument) are distinct UHDM classes
+            // both reached by vpiAssignStmt; cast generically (the old single
+            // cast to `assignment` returned null for assign_stmt -> crash when
+            // the task-body recursion below dereferenced it).
+            const UHDM::expr* a_lhs = nullptr;
+            if (auto assign = any_cast<const assignment*>(stmt))
+                a_lhs = assign->Lhs();
+            else if (auto as = any_cast<const UHDM::assign_stmt*>(stmt))
+                a_lhs = as->Lhs();
+            if (auto lhs = a_lhs) {
                 if (auto lhs_expr = dynamic_cast<const expr*>(lhs)) {
                     AssignedSignal sig;
                     sig.lhs_expr = lhs_expr;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -336,6 +336,11 @@ struct UhdmImporter {
     // When true, suppress current_comb_values read/write so that
     // always_ff body processing uses original register values (NB semantics)
     bool in_always_ff_body_mode = false;
+    // Set by a `return` inside an inlined task/void-function body
+    // (inline_task_body_comb) so subsequent statements in the same block are
+    // skipped — `assign x=1; return; assign x=2;` must keep x=1 not x=2
+    // (VoidFunction2Returns).  Reset at each import_tf_call_comb entry.
+    bool tf_call_returned = false;
     // Set while evaluating a typespec RANGE bound (a compile-time constant
     // context): forces import_operation to constant-fold all-const operations
     // such as `NumScrmblBlocks-1` so get_width_from_typespec reads a literal


### PR DESCRIPTION
Fixes the func/task output-argument group (FunctionOutputArgument, TaskOutputArgument, VoidFunction2Returns): `initial begin my_pkg::assign_1(o); end` where the callee has an `output` formal driven by `assign x = <const>` left `o` undriven (or crashed).  Three related causes:

1. Routing.  import_initial's has_task_call only checked the TOP statement for vpiTaskCall, but the call sits inside a `begin` block, and a VOID FUNCTION call is a vpiFuncCall — so both fell through to the sync path (no inlining) and the output arg was never driven.  Now detect a task/func/method call as the top statement OR inside a begin, including vpiFuncCall.

2. assign_stmt vs assignment.  The callee body `assign x = c` is a UHDM `assign_stmt`, a different class from a procedural `assignment` though both reach the vpiAssignStmt case.  inline_task_body_comb and extract_assigned_signals cast only to `assignment*`; for assign_stmt that returned null — the body was silently dropped (function) and the task-body recursion dereferenced null (SEGFAULT, exit 139).  Resolve Lhs()/Rhs() generically from either class.

3. return.  inline_task_body_comb ignored `return`, so `assign x=1; return; assign x=2;` ran both and kept x=2.  Add a vpiReturn case that sets a tf_call_returned flag; the block loop stops at it.  Flag is saved/reset per import_tf_call_comb so nested calls don't leak it.

Full suite green: 652/653 (only CastStructArray), True failures: 0.

(SelectFromUnpackedInFunction / 2DUnpackedFunctionArgument remain: those pass an unpacked ARRAY as a function arg and select inside — a separate function-as-RHS arg-mapping issue, not output args.)