### PR TITLE
uhdm: synthesize rp32 r5p_hamster — drop empty string params from par…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1455,7 +1455,20 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
                         val_str = val_str.substr(colon_pos + 1);
                     }
 
-                    if (!val_str.empty() && value_type != "STRING") {
+                    if (value_type == "STRING") {
+                        // Include non-empty string params (matching
+                        // import_module's `\name="val"`), but SKIP empty ones
+                        // (e.g. CHIP=""): the canonical module-def name omits an
+                        // empty string param, so including it here made the
+                        // instance cell type (e.g. r5p_hamster's `gpr`) differ
+                        // from the module definition by a trailing `\CHIP=""`,
+                        // turning the cell into a blackbox so synth picked the
+                        // wrong top.  Keep both namings identical.
+                        if (!val_str.empty()) {
+                            param_string += "\\" + param_name + "=\"" + val_str + "\"";
+                            has_params = true;
+                        }
+                    } else if (!val_str.empty()) {
                         param_string += "\\" + param_name + "=s32'";
                         // Determine numeric base from type prefix
                         int base = 10;

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -930,7 +930,14 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
 
                                 // Convert to Yosys format
                                 if (is_string) {
-                                    cell_type += "\\" + param_name + "=\"" + value_to_use + "\"";
+                                    // Skip empty string params (e.g. CHIP=""):
+                                    // import_module's name builder guards on a
+                                    // non-empty value and drops them, so a cell
+                                    // type that kept `\CHIP=""` would not match
+                                    // the module definition (blackbox → wrong
+                                    // synth top, e.g. rp32 r5p_hamster's gpr).
+                                    if (!value_to_use.empty())
+                                        cell_type += "\\" + param_name + "=\"" + value_to_use + "\"";
                                 } else {
                                     cell_type += "\\" + param_name + "=s32'";
                                     // Strip type prefix and determine base

--- a/test/rp32_STATUS.md
+++ b/test/rp32_STATUS.md
@@ -31,11 +31,12 @@ compat fixes in test/rp32/.
 |--------|-----------|------------------|-------|
 | r5p_mouse_soc_simple_top | ✅ | ✅ PASS | **the complete Mouse SoC** — r5p_mouse core + internal memory (`$readmemh mem_if.mem`) + simple GPIO/UART, self-contained (no external TCB).  Synthesises via UHDM and the co-sim PASSES (the deterministic boot program in memory keeps the core out of the standalone-core's random-X divergence).  `mem_if.vh` is only used under `YOSYS_SLANG`; the UHDM path uses a plain memory array.  The Mouse core uses memory-mapped registers (very slow), so a longer run is needed to exercise GPIO writes; the bus/memory/uart paths are verified. |
 
-## Hierarchical cores (need the external TCB submodule)
+## Hierarchical cores
 
 | core | uhdm synth | verilator co-sim | notes |
 |------|-----------|------------------|-------|
 | r5p_degu | ✅ | ⏭ N/A | **the hierarchical Degu core** — uses the external TCB bus **interface** (`tcb_lite_if.man`) + 6 r5p submodules (alu/bru/mdu/lsu/wbu/gpr_2r1w). The TCB `tcb_lite_pkg` + `tcb_lite_if` are imported into `test/rp32/tcb/` (from jeras/TCB). Synthesises via UHDM after fixing an interface-port duplicate-cell crash. CSR is disabled (`ENABLE_CSR` undefined; the `import riscv_csr_pkg` is commented out — the generator's riscv_csr_pkg "dep" was a false match on that comment). Co-sim N/A: the harness's wrapper generator can't express SV interface ports. |
+| r5p_hamster | ✅ | ⏭ N/A | **the hierarchical Hamster core** — a custom bus (no TCB) + the `r5p_gpr_1r1w` register-file submodule. Synthesises via UHDM after fixing a `$paramod` naming bug: the gpr instance's cell type carried an empty string param (`\CHIP=""`) that the module-def name dropped, so the instance was a blackbox and synth picked the standalone gpr as top. Co-sim N/A: Verilator can't compile the source (`r5p_hamster.sv:575` — `{32{idu_buf.alu.fn7[5]}}`, a replicate of a nested struct-field bit-select, VOIDDTYPE), which UHDM handles. |
 
 ## Skipped by the generator (need external deps / complete design)
 
@@ -43,6 +44,8 @@ compat fixes in test/rp32/.
   *commented-out* import guarded by `\`ifdef ENABLE_CSR`; CSR-less builds don't need it.
 - Vendor variants (`__xilinx_xpm`, `__gowin_*`) and the remaining SoC/FPGA tops
   (r5p_degu_soc_*, r5p_hamster_soc_*).
+
+All three r5p cores (Mouse, Degu, Hamster) now synthesise via UHDM.
 
 ## Next
 

--- a/test/rp32_r5p_hamster/project.f
+++ b/test/rp32_r5p_hamster/project.f
@@ -1,0 +1,14 @@
+# rp32 r5p_hamster — flat RISC-V core (like r5p_mouse; no TCB interface / no
+# submodules).  Hand-written.  CSR disabled (ENABLE_CSR undefined; the
+# riscv_csr_pkg / r5p_pkg imports are commented out — the generator's
+# riscv_csr_pkg "dep" was a false match on the comment).
+# top: r5p_hamster
+# mode: uhdm-only
+# surelog: -top r5p_hamster
+
+../rp32/riscv/riscv_isa_pkg.sv
+../rp32/riscv/riscv_priv_pkg.sv
+../rp32/riscv/riscv_isa_i_pkg.sv
+../rp32/riscv/riscv_isa_c_pkg.sv
+../rp32/core/r5p_gpr_1r1w.sv
+../rp32/hamster/r5p_hamster.sv


### PR DESCRIPTION
…amod names

r5p_hamster is the hierarchical Hamster core (a custom bus + the r5p_gpr_1r1w register-file submodule).  It failed to synthesize correctly: the gpr instance's cell type was `$paramod\r5p_gpr_1r1w\AW=..\XLEN=..\WBYP=..\CHIP=""` but the module definition was named `$paramod\r5p_gpr_1r1w\AW=..\XLEN=..\WBYP=..` (no `CHIP`). The names differed only by a trailing empty string param, so the cell became a blackbox and `synth -auto-top` picked the standalone gpr as the design top — the co-sim then extracted the gpr's ports instead of hamster's.

Root cause: the cell-type builder (uhdm2rtlil.cpp) appended string params unconditionally, while import_module's name builder guards on a non-empty value and drops empty ones.  Skip empty string params in the cell-type builder, and make import_instance's name builder match (include non-empty strings like import_module, skip empty ones) so all three namings agree.

Result: the gpr instance links to its definition, hamster is the synth top, and it synthesises via UHDM (385 KB netlist).  Co-sim is N/A — Verilator can't compile the source (`r5p_hamster.sv:575`, a replicate of a nested struct-field bit-select, VOIDDTYPE) which UHDM handles.  All three r5p cores (Mouse, Degu, Hamster) now synthesise via UHDM.  No regressions (run_all_tests 666/668; interface/parameterized-instance tests pass; 21 sim-equiv warnings unchanged).