### PR TITLE
test: triage cosim-warning batch 1 (8 artefacts classified, 1 bug found)

### DIFF
--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -130,3 +130,15 @@
 #      undriven), assignment-pattern (self-checking asserts $stop Verilator).
 #  - DotRange: confirmed bug, tracked above (LHS struct-field var_select dropped).
 # ===========================================================================
+
+# FunctionWireAssignmentOnDeclaration — CONFIRMED real UHDM bug (triaged 2026-06).
+#   `function automatic logic [2:0] test(logic [2:0] in); logic [2:0] data = in;
+#    return data; endfunction  assign o = test(i);`  The output `o` is left
+#   UNDRIVEN (reads 0) — the function result never connects to o.  UHDM-only test
+#   (Yosys Verilog frontend build-fails), deterministic o=0 vs RTL => real bug.
+#   Routed through process_function_with_context/process_stmt_to_case: the begin
+#   block's local `data` is mapped to a `$blk_data` wire, but a SEPARATE `.data`
+#   wire is created and driven Sx, and after `opt` nothing drives `o`.  The
+#   declaration initializer `data = in` IS present as a vpiAssignment stmt in the
+#   begin block AND `data->Expr()` is null.  Fix needs the result-wire wiring in
+#   process_function_with_context to survive (deferred — non-trivial).

--- a/test/cosim_warnings_plan.md
+++ b/test/cosim_warnings_plan.md
@@ -18,15 +18,15 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [x] 2DFunctionArg — FIXED: `inline_func_body_comb` had NO `vpiReturn` case (return value dropped → X); also `var_select` ignored `input_mapping` for function params, and `elem_w` wasn't read from an `io_decl` typespec. Added all three. a=1, co-sim PASS.
 - [x] TypedefedFunctionArgument — FIXED by the same vpiReturn/var_select fix.
 - [x] CaseInside — FIXED: `case(x) inside` with a `[lo:hi]` range item — Surelog wraps the match-set in vpiInsideOp/vpiListOp, which import_case_stmt_comb returned empty for (first item became default -> y=01 always). Now expand inside-set members into equality compares; ranges expand to individual values.
-- [?] 1DUnpackedArray
+- [A] 1DUnpackedArray — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [B] 2DParameterOfInstance — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [B] 2DUnpackedFunctionArgument — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
-- [?] AssignSizeOfVar
+- [A] AssignSizeOfVar — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [B] BitSelectOfParameterPassedToSubmoduleInGenForOfSubmodule — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [x] BitSelectPartSelectInFunction — FIXED: packed multi-dim local element/part-select read+write in const-eval (register inner_w; bit_select returns full element; var_select+part_select range read/write; io_decl typespec), AND a cast bug — `int'(2'b11)` self-replicated all-ones as if a fill literal; now only UNSIZED (`'1`, VpiSize==-1) literals self-replicate, sized constants zero/sign-extend.
 - [A] ConcatWidth — ARTIFACT: miter EQUIVALENT; co-sim diff is uninitialised `counter_upd` X-init.
 - [A] ConstSizes — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); classified in sim_equiv_analyzed.txt
-- [?] ContinueNested
+- [A] ContinueNested — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [x] DotMultirange — FIXED: read `g[i][j]` on a packed array of structs (`status_t [1:0][1:0]`). Dims live on packed_array_var.Ranges() with a struct (not logic) element, so the logic packed-multidim path missed it; added a sibling using Ranges() + struct width as the leaf. cosim PASS.
 - [B] DotRange — CONFIRMED REAL UHDM BUG (UHDM-vs-RTL FAIL, Verilog PASS), but DEFERRED. `bar.l[2][1] = foo.k[2]` on packed structs is dropped entirely (no assignment emitted). A first fix (LHS hier_path var_select on a struct-field typespec_member → bit i*inner_w+j; RHS bit_select falling back to the base wire) made it produce the exact-correct `bar[15]=foo[2]` and pass co-sim, BUT regressed 6 multi-field/3D struct tests (struct_3d_packed_array, multidim_hier_path7/8, svtypes_struct_array, struct_unpacked_array_member, struct_little_endian_bit_array) because it ignores the field's OFFSET inside a multi-field struct and intercepts cases other handlers handle. Reverted. Needs offset-aware handling that only fires where existing handlers don't.
 - [A] EnumBases — ARTEFACT (sim-only/undriven/intentional-X/self-checking); classified in sim_equiv_analyzed + classification override.
@@ -35,7 +35,7 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [B] FunctionOutputArgument — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [x] FunctionParam — FIXED: unpacked-parameter-array element read in const-eval (`return X[0]`). Resolve value from module_inst Param_assigns; operands are in ascending index order.
 - [x] SelectGivenBySelectOnParameterInFunction — FIXED (same batch): param-array element + packed-local var_select (`c[idx][0]`) + function-local var initializer in const-eval + variable-as-LHS assignment.
-- [?] FunctionWireAssignmentOnDeclaration
+- [B] FunctionWireAssignmentOnDeclaration — CONFIRMED real UHDM bug: a return-based function with a declaration-initialized local (`logic [2:0] data = in; return data;`) leaves the output `o` UNDRIVEN (o=0). The function result never connects to o in process_function_with_context (conflicting block-local `data` wires). See cosim_uhdm_bugs.txt.
 - [?] FunctionWithOverriddenParameter
 - [x] GenIfInside — RESOLVED by observability restructure (widen ports / expose param / non-zero output); co-sim now PASS.
 - [B] GetC — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
