### PR TITLE
uhdm: create memory for array_var register files in generate scopes

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2497,6 +2497,23 @@ void UhdmImporter::import_gen_scope(const gen_scope* uhdm_scope) {
             // Variables can be logic_var or other types, we need to handle them
             // For now, create a wire for each variable
             std::string var_name = std::string(var->VpiName());
+
+            // Generate-scope array variable that is a memory — e.g. a register
+            // file `logic [XLEN-1:0] gpr [0:2**AW-1]` inside a generate `else`
+            // branch (rp32 r5p_gpr_1r1w).  The module-level path creates an
+            // RTLIL memory via create_memory_from_array; the gen-scope path must
+            // too, otherwise the whole array collapses to a 1-bit wire and every
+            // read returns ~0.  Registered under the bare name so the always_ff
+            // memory-write scan and the bit-select read (which use the bare
+            // signal name) resolve to it.
+            if (var->UhdmType() == uhdmarray_var) {
+                if (auto av = any_cast<const UHDM::array_var*>(var)) {
+                    if (is_memory_array(av)) {
+                        create_memory_from_array(av);
+                        continue;
+                    }
+                }
+            }
             std::string full_gen_path = get_current_gen_scope();
             std::string hierarchical_name = full_gen_path + "." + var_name;
             int width = get_width(var, current_instance);

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -182,3 +182,12 @@ CastStructArray
 # the Verilator co-sim is N/A and equiv_induct has nothing meaningful to prove;
 # it reports an Induct-Formal failure.  Kept here (cannot be cosim-adjudicated).
 svtypes/array_assign.sv
+
+# ---------------------------------------------------------------------------
+# Imported rp32 RISC-V core (see test/rp32_STATUS.md).  r5p_mouse is the full
+# CPU core: it instantiates submodules that are NOT in its per-module project.f
+# (the generator wires up package deps, not module-instantiation deps), so the
+# UHDM flow has undefined blackboxes and produces no top netlist.  Belongs to
+# the complete-design phase (TCB submodule + cores + SoC tops), not the per-
+# module sweep — listed here until the full design is wired up.
+rp32_r5p_mouse

--- a/test/gpr_genscope_repro/dut.sv
+++ b/test/gpr_genscope_repro/dut.sv
@@ -1,0 +1,31 @@
+// Minimal regression for generate-scope register-file memory inference.
+//
+// A `logic [XLEN-1:0] mem [0:2**AW-1]` array declared inside a generate block
+// (here the `else` branch) used to be imported by the UHDM frontend as a single
+// 1-bit wire — both the packed element width (XLEN) and the unpacked dimension
+// (2**AW) were dropped — so every read returned ~0.  This reproduces the rp32
+// r5p_gpr_1r1w bug in isolation: the gen-scope variable loop must create an
+// RTLIL memory (like the module-level path) for an array_var that is a memory.
+module gpr_genscope_repro #(
+  parameter AW   = 5,
+  parameter XLEN = 32,
+  parameter SEL  = 0   // selects the generate branch
+)(
+  input  logic            clk,
+  input  logic            wen,
+  input  logic [AW-1:0]   a_rd,
+  input  logic [AW-1:0]   a_rs,
+  input  logic [XLEN-1:0] d_rd,
+  output logic [XLEN-1:0] d_rs
+);
+generate
+if (SEL == 1) begin: gen_alt
+  assign d_rs = '0;
+end
+else begin: gen_default
+  logic [XLEN-1:0] mem [0:2**AW-1];
+  always_ff @(posedge clk) if (wen) mem[a_rd] <= d_rd;
+  assign d_rs = mem[a_rs];
+end
+endgenerate
+endmodule

--- a/test/rp32_STATUS.md
+++ b/test/rp32_STATUS.md
@@ -20,7 +20,7 @@ compat fixes in test/rp32/.
 | r5p_bru      | ✅        | ✅ PASS          | branch unit — clean |
 | r5p_alu      | ✅        | ⚠ mismatch       | `dec` is a 306-bit decoded-instruction struct port; random bits = mostly INVALID instructions, RTL emits default while netlist computes from operands (README X-prop caveat) — needs constrained-valid stimulus |
 | r5p_wbu      | ✅        | ⚠ mismatch       | same struct-port stimulus issue (`dec` port) |
-| r5p_gpr_1r1w | ✅        | ❌ mismatch       | **REAL bug candidate**: register file, FLAT ports (valid stimulus); `d_rs` read-data reads 0 in the UHDM netlist where RTL reads back the written word — the async-read register-file inference is mis-synthesised. To triage/fix. |
+| r5p_gpr_1r1w | ✅        | ✅ PASS          | **FIXED** — was a real bug: the `logic [XLEN-1:0] gpr [0:2**AW-1]` register file is in a generate `else` branch, and the gen-scope variable import created a 1-bit wire instead of a memory (both dims dropped). Now creates an RTLIL memory; cosim PASSES. Regression guard: test/gpr_genscope_repro. |
 | r5p_csr      | ✅        | ⏭ skip           | co-sim not applicable (investigate observability) |
 | r5p_mdu      | ✅        | ⏭ skip           | multiply/divide — co-sim skip (investigate) |
 | r5p_mouse    | ❌        | —                | full CPU core; uhdm synth fails — instantiates submodules not in the file list (belongs to the complete-design phase) |


### PR DESCRIPTION
A register-file array declared inside a generate block — e.g. rp32 r5p_gpr_1r1w's `logic [XLEN-1:0] gpr [0:2**AW-1]` in a generate `else` branch — was imported by `import_gen_scope` as a single 1-bit wire: the gen-scope variable loop fell through to `create_wire(get_width(var))`, dropping both the packed element width (XLEN) and the unpacked dimension (2**AW).  The async read `gpr[a_rs]` then became a `$shiftx` of width 1, so every read returned ~0 and `d_rs[XLEN-1:1]` was tied low.

The module-level path already handles this via `is_memory_array` + `create_memory_from_array`; the gen-scope variable loop now does the same for an `array_var` that is a memory.  `create_memory_from_array` resolves XLEN/AW correctly (width=32, size=32) and registers the memory under the bare name, so the existing always_ff `$memwr` scan and the bit-select `$memrd` read both resolve to it.

The parameters were already sensible (XLEN=32, AW=5 elaborate correctly; verified `-top`/`-P` change nothing) — this was purely a frontend gap.

Result: rp32_r5p_gpr_1r1w now synthesizes a 32x32 memory and the Verilator co-sim PASSES (was: d_rs reads 0).  Minimal regression guard added in test/gpr_genscope_repro (full formal-equiv + co-sim PASS).  Full internal regression green except the pre-existing rp32_r5p_mouse (core needs submodules — now listed in failing_tests.txt for the complete-design phase).