### PR TITLE
uhdm: read element of a packed array of structs (DotMultirange)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -1492,6 +1492,64 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                     }
                 }
 
+                // Packed array of (packed) STRUCTS: `status_t [1:0][1:0] g;
+                // g[i][j]` reads the (i,j) struct element.  The dims live on the
+                // packed_array_var's Ranges and the element is the struct width —
+                // neither is a logic_typespec, so the logic path above misses it
+                // (DotMultirange).
+                if (exprs->size() >= 2) {
+                    RTLIL::Wire* bw = mapped_base_wire ? mapped_base_wire
+                                    : module->wire(RTLIL::escape_id(base_name));
+                    const UHDM::packed_array_var* pav =
+                        dynamic_cast<const UHDM::packed_array_var*>(vs->Actual_group());
+                    if (!pav && bw)
+                        for (auto& kv : wire_map)
+                            if (kv.second == bw && kv.first->UhdmType() == uhdmpacked_array_var) {
+                                pav = any_cast<const UHDM::packed_array_var*>(kv.first);
+                                break;
+                            }
+                    if (bw && pav && pav->Ranges() && !pav->Ranges()->empty()) {
+                        int elem_w = 0;
+                        if (pav->Typespec() && pav->Typespec()->Actual_typespec())
+                            elem_w = get_width_from_typespec(pav->Typespec()->Actual_typespec(),
+                                                             current_instance);
+                        if (elem_w <= 0 && pav->Elements() && !pav->Elements()->empty())
+                            elem_w = get_width((*pav->Elements())[0], current_instance);
+                        std::vector<std::pair<int,int>> adims; // (size, low) outer->inner
+                        bool ok = true;
+                        for (auto r : *pav->Ranges()) {
+                            RTLIL::SigSpec l = import_expression(r->Left_expr(), input_mapping);
+                            RTLIL::SigSpec rr = import_expression(r->Right_expr(), input_mapping);
+                            if (l.is_fully_const() && rr.is_fully_const())
+                                adims.push_back({std::abs(l.as_const().as_int() - rr.as_const().as_int()) + 1,
+                                                 std::min(l.as_const().as_int(), rr.as_const().as_int())});
+                            else ok = false;
+                        }
+                        size_t K = exprs->size();
+                        if (ok && elem_w > 0 && adims.size() >= K && adims.size() >= 1) {
+                            int total = elem_w;
+                            for (auto& d : adims) total *= d.first;
+                            if (total == bw->width) {
+                                int leaf_w = elem_w;
+                                for (size_t d = K; d < adims.size(); d++) leaf_w *= adims[d].first;
+                                long off = 0; bool cok = true;
+                                for (size_t k = 0; k < K; k++) {
+                                    RTLIL::SigSpec is = import_expression((*exprs)[k], input_mapping);
+                                    if (!is.is_fully_const()) { cok = false; break; }
+                                    int inner = elem_w;
+                                    for (size_t d = k + 1; d < adims.size(); d++) inner *= adims[d].first;
+                                    off += (long)(is.as_const().as_int() - adims[k].second) * inner;
+                                }
+                                if (cok && off >= 0 && off + leaf_w <= bw->width) {
+                                    log("  vpiVarSelect: packed struct-array %s[...] → [%d+:%d]\n",
+                                        base_name.c_str(), (int)off, leaf_w);
+                                    return RTLIL::SigSpec(bw).extract((int)off, leaf_w);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // Fully-indexed N-dim var_select `x[i0][i1]...[ik]` on a
                 // packed+unpacked array that carries no wire metadata.  Walk the
                 // array_var typespec dimensions outer->inner (unpacked

--- a/test/cosim_warnings_plan.md
+++ b/test/cosim_warnings_plan.md
@@ -27,7 +27,7 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [A] ConcatWidth — ARTIFACT: miter EQUIVALENT; co-sim diff is uninitialised `counter_upd` X-init.
 - [A] ConstSizes — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); classified in sim_equiv_analyzed.txt
 - [?] ContinueNested
-- [?] DotMultirange
+- [x] DotMultirange — FIXED: read `g[i][j]` on a packed array of structs (`status_t [1:0][1:0]`). Dims live on packed_array_var.Ranges() with a struct (not logic) element, so the logic packed-multidim path missed it; added a sibling using Ranges() + struct width as the leaf. cosim PASS.
 - [B] DotRange — CONFIRMED REAL UHDM BUG (UHDM-vs-RTL FAIL, Verilog PASS), but DEFERRED. `bar.l[2][1] = foo.k[2]` on packed structs is dropped entirely (no assignment emitted). A first fix (LHS hier_path var_select on a struct-field typespec_member → bit i*inner_w+j; RHS bit_select falling back to the base wire) made it produce the exact-correct `bar[15]=foo[2]` and pass co-sim, BUT regressed 6 multi-field/3D struct tests (struct_3d_packed_array, multidim_hier_path7/8, svtypes_struct_array, struct_unpacked_array_member, struct_little_endian_bit_array) because it ignores the field's OFFSET inside a multi-field struct and intercepts cases other handlers handle. Reverted. Needs offset-aware handling that only fires where existing handlers don't.
 - [A] EnumBases — ARTEFACT (sim-only/undriven/intentional-X/self-checking); classified in sim_equiv_analyzed + classification override.
 - [?] EnumFirstInInitial


### PR DESCRIPTION
`status_t [1:0][1:0] g; assign out = g[i][j]` read 0 instead of the struct element.  The LHS field writes (`g[i][j].a = ...`) already resolved to the right bits, but the RHS read `g[i][j]` — a var_select reading the whole struct element — had no handler and fell through to an element-wire lookup that fails ("element 'g[0]' not found").

The dims of a packed struct array live on the `packed_array_var`'s Ranges() and the element is a struct (not a logic_typespec), so the LogicPackedArray multi-dim path (which walks a logic_typespec) doesn't match.  Add a sibling var_select handler: pull the dims from packed_array_var->Ranges(), take the struct width as the per-element leaf, and slice
  base[ (sum_k (i_k-low_k) * prod(dims[k+1..]) ) * elem_w +: leaf ]
matching the existing LHS field-write layout.

Full suite green: 652/653 (only CastStructArray), True failures: 0.