### PR TITLE
ci: build with g++-11 (Yosys v0.66 requires C++20; g++-9 can't)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,17 @@ jobs:
         echo "PATH after: /opt/verilator-5.048/bin:$PATH"
         /opt/verilator-5.048/bin/verilator --version
 
-    - name: Setup GCC-9
+    - name: Setup GCC-11
       shell: bash
       run: |
-        # Install and setup gcc-9
-        sudo apt install -y g++-9
-        sudo ln -sf /usr/bin/g++-9 /usr/bin/g++
-        sudo ln -sf /usr/bin/gcc-9 /usr/bin/gcc
-        sudo ln -sf /usr/bin/gcov-9 /usr/bin/gcov
+        # Yosys v0.66 hard-requires C++20: its build passes `-std=c++20`, which
+        # g++-9 rejects ("unrecognized ... did you mean -std=c++2a").  Use g++-11
+        # (the locally-validated toolchain) so Yosys builds; Surelog/antlr4 still
+        # build at C++17 and the uhdm2rtlil plugin at C++20.
+        sudo apt install -y g++-11
+        sudo ln -sf /usr/bin/g++-11 /usr/bin/g++
+        sudo ln -sf /usr/bin/gcc-11 /usr/bin/gcc
+        sudo ln -sf /usr/bin/gcov-11 /usr/bin/gcov
     
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/frontend-matrix.yml
+++ b/.github/workflows/frontend-matrix.yml
@@ -74,7 +74,7 @@ jobs:
           build-essential cmake git python3 python3-pip pkg-config \
           libssl-dev zlib1g-dev libtcmalloc-minimal4 uuid-dev tcl-dev \
           libffi-dev libreadline-dev bison flex libfl-dev libunwind-dev \
-          libgoogle-perftools-dev ccache help2man unzip g++-9 g++-13
+          libgoogle-perftools-dev ccache help2man unzip g++-11 g++-13
 
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -88,9 +88,10 @@ jobs:
 
     - name: Build project (Surelog + Yosys + uhdm2rtlil plugin)
       run: |
-        sudo ln -sf /usr/bin/g++-9 /usr/bin/g++
-        sudo ln -sf /usr/bin/gcc-9 /usr/bin/gcc
-        sudo ln -sf /usr/bin/gcov-9 /usr/bin/gcov
+        # Yosys v0.66 requires C++20; g++-9 only offers -std=c++2a -> use g++-11.
+        sudo ln -sf /usr/bin/g++-11 /usr/bin/g++
+        sudo ln -sf /usr/bin/gcc-11 /usr/bin/gcc
+        sudo ln -sf /usr/bin/gcov-11 /usr/bin/gcov
         rm -rf build/CMakeCache.txt build/CMakeFiles/
         make -j4 CC="ccache gcc" CXX="ccache g++" CPU_CORES=4
 


### PR DESCRIPTION
CI pinned g++-9 for the Surelog+Yosys+plugin build, but Yosys v0.66 passes `-std=c++20` and g++-9 rejects it ("unrecognized command line option '-std=c++20'; did you mean '-std=c++2a'?") — failing at kernel/driver.o.  This is the actual cause of the post-bump CI build failure (not the antlr4 line in the parallel log, and not the CMakeLists scoping, which only governs the main cmake tree).

Bump both workflows' main build from g++-9 to g++-11 (the locally-validated toolchain — my clean build uses g++ 11.4).  g++-11 fully supports -std=c++20, so Yosys builds; Surelog/antlr4 still compile at C++17 and the uhdm2rtlil plugin at C++20.  g++-13 is kept where it was (yosys-slang's gcc>=11 requirement).