### PR TITLE
uhdm: memory element-range slice shift (MemorySlice)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5157,6 +5157,51 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
                 base = RTLIL::SigSpec(module->parameter_default_values.at(param_id));
                 log("      Resolved '%s' as parameter for part select (width=%d)\n",
                     base_signal_name.c_str(), base.size());
+            } else if (RTLIL::Wire* e0 =
+                           (name_map.count(base_signal_name + "[0]")
+                                ? name_map[base_signal_name + "[0]"]
+                                : module->wire(RTLIL::escape_id(base_signal_name + "[0]")))) {
+                // Element-array part-select: `mem[hi:lo]` where `mem` is an
+                // UNPACKED array split into per-element wires \mem[0]..\mem[N-1]
+                // (no flat \mem wire).  Resolve to the concatenation of the
+                // selected element wires (element `lo` at the LSB).  Both the LHS
+                // and RHS of `mem[N-1:1] <= mem[N-2:0]` take this path, so the
+                // element-wise shift lines up (MemorySlice).
+                (void)e0;
+                int el = -1, er = -1;
+                if (auto le = uhdm_part->Left_range()) {
+                    RTLIL::SigSpec s = import_expression(le, input_mapping);
+                    if (s.is_fully_const()) el = s.as_const().as_int();
+                }
+                if (auto re = uhdm_part->Right_range()) {
+                    RTLIL::SigSpec s = import_expression(re, input_mapping);
+                    if (s.is_fully_const()) er = s.as_const().as_int();
+                }
+                std::string gs = get_current_gen_scope();
+                auto elem_wire = [&](int i) -> RTLIL::Wire* {
+                    std::string en = base_signal_name + "[" + std::to_string(i) + "]";
+                    if (!gs.empty() && name_map.count(gs + "." + en)) return name_map[gs + "." + en];
+                    if (name_map.count(en)) return name_map[en];
+                    return module->wire(RTLIL::escape_id(en));
+                };
+                if (el >= 0 && er >= 0) {
+                    int lo = std::min(el, er), hi = std::max(el, er);
+                    RTLIL::SigSpec concat;
+                    bool ok = true;
+                    for (int i = lo; i <= hi; i++) {
+                        if (RTLIL::Wire* w = elem_wire(i)) concat.append(RTLIL::SigSpec(w));
+                        else { ok = false; break; }
+                    }
+                    if (ok && concat.size() > 0) {
+                        log("    part_select: element-array %s[%d:%d] → %d-bit concat\n",
+                            base_signal_name.c_str(), el, er, concat.size());
+                        return concat;
+                    }
+                }
+                std::string gen_scope = get_current_gen_scope();
+                log_warning("Base signal '%s' not found in module or generate scope %s\n",
+                    base_signal_name.c_str(), gen_scope.c_str());
+                return RTLIL::SigSpec();
             } else {
                 std::string gen_scope = get_current_gen_scope();
                 log_warning("Base signal '%s' not found in module or generate scope %s\n",

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -371,8 +371,48 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                             sig.name = std::string(part_sel->VpiName());
                         }
 
-                        signals.push_back(sig);
-                        log("extract_assigned_signals: Found assignment to part select of '%s'\n", sig.name.c_str());
+                        // Element-array part-select (`mem[hi:lo] <= ...` where
+                        // `mem` is an UNPACKED array split into per-element wires
+                        // \mem[0]..\mem[N-1]): register EACH selected element as
+                        // its own full-wire signal, so the always_ff lowering
+                        // gives each its own $0\ temp + sync update — the
+                        // import_part_select concat then remaps element-wise
+                        // (MemorySlice's shift `mem[N-1:1] <= mem[N-2:0]`).
+                        bool elem_array_handled = false;
+                        if (!sig.name.empty() &&
+                            (name_map.count(sig.name + "[0]") ||
+                             module->wire(RTLIL::escape_id(sig.name + "[0]")))) {
+                            int el = -1, er = -1;
+                            if (auto le = part_sel->Left_range()) {
+                                RTLIL::SigSpec s = import_expression(le);
+                                if (s.is_fully_const()) el = s.as_const().as_int();
+                            }
+                            if (auto re = part_sel->Right_range()) {
+                                RTLIL::SigSpec s = import_expression(re);
+                                if (s.is_fully_const()) er = s.as_const().as_int();
+                            }
+                            if (el >= 0 && er >= 0) {
+                                int lo = std::min(el, er), hi = std::max(el, er);
+                                for (int i = lo; i <= hi; i++) {
+                                    std::string en = sig.name + "[" + std::to_string(i) + "]";
+                                    if (name_map.count(en) ||
+                                        module->wire(RTLIL::escape_id(en))) {
+                                        AssignedSignal es;
+                                        es.name = en;
+                                        es.is_part_select = false;
+                                        es.lhs_expr = nullptr;
+                                        signals.push_back(es);
+                                    }
+                                }
+                                elem_array_handled = true;
+                                log("extract_assigned_signals: expanded element-array part-select '%s[%d:%d]'\n",
+                                    sig.name.c_str(), el, er);
+                            }
+                        }
+                        if (!elem_array_handled) {
+                            signals.push_back(sig);
+                            log("extract_assigned_signals: Found assignment to part select of '%s'\n", sig.name.c_str());
+                        }
                     } else if (lhs_expr->VpiType() == vpiBitSelect) {
                         // Handle bit selects like result[0] or memory[addr]
                         auto bit_sel = any_cast<const bit_select*>(lhs_expr);


### PR DESCRIPTION
`logic [3:0] mem[N-1:0]; always_ff @(posedge ck) begin mem[N-1:1] <= mem[N-2:0]; mem[0] <= sin; end` (a shift register through memory) left mem undriven — sout stuck at 0.  `mem` is split into per-element wires \mem[0]..\mem[N-1] with no flat \mem wire, and the element-RANGE part-select `mem[hi:lo]` was unhandled:

1. import_part_select: when the base has no flat wire but per-element wires exist, resolve `mem[hi:lo]` to the concatenation of the selected element wires (element lo at the LSB).  Both the LHS and RHS take this path, so the element-wise shift lines up.

2. extract_assigned_signals: a part-select LHS on such an element-array is expanded into one full-wire assigned signal PER element, so the always_ff lowering gives each its own $0\ temp + posedge sync update (the temp-wire machinery only handled single-wire LHS chunks, so previously only one element was retargeted and the rest were driven combinationally).

cosim PASS.  Full suite green: 652/653 (only CastStructArray), True failures: 0.