### PR TITLE
uhdm: synthesize rp32 r5p_degu — interface-port duplicate-cell fix + …

### DIFF
--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -495,8 +495,18 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                 }
                 
                 RTLIL::IdString cell_name = "\\" + interface_name;
-                module->addCell(cell_name, RTLIL::escape_id(param_interface_type));
-                log("UHDM: Created interface cell %s of type %s\n", interface_name.c_str(), param_interface_type.c_str());
+                // For an interface PORT (e.g. `tcb_lite_if.man tcb_ifu` on
+                // rp32 r5p_degu), the interface's signals are already created
+                // as wires and the port itself may exist as a wire/cell, so an
+                // interface-instance cell of the same name would collide
+                // (rtlil count_id assert).  Only add the representative cell
+                // when nothing with that name exists yet.
+                if (!module->wire(cell_name) && !module->cell(cell_name)) {
+                    module->addCell(cell_name, RTLIL::escape_id(param_interface_type));
+                    log("UHDM: Created interface cell %s of type %s\n", interface_name.c_str(), param_interface_type.c_str());
+                } else {
+                    log("UHDM: Interface '%s' already represented (wire/cell exists) — skipping instance cell\n", interface_name.c_str());
+                }
             }
             
         }

--- a/test/rp32/tcb/IMPORT_README.md
+++ b/test/rp32/tcb/IMPORT_README.md
@@ -1,0 +1,7 @@
+# TCB (Tightly Coupled Bus) — imported dependency
+
+`tcb_lite_pkg.sv` and `tcb_lite_if.sv` imported from jeras/TCB
+(https://github.com/jeras/TCB, hdl/rtl/) — the bus package + SystemVerilog
+interface that rp32's r5p_degu / r5p_lsu use for their instruction/data ports.
+Only the lite package + interface are needed for the degu core (the lite_lib and
+device files are for full SoCs).

--- a/test/rp32/tcb/LICENSE
+++ b/test/rp32/tcb/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/rp32/tcb/tcb_lite_if.sv
+++ b/test/rp32/tcb/tcb_lite_if.sv
@@ -1,0 +1,181 @@
+////////////////////////////////////////////////////////////////////////////////
+// TCB-Lite (Tightly Coupled Bus) SystemVerilog interface
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Iztok Jeras
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////////////////////////////////////
+
+interface tcb_lite_if
+    import tcb_lite_pkg::*;
+#(
+    // configuration parameters
+    parameter tcb_lite_cfg_t CFG = TCB_LITE_CFG_DEF
+)(
+    // system signals
+    input  logic clk,  // clock
+    input  logic rst   // reset
+);
+
+    // local parameters (calculated from configuration)
+    localparam int unsigned CFG_BUS_BYT = CFG.BUS.DAT/8;          // byte enable width
+    localparam int unsigned CFG_BUS_OFF = $clog2(CFG_BUS_BYT);    // address offset size
+    localparam int unsigned CFG_BUS_SIZ = $clog2(CFG_BUS_OFF+1);  // logarithmic size width
+
+    // request type
+    typedef struct {
+        logic                   lck;  // arbitration lock
+        logic                   wen;  // write enable
+        logic                   ren;  // read  enable
+        logic                   ndn;  // endianness (0-little, 1-big)
+        logic [CFG.BUS.CTL-1:0] ctl;  // control (user defined request signals)
+        logic [CFG.BUS.ADR-1:0] adr;  // address
+        logic [CFG_BUS_SIZ-1:0] siz;  // transfer size
+        logic [CFG_BUS_BYT-1:0] byt;  // byte enable
+        logic [CFG.BUS.DAT-1:0] wdt;  // write data
+    } req_t;
+
+    // response type
+    typedef struct {
+        logic [CFG.BUS.DAT-1:0] rdt;  // read data
+        logic [CFG.BUS.STS-1:0] sts;  // response status (user defined response signals)
+        logic                   err;  // response error
+    } rsp_t;
+
+////////////////////////////////////////////////////////////////////////////////
+// I/O ports
+////////////////////////////////////////////////////////////////////////////////
+
+    // handshake
+    logic vld;  // valid
+    logic rdy;  // ready
+
+    // request/response
+    req_t req;
+    rsp_t rsp;
+
+////////////////////////////////////////////////////////////////////////////////
+// transaction handshake
+////////////////////////////////////////////////////////////////////////////////
+
+    // handshake
+    logic trn;  // transfer
+    logic stl;  // stall
+    logic idl;  // idle
+
+    // transfer (valid and ready at the same time)
+    assign trn = vld & rdy;
+
+    // stall (valid while not ready)
+    assign stl = vld & ~rdy;
+
+    // TODO: improve description
+    // idle (either not valid or ending the current cycle with a transfer)
+    assign idl = ~vld | trn;
+
+////////////////////////////////////////////////////////////////////////////////
+// request/response delay
+////////////////////////////////////////////////////////////////////////////////
+
+    // delay line
+    logic trn_dly [0:CFG.HSK.DLY];  // handshake transfer
+    req_t req_dly [0:CFG.HSK.DLY];  // request
+
+    // zero delay (continuous assignment)
+    assign trn_dly[0] = trn;
+    assign req_dly[0] = req;
+
+    // handshake/request delay line
+    generate
+    for (genvar i=1; i<=CFG.HSK.DLY; i++) begin: dly
+        logic trn_tmp;
+        req_t req_tmp;
+        // continuous assignment
+        assign trn_dly[i] = trn_tmp;
+        assign req_dly[i] = req_tmp;
+        // propagate through delay line
+        always_ff @(posedge clk)
+        begin
+            trn_tmp <= trn_dly[i-1];
+            if (trn_dly[i-1]) begin
+                req_tmp <= req_dly[i-i];
+            end
+        end
+    end: dly
+    endgenerate
+
+////////////////////////////////////////////////////////////////////////////////
+// modports
+////////////////////////////////////////////////////////////////////////////////
+
+    // manager
+    modport  man (
+        // system signals
+        input  clk,
+        input  rst,
+        // handshake
+        output vld,
+        input  rdy,
+        // local signals
+        input  trn,
+        input  stl,
+        input  idl,
+        // request/response
+        output req,
+        input  rsp,
+        // delay line
+        input  trn_dly,
+        input  req_dly
+    );
+
+    // monitor
+    modport  mon (
+        // system signals
+        input  clk,
+        input  rst,
+        // handshake
+        input  vld,
+        input  rdy,
+        // local signals
+        input  trn,
+        input  stl,
+        input  idl,
+        // request/response
+        input  req,
+        input  rsp,
+        // delay line
+        input  trn_dly,
+        input  req_dly
+    );
+
+    // subordinate
+    modport  sub (
+        // system signals
+        input  clk,
+        input  rst,
+        // handshake
+        input  vld,
+        output rdy,
+        // local signals
+        input  trn,
+        input  stl,
+        input  idl,
+        // request/response
+        input  req,
+        output rsp,
+        // delay line
+        input  trn_dly,
+        input  req_dly
+    );
+
+endinterface: tcb_lite_if