@@ -51,7 +51,7 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [B] MemorySlice — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [x] ModuleInstantiationAndIndirectParams — RESOLVED by observability restructure (widen ports / expose param / non-zero output); co-sim now PASS.
 - [B] MultiAssignmentPatternOfConcat — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
-- [?] MultiplePrints
+- [A] MultiplePrints — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [?] NestedForLoops
 - [B] NestedPatternPassedAsPort — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [x] OneArithShift — RESOLVED by observability restructure (widen ports / expose param / non-zero output); co-sim now PASS.
@@ -80,7 +80,7 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [?] StructLocalParam
 - [B] StructParameterInitializedWithPatternAndReferenced — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [?] SumOfParameters
-- [?] SystemFunctions
+- [A] SystemFunctions — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [B] TaskOutputArgument — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [A] TaskReturn — ARTEFACT (sim-only/undriven/intentional-X/self-checking); classified in sim_equiv_analyzed + classification override.
 - [?] TypedefInModule
@@ -93,8 +93,8 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [A] assignment-pattern — ARTEFACT (sim-only/undriven/intentional-X/self-checking); classified in sim_equiv_analyzed + classification override.
 - [?] case_expr_extend
 - [?] case_expr_query
-- [?] conditional_if
-- [?] const_fold_func
+- [A] conditional_if — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
+- [A] const_fold_func — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [?] counter_unbased
 - [?] fmt_always_comb
 - [A] fsm_using_always — ARTEFACT (miter EQUIVALENT, UHDM==Verilog); X-init co-sim diff; classified
@@ -113,7 +113,7 @@ Status key: `[ ]` todo · `[B]` bug-fixing · `[x]` fixed · `[A]` artifact-clas
 - [B] rsp_gen_minimal — CONFIRMED real UHDM bug (determinism pass): combinational, deterministic co-sim mismatch (UHDM netlist computes wrong value vs Verilator RTL). See cosim_uhdm_bugs.txt.
 - [?] signed_ext_case
 - [?] simple_forloops
-- [?] simple_function
+- [A] simple_function — ARTEFACT (miter EQUIVALENT or UHDM-vs-RTL PASS / vacuous / skip); classified in sim_equiv_analyzed.txt
 - [?] simple_generate
 - [?] simple_hierarchy
 - [?] simple_memory

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -502,3 +502,36 @@ Test: assignment-pattern
 
 
 
+
+Test: 1DUnpackedArray
+    Artefact: SAT miter proves UHDM == Verilog (bounded from reset) and both
+    Verilator co-sims (UHDM-vs-RTL, Verilog-vs-RTL) PASS.  Any residual co-sim
+    warning is Verilator-vs-synth noise, not a frontend divergence.
+
+Test: AssignSizeOfVar
+    Artefact: SAT miter EQUIVALENT (UHDM == Verilog); the co-sim diff is a
+    Verilator-vs-synth X-init artefact, not a frontend bug.
+
+Test: SystemFunctions
+    Artefact: SAT miter EQUIVALENT (UHDM == Verilog); Verilator-vs-synth diff.
+
+Test: const_fold_func
+    Artefact: SAT miter EQUIVALENT (UHDM == Verilog); Verilator-vs-synth diff.
+
+Test: simple_function
+    Artefact: SAT miter EQUIVALENT (UHDM == Verilog); Verilator-vs-synth diff.
+
+Test: ContinueNested
+    Artefact: UHDM-only test (the Yosys Verilog frontend build-fails, so there is
+    no miter reference), but the UHDM-vs-RTL Verilator co-sim PASSES — the UHDM
+    netlist matches the behavioural RTL exactly.  Not a divergence.
+
+Test: conditional_if
+    Artefact: the co-sim is SKIPPED (no observable output / not Verilator-
+    buildable), so there is no RTL-vs-netlist divergence to report.
+
+Test: MultiplePrints
+    Artefact: a `$display`/`$write` test with no registered outputs — the co-sim
+    is VACUOUS (outputs all-zero every cycle, bits_ever_set=0), so the "mismatch"
+    is not an observable divergence.  The print side-effects are validated by the
+    synth flow, not by output comparison.


### PR DESCRIPTION
Worked cosim_warnings_plan.md with triage_cosim.py (SAT miter + two-cosim adjudication).  Batch of 10 `[?]` tests:

ARTEFACTS (classified in sim_equiv_analyzed.txt, marked [A]):
  1DUnpackedArray, AssignSizeOfVar, SystemFunctions, const_fold_func,
  simple_function   — SAT miter EQUIVALENT (UHDM == Verilog)
  ContinueNested    — UHDM-only; UHDM-vs-RTL co-sim PASSES (matches RTL)
  conditional_if    — co-sim SKIP (no observable output)
  MultiplePrints    — $display test, VACUOUS co-sim (all-zero outputs)

REAL BUG (marked [B], documented in cosim_uhdm_bugs.txt):
  FunctionWireAssignmentOnDeclaration — a return-based function with a
  declaration-initialized local (`logic [2:0] data = in; return data;`) leaves
  the output `o` UNDRIVEN (o=0).  UHDM-only, deterministic => real bug; the
  result wire never connects to o in process_function_with_context.  Deferred
  (non-trivial wiring fix).

EnumFirstInInitial left `[?]` (UHDM-vs-RTL FAIL, needs more triage).