### PR TITLE
build: bump Yosys submodule v0.64 → v0.65 (fork branch + write_verilo…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,13 @@
 [submodule "third_party/yosys"]
 	path = third_party/yosys
 	url = https://github.com/alainmarcel/yosys.git
-	# Tracking a fork branch (v0.64 + one local patch) until upstream
-	# Yosys merges the `write_verilog` signedness fix.  See:
-	#   - upstream PR (placeholder):     YosysHQ/yosys#TBD
-	#   - tracking branch on the fork:   v0.64-write-verilog-signed-port
+	# Tracking a fork branch (v0.65 + one local patch) until upstream
+	# Yosys merges the `write_verilog` signedness fix (still not upstream as of
+	# v0.65/v0.66 — the backend's dump_wire does not emit `signed`; the related
+	# upstream PR #5887 fixes the READ side only).  See:
+	#   - upstream PR (placeholder):     YosysHQ/yosys#TBD (write_verilog side)
+	#   - tracking branch on the fork:   v0.65-write-verilog-signed-port
 	#   - related downstream issue:      chipsalliance/synlig#2425
-	# When upstream merges and uhdm2rtlil bumps Yosys past v0.64,
-	# revert this to https://github.com/YosysHQ/yosys.git.
+	# Pinned to v0.65 (not v0.66) because yosys-slang — used by the 4-frontend
+	# matrix — supports up to v0.65 only.  When upstream merges the write-side fix
+	# and uhdm2rtlil bumps Yosys, revert this to https://github.com/YosysHQ/yosys.git.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Yosys frontend that converts SystemVerilog to RTLIL (Register Transfer Level Intermediate Language) via UHDM (Universal Hardware Data Model). The workflow is: SystemVerilog → Surelog → UHDM → UHDM Frontend → RTLIL → Yosys synthesis.
 
-The Yosys submodule is pinned at **v0.64** (`third_party/yosys`).
+The Yosys submodule is pinned at **v0.65** (`third_party/yosys`, on the fork's
+`v0.65-write-verilog-signed-port` branch = v0.65 + one local write_verilog
+signedness patch). Capped at v0.65 (not v0.66) because yosys-slang — used by the
+4-frontend matrix — supports up to v0.65 only.
 
 ## Build Commands
 


### PR DESCRIPTION
…g patch)

Move the pinned Yosys from v0.64 to v0.65, the highest release that is both stable AND supported by yosys-slang (the matrix's slang frontend caps at v0.65; v0.66 would break it).

The local write_verilog signedness patch is still required — v0.65's (and v0.66's) verilog_backend dump_wire still does not emit `signed` on wire/port declarations (upstream PR #5887 fixes only the read side).  Cherry-picked it cleanly onto v0.65; the submodule now tracks the fork branch `v0.65-write-verilog-signed-port` (d6b732e5b = v0.65 + the patch).

abc sub-submodule advances to v0.65's commit (5d51a5e42).  Plugin compiles clean against v0.65's RTLIL API (no source changes needed).  .gitmodules + CLAUDE.md updated to v0.65.