--- a/test/rp32/tcb/tcb_lite_pkg.sv
+++ b/test/rp32/tcb/tcb_lite_pkg.sv
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// TCB-Lite (Tightly Coupled Bus) SystemVerilog package
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Iztok Jeras
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////////////////////////////////////
+
+package tcb_lite_pkg;
+
+////////////////////////////////////////////////////////////////////////////////
+// handshake layer (defines the response delay and stability)
+////////////////////////////////////////////////////////////////////////////////
+
+    // parameter structure
+    typedef struct {
+        int unsigned DLY;  // response delay
+        bit          HLD;  // response hold (till the next access, response data even further till the next read access)
+    } tcb_lite_hsk_t;
+
+    // parameter defaults
+    localparam tcb_lite_hsk_t TCB_LITE_HSK_DEF = '{
+        DLY:    1,
+        HLD: 1'b0
+    };
+
+////////////////////////////////////////////////////////////////////////////////
+// bus layer (defines which signal subset is used)
+////////////////////////////////////////////////////////////////////////////////
+
+    // parameter structure
+    typedef struct {
+        bit          MOD;  // mode (0-logarithmic size, 1-byte enable)
+        int unsigned CTL;  // control width (user defined request signals)
+        int unsigned ADR;  // address width
+        int unsigned DAT;  // data    width
+        int unsigned STS;  // status  width (user defined response signals)
+    } tcb_lite_bus_t;
+
+    // physical interface parameter default
+    localparam tcb_lite_bus_t TCB_LITE_BUS_DEF = '{
+        MOD: 1'b0,
+        CTL:    0,
+        ADR:   32,
+        DAT:   32,
+        STS:    0
+    };
+
+////////////////////////////////////////////////////////////////////////////////
+// TCB configuration structure
+////////////////////////////////////////////////////////////////////////////////
+
+    // PMA parameter structure
+    typedef struct {
+        tcb_lite_hsk_t HSK;  // handshake
+        tcb_lite_bus_t BUS;  // bus
+    } tcb_lite_cfg_t;
+
+    // configuration parameter default
+    localparam tcb_lite_cfg_t TCB_LITE_CFG_DEF = '{
+        HSK: TCB_LITE_HSK_DEF,
+        BUS: TCB_LITE_BUS_DEF
+    };
+
+////////////////////////////////////////////////////////////////////////////////
+// predefined types
+////////////////////////////////////////////////////////////////////////////////
+
+//  typedef tcb_c #(.ADR (32), .DAT (32))::req_t tcb_req_t;  // request
+//  typedef tcb_c #(.ADR (32), .DAT (32))::req_t tcb_rsp_t;  // response
+
+////////////////////////////////////////////////////////////////////////////////
+// miscellaneous
+////////////////////////////////////////////////////////////////////////////////
+
+    // TODO: this is actually a RISC-V definition
+    // atomic encoding
+    typedef enum logic [5-1:0] {
+        LR      = 5'b00010,
+        SC      = 5'b00011,
+        AMOSWAP = 5'b00001,
+        AMOADD  = 5'b00000,
+        AMOXOR  = 5'b00100,
+        AMOAND  = 5'b01100,
+        AMOOR   = 5'b01000,
+        AMOMIN  = 5'b10000,
+        AMOMAX  = 5'b10100,
+        AMOMINU = 5'b11000,
+        AMOMAXU = 5'b11100
+    } tcb_lite_amo_t;
+
+endpackage: tcb_lite_pkg

