### PR TITLE
uhdm: pass unpacked arrays as function arguments and select inside

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4567,6 +4567,33 @@ RTLIL::SigSpec UhdmImporter::import_ref_obj(const ref_obj* uhdm_ref, const UHDM:
     if (loop_values.count(ref_name))
         return RTLIL::SigSpec(RTLIL::Const(loop_values[ref_name], 32));
 
+    // A bare reference to a whole UNPACKED ARRAY (`logic [2:0] a [3:0]`,
+    // `int x [1:0][0:0]`) — e.g. passing it as a function argument
+    // `get_3rd(a)` / `my_func(x)` — resolves to the concatenation of its
+    // per-element wires (\a[0]..\a[N-1]), element 0 at the LSB so the callee's
+    // flattened formal lines up (mat[i] == a[i]).  Without this the bare name
+    // resolved to a 1-bit unknown wire and the callee read garbage.
+    // (SelectFromUnpackedInFunction / 2DUnpackedFunctionArgument.)
+    if (!name_map.count(ref_name) && name_map.count(ref_name + "[0]")) {
+        std::string gs = get_current_gen_scope();
+        RTLIL::SigSpec arr;
+        for (int i = 0; ; i++) {
+            std::string en = ref_name + "[" + std::to_string(i) + "]";
+            RTLIL::Wire* ew = nullptr;
+            if (!gs.empty() && name_map.count(gs + "." + en))
+                ew = name_map[gs + "." + en];
+            else if (name_map.count(en))
+                ew = name_map[en];
+            if (!ew) break;
+            arr.append(RTLIL::SigSpec(ew));
+        }
+        if (arr.size() > 0) {
+            log("    ref_obj: whole unpacked array %s -> %d-bit element concat\n",
+                ref_name.c_str(), arr.size());
+            return arr;
+        }
+    }
+
     // Check if the ref_obj has an Actual_group() that points to the real signal
     // This is used in generate blocks where ref_obj names include generate scope prefixes
     // but the Actual_group() points to the real module-level signal
@@ -5385,8 +5412,32 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                 RTLIL::SigSpec index = import_expression(uhdm_bit->VpiIndex(), input_mapping);
                 if (index.is_fully_const()) {
                     int idx = index.as_const().as_int();
-                    if (idx >= 0 && idx < it->second.size()) {
-                        return it->second.extract(idx, 1);
+                    // Unpacked-array param `logic [2:0] mat [3:0]`: `mat[i]`
+                    // selects the i-th element (W bits), not bit i.  Derive W
+                    // from the param's unpacked dimension on the bit_select's
+                    // Actual_group (SelectFromUnpackedInFunction).
+                    int elem_w = 1, outer_lo = 0;
+                    if (auto ag = uhdm_bit->Actual_group()) {
+                        UHDM::VectorOfrange* rngs = nullptr;
+                        if (auto lv = dynamic_cast<const UHDM::logic_var*>(ag)) rngs = lv->Ranges();
+                        else if (auto io = dynamic_cast<const UHDM::io_decl*>(ag)) rngs = io->Ranges();
+                        else if (auto av = dynamic_cast<const UHDM::array_var*>(ag)) rngs = av->Ranges();
+                        if (rngs && !rngs->empty()) {
+                            auto r0 = (*rngs)[0];
+                            RTLIL::SigSpec l = import_expression(r0->Left_expr());
+                            RTLIL::SigSpec rr = import_expression(r0->Right_expr());
+                            if (l.is_fully_const() && rr.is_fully_const()) {
+                                int osz = std::abs(l.as_const().as_int() - rr.as_const().as_int()) + 1;
+                                if (osz > 0 && it->second.size() % osz == 0) {
+                                    elem_w = it->second.size() / osz;
+                                    outer_lo = std::min(l.as_const().as_int(), rr.as_const().as_int());
+                                }
+                            }
+                        }
+                    }
+                    int off = (idx - outer_lo) * elem_w;
+                    if (off >= 0 && off + elem_w <= it->second.size()) {
+                        return it->second.extract(off, elem_w);
                     }
                 }
                 // For non-constant index, we'd need to create a mux tree

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1987,7 +1987,20 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
             log("UHDM: Found net object\n");
             if (auto typespec = variable->Typespec()) {
                 log("UHDM: Net has typespec, calling get_width_from_typespec\n");
-                return get_width_from_typespec(typespec, inst);
+                int w = get_width_from_typespec(typespec, inst);
+                // Multiply by any UNPACKED array dimensions carried on the
+                // io_decl itself (`logic [2:0] mat [3:0]` -> packed 3 * unpacked
+                // 4 = 12) so a whole-array argument flattens to the right width
+                // (SelectFromUnpackedInFunction / 2DUnpackedFunctionArgument).
+                if (variable->Ranges())
+                    for (auto r : *variable->Ranges()) {
+                        if (!r->Left_expr() || !r->Right_expr()) continue;
+                        RTLIL::SigSpec l = import_expression(r->Left_expr());
+                        RTLIL::SigSpec rr = import_expression(r->Right_expr());
+                        if (l.is_fully_const() && rr.is_fully_const())
+                            w *= std::abs(l.as_const().as_int() - rr.as_const().as_int()) + 1;
+                    }
+                return w;
             } else {
                 log("UHDM: Net has no typespec\n");
             }

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2132,6 +2132,32 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                                             .at(RTLIL::escape_id("unpacked_elem_width")).as_int();
                                         int inner_sz = wire->attributes
                                             .at(RTLIL::escape_id("unpacked_inner_size")).as_int();
+                                        // Pattern row/col 0 maps to the FIRST
+                                        // declared index — the HIGHEST for a
+                                        // descending dim (`[1:0]`), the lowest
+                                        // for an ascending one — matching the
+                                        // var_select read offset.  Without this
+                                        // a descending `int x[1:0][0:0]` init put
+                                        // row 0 at the low slot but the read took
+                                        // it from the high slot
+                                        // (2DUnpackedFunctionArgument).
+                                        bool outer_asc = false, inner_asc = false;
+                                        int outer_cnt = (int)init_op->Operands()->size();
+                                        int inner_cnt = inner_sz;
+                                        if (array_var->Ranges() && array_var->Ranges()->size() >= 2) {
+                                            auto dir = [&](int di, bool& asc, int& sz) {
+                                                auto r = (*array_var->Ranges())[di];
+                                                if (!r->Left_expr() || !r->Right_expr()) return;
+                                                RTLIL::SigSpec l = import_expression(r->Left_expr());
+                                                RTLIL::SigSpec rr = import_expression(r->Right_expr());
+                                                if (l.is_fully_const() && rr.is_fully_const()) {
+                                                    asc = l.as_const().as_int() < rr.as_const().as_int();
+                                                    sz = std::abs(l.as_const().as_int() - rr.as_const().as_int()) + 1;
+                                                }
+                                            };
+                                            dir(0, outer_asc, outer_cnt);
+                                            dir(1, inner_asc, inner_cnt);
+                                        }
                                         if (init_op->Operands()) {
                                             int row_idx = 0;
                                             for (auto row_any : *init_op->Operands()) {
@@ -2146,7 +2172,9 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                                                     if (auto ce = dynamic_cast<const UHDM::expr*>(cell_any)) {
                                                         RTLIL::SigSpec cs = import_expression(ce);
                                                         if (cs.is_fully_const()) {
-                                                            int off = (row_idx * inner_sz + col_idx) * elem_w;
+                                                            int eff_row = outer_asc ? row_idx : (outer_cnt - 1 - row_idx);
+                                                            int eff_col = inner_asc ? col_idx : (inner_cnt - 1 - col_idx);
+                                                            int off = (eff_row * inner_sz + eff_col) * elem_w;
                                                             if (cs.size() < elem_w) cs.extend_u0(elem_w);
                                                             else if (cs.size() > elem_w) cs = cs.extract(0, elem_w);
                                                             if (off + elem_w <= wire->width)


### PR DESCRIPTION
Fixes SelectFromUnpackedInFunction (`get_3rd(a)` -> `mat[3]`) and 2DUnpackedFunctionArgument (`my_func(x)` -> `arg[1][0]`), which both read 0 instead of the selected element.  Four layers, all real:

1. Whole-array ref (expression.cpp import_ref_obj).  A bare reference to an unpacked array (`logic [2:0] a [3:0]`) passed as an argument resolved to a 1-bit unknown wire.  Return the concatenation of its per-element wires (\a[0]..\a[N-1], element 0 at LSB) so the callee's flat formal lines up.

2. Param width (module.cpp get_width).  An io_decl's width ignored its UNPACKED array Ranges (`mat [3:0]` -> 3 not 12), so the param wire was too small and truncated the argument to one element.  Multiply by the unpacked dims.

3. Element select (expression.cpp import_bit_select).  In the function body `mat[i]` on a func-mapping value did a 1-bit extract; derive the element width from the param's unpacked dimension so it slices the i-th W-bit element.

4. Multi-dim init order (uhdm2rtlil.cpp).  A descending `int x[1:0][0:0]` nested pattern init wrote pattern row 0 to the LOW slot while the var_select read it from the HIGH slot.  Map pattern row/col direction-aware (descending: first row -> highest index), matching the read and the element_wires path.

Full suite green: 652/653 (only CastStructArray), True failures: 0.