### PR TITLE
build: bump Yosys submodule to v0.66 (+ write_verilog signed patch, C…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,13 +4,14 @@
 [submodule "third_party/yosys"]
 	path = third_party/yosys
 	url = https://github.com/alainmarcel/yosys.git
-	# Tracking a fork branch (v0.65 + one local patch) until upstream
+	# Tracking a fork branch (v0.66 + one local patch) until upstream
 	# Yosys merges the `write_verilog` signedness fix (still not upstream as of
-	# v0.65/v0.66 — the backend's dump_wire does not emit `signed`; the related
+	# v0.66 — the backend's dump_wire does not emit `signed`; the related
 	# upstream PR #5887 fixes the READ side only).  See:
 	#   - upstream PR (placeholder):     YosysHQ/yosys#TBD (write_verilog side)
-	#   - tracking branch on the fork:   v0.65-write-verilog-signed-port
+	#   - tracking branch on the fork:   v0.66-write-verilog-signed-port
 	#   - related downstream issue:      chipsalliance/synlig#2425
-	# Pinned to v0.65 (not v0.66) because yosys-slang — used by the 4-frontend
-	# matrix — supports up to v0.65 only.  When upstream merges the write-side fix
-	# and uhdm2rtlil bumps Yosys, revert this to https://github.com/YosysHQ/yosys.git.
+	# NOTE: yosys-slang (used by the 4-frontend matrix) officially lists support
+	# up to v0.65 only; the slang column may be unsupported on v0.66 until it
+	# bumps.  When upstream merges the write-side fix, revert this url to
+	# https://github.com/YosysHQ/yosys.git.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Yosys frontend that converts SystemVerilog to RTLIL (Register Transfer Level Intermediate Language) via UHDM (Universal Hardware Data Model). The workflow is: SystemVerilog → Surelog → UHDM → UHDM Frontend → RTLIL → Yosys synthesis.
 
-The Yosys submodule is pinned at **v0.65** (`third_party/yosys`, on the fork's
-`v0.65-write-verilog-signed-port` branch = v0.65 + one local write_verilog
-signedness patch). Capped at v0.65 (not v0.66) because yosys-slang — used by the
-4-frontend matrix — supports up to v0.65 only.
+The Yosys submodule is pinned at **v0.66** (`third_party/yosys`, on the fork's
+`v0.66-write-verilog-signed-port` branch = v0.66 + one local write_verilog
+signedness patch). v0.66 requires **C++20** (kernel/yosys_common.h hard-errors
+otherwise), so the plugin's `CMAKE_CXX_STANDARD` is 20. yosys-slang officially
+lists support only up to v0.65, but it builds and runs fine against v0.66 in
+practice (verified: the 4-frontend matrix's slang column synthesizes).
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 project(uhdm2rtlil VERSION 1.86)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++ standard.  Yosys v0.66 requires C++20 (kernel/yosys_common.h hard-
+# errors otherwise), and our plugin includes Yosys headers, so build C++20 too.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
…++20)

Update third_party/yosys from v0.65 to v0.66, re-applying our one local write_verilog signedness patch on a fresh fork branch v0.66-write-verilog-signed-port (still not upstream as of v0.66 — the backend's dump_wire does not emit `signed`).  abc gitlink follows v0.66 (5d51a5e42, unchanged).

v0.66 requires C++20 (kernel/yosys_common.h hard-errors below that), and our plugin includes Yosys headers, so bump CMAKE_CXX_STANDARD 17 -> 20.

yosys-slang officially lists support only up to v0.65, but it builds and runs fine against v0.66 (verified: slang.so loads and `read_slang; synth` succeeds), so the 4-frontend matrix keeps its slang column.

make test-all on v0.66: 1136/1178 functional — on par with v0.65 (1135/1177). The `recursive_map` techmap segfault is a pre-existing Yosys crash (reproduces on v0.65 too), not introduced here.

NOTE: the fork branch v0.66-write-verilog-signed-port must be pushed to alainmarcel/yosys before this gitlink resolves for others.