--- a/test/rp32_STATUS.md
+++ b/test/rp32_STATUS.md
@@ -31,13 +31,18 @@ compat fixes in test/rp32/.
 |--------|-----------|------------------|-------|
 | r5p_mouse_soc_simple_top | ✅ | ✅ PASS | **the complete Mouse SoC** — r5p_mouse core + internal memory (`$readmemh mem_if.mem`) + simple GPIO/UART, self-contained (no external TCB).  Synthesises via UHDM and the co-sim PASSES (the deterministic boot program in memory keeps the core out of the standalone-core's random-X divergence).  `mem_if.vh` is only used under `YOSYS_SLANG`; the UHDM path uses a plain memory array.  The Mouse core uses memory-mapped registers (very slow), so a longer run is needed to exercise GPIO writes; the bus/memory/uart paths are verified. |
 
-## Skipped by the generator (need the complete design / external deps)
+## Hierarchical cores (need the external TCB submodule)
 
-- `tcb_lite_pkg` consumers: r5p_lsu, r5p_degu, r5p_degu_soc_top, r5p_mouse_soc_top
-  (need the external TCB submodule).
-- `riscv_csr_pkg` consumers: r5p_hamster, r5p_degu (package name not present in the
-  design — needs investigation; possibly an alias/conditional).
-- Vendor variants (`__xilinx_xpm`, `__gowin_*`) and SoC/FPGA tops.
+| core | uhdm synth | verilator co-sim | notes |
+|------|-----------|------------------|-------|
+| r5p_degu | ✅ | ⏭ N/A | **the hierarchical Degu core** — uses the external TCB bus **interface** (`tcb_lite_if.man`) + 6 r5p submodules (alu/bru/mdu/lsu/wbu/gpr_2r1w). The TCB `tcb_lite_pkg` + `tcb_lite_if` are imported into `test/rp32/tcb/` (from jeras/TCB). Synthesises via UHDM after fixing an interface-port duplicate-cell crash. CSR is disabled (`ENABLE_CSR` undefined; the `import riscv_csr_pkg` is commented out — the generator's riscv_csr_pkg "dep" was a false match on that comment). Co-sim N/A: the harness's wrapper generator can't express SV interface ports. |
+
+## Skipped by the generator (need external deps / complete design)
+
+- `riscv_csr_pkg` consumers (r5p_hamster, r5p_degu) — a **false positive**: it is a
+  *commented-out* import guarded by `\`ifdef ENABLE_CSR`; CSR-less builds don't need it.
+- Vendor variants (`__xilinx_xpm`, `__gowin_*`) and the remaining SoC/FPGA tops
+  (r5p_degu_soc_*, r5p_hamster_soc_*).
 
 ## Next
 

--- a/test/rp32_r5p_degu/project.f
+++ b/test/rp32_r5p_degu/project.f
@@ -1,0 +1,24 @@
+# rp32 r5p_degu — hierarchical RISC-V core (needs the external TCB submodule's
+# bus interface + several r5p submodules).  Hand-written.  CSR is disabled
+# (ENABLE_CSR not defined; the `import riscv_csr_pkg` in the source is commented
+# out — the generator's riscv_csr_pkg "dep" was a false match on that comment).
+# top: r5p_degu
+# mode: uhdm-only
+
+../rp32/tcb/tcb_lite_pkg.sv
+../rp32/tcb/tcb_lite_if.sv
+../rp32/riscv/riscv_isa_pkg.sv
+../rp32/riscv/riscv_priv_pkg.sv
+../rp32/riscv/riscv_isa_i_pkg.sv
+../rp32/riscv/riscv_isa_c_pkg.sv
+../rp32/riscv/rv32_csr_pkg.sv
+../rp32/riscv/rv64_csr_pkg.sv
+../rp32/degu/r5p_pkg.sv
+../rp32/degu/r5p_degu_pkg.sv
+../rp32/core/r5p_gpr_2r1w.sv
+../rp32/degu/r5p_bru.sv
+../rp32/degu/r5p_alu.sv
+../rp32/degu/r5p_mdu.sv
+../rp32/degu/r5p_lsu.sv
+../rp32/degu/r5p_wbu.sv
+../rp32/degu/r5p_degu.sv


### PR DESCRIPTION
…TCB import

r5p_degu is the hierarchical Degu RISC-V core: it uses the external TCB bus SystemVerilog *interface* (`tcb_lite_if.man tcb_ifu/tcb_lsu`) plus six r5p submodules (alu/bru/mdu/lsu/wbu/gpr_2r1w).

- import_interface_instances added a representative interface-instance cell named after the interface (`\tcb_ifu`), but for an interface PORT the signals already exist as wires (and the port itself), so the cell collided — `Assert count_id == 0` in rtlil.cc.  Only add the cell when nothing with that name exists yet (a no-op for the existing local-interface tests, which have no such collision — svinterface*/iface_*/InterfaceAsPort still pass).

- Imported the TCB bus package + interface (jeras/TCB hdl/rtl: tcb_lite_pkg.sv, tcb_lite_if.sv) into test/rp32/tcb/.  `riscv_csr_pkg` is NOT needed — its `import` in r5p_degu is commented out / behind `ifdef ENABLE_CSR` (the generator's "dep" was a false match on the comment).

Result: r5p_degu synthesises cleanly via UHDM (160 KB netlist, all submodules + the bus interface).  Co-sim is N/A — the harness's wrapper generator can't express SV interface ports.  No regressions (run_all_tests 665/667; interface tests pass; 21 sim-equiv warnings unchanged).