### PR TITLE
uhdm: interface arrays — expand element connections (.b(arr[0]))

### DIFF
--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -249,6 +249,7 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     RTLIL::Wire* wire = create_wire(full_name, width);
                     add_src_attribute(wire->attributes, var);
                     name_map[full_name] = wire;
+                    iface_inst_vars_[interface_name].push_back(var_name);
 
                     // Net-decl-assign initializer in the elaborated
                     // interface (`logic [W-1:0] start_addr = '1`) lives
@@ -289,6 +290,7 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     RTLIL::Wire* wire = create_wire(full_name, width);
                     add_src_attribute(wire->attributes, net);
                     name_map[full_name] = wire;
+                    iface_inst_vars_[interface_name].push_back(net_name);
                 }
             }
 

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1651,7 +1651,39 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
                         continue;
                     }
                 }
-                
+
+                // Interface-ARRAY element connection: `.b(arr[0])`.  Surelog
+                // elaborates an interface array (`myif arr [N]`) into per-element
+                // interface instances named "arr[0]","arr[1]".  The High_conn is
+                // a bit_select on the array base; expand the selected element's
+                // signals into individual connections (b.vld -> arr[0].vld, ...),
+                // exactly like the single-interface ref_obj case above.
+                if (high_conn->UhdmType() == uhdmbit_select) {
+                    const bit_select* bs = any_cast<const bit_select*>(high_conn);
+                    std::string base = std::string(bs->VpiName());
+                    int idx = -1;
+                    if (bs->VpiIndex()) {
+                        RTLIL::SigSpec is = import_expression(bs->VpiIndex());
+                        if (is.is_fully_const()) idx = is.as_const().as_int();
+                    }
+                    if (idx >= 0) {
+                        std::string elem = base + "[" + std::to_string(idx) + "]";
+                        auto it = iface_inst_vars_.find(elem);
+                        if (it != iface_inst_vars_.end()) {
+                            log("    Port %s connected to interface-array element %s\n",
+                                port_name.c_str(), elem.c_str());
+                            for (auto &var_name : it->second) {
+                                std::string full_signal_name = elem + "." + var_name;
+                                std::string port_signal_name = port_name + "." + var_name;
+                                if (name_map.count(full_signal_name))
+                                    cell->setPort(RTLIL::escape_id(port_signal_name),
+                                                  name_map[full_signal_name]);
+                            }
+                            continue;
+                        }
+                    }
+                }
+
                 // Try to handle as expression directly
                 RTLIL::SigSpec actual_sig;
                 try {

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1071,6 +1071,50 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                     continue;
                                 }
                             }
+                            // Interface-ARRAY element: `.b(arr[0])`.  Surelog
+                            // elaborates `myif arr [N]` into per-element interface
+                            // instances named "arr[0]","arr[1]" whose signals are
+                            // "arr[0].<field>".  The High_conn is a bit_select on
+                            // the array base; pair the target's `<port>.<field>`
+                            // wires with the element's `arr[<idx>].<field>`.
+                            if (tgt_mod && port->High_conn()->UhdmType() == uhdmbit_select) {
+                                const bit_select* bs = any_cast<const bit_select*>(port->High_conn());
+                                std::string base = std::string(bs->VpiName());
+                                int idx = -1;
+                                if (bs->VpiIndex()) {
+                                    RTLIL::SigSpec is = import_expression(bs->VpiIndex());
+                                    if (is.is_fully_const()) idx = is.as_const().as_int();
+                                }
+                                std::string src_name = (idx >= 0)
+                                    ? base + "[" + std::to_string(idx) + "]" : std::string();
+                                std::string tgt_prefix = "\\" + port_name + ".";
+                                std::vector<std::string> field_names;
+                                if (!src_name.empty())
+                                    for (auto& w : tgt_mod->wires_) {
+                                        std::string wn = w.first.str();
+                                        if (wn.compare(0, tgt_prefix.size(), tgt_prefix) == 0)
+                                            field_names.push_back(wn.substr(tgt_prefix.size()));
+                                    }
+                                if (!field_names.empty()) {
+                                    for (const auto& f : field_names) {
+                                        std::string src_full = src_name + "." + f;
+                                        std::string dst_port = port_name + "." + f;
+                                        RTLIL::Wire* src_w = nullptr;
+                                        if (name_map.count(src_full))
+                                            src_w = name_map[src_full];
+                                        if (!src_w)
+                                            src_w = parent_rtlil_module->wire(
+                                                RTLIL::escape_id(src_full));
+                                        if (src_w) {
+                                            cell->setPort(RTLIL::escape_id(dst_port),
+                                                          RTLIL::SigSpec(src_w));
+                                            log("UHDM: Connected interface-array element %s -> %s\n",
+                                                src_full.c_str(), dst_port.c_str());
+                                        }
+                                    }
+                                    continue;
+                                }
+                            }
                             const expr* high_conn = any_cast<const expr*>(port->High_conn());
                             RTLIL::SigSpec conn = import_expression(high_conn);
 

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -210,7 +210,12 @@ struct UhdmImporter {
     std::map<const any*, RTLIL::SigBit> net_map;
     std::map<const any*, RTLIL::Wire*> wire_map;
     std::map<std::string, RTLIL::Wire*> name_map;
-    
+    // Per interface-instance name (incl. array index, e.g. "arr[0]") -> the
+    // ordered list of its signal names ("vld","dat",...).  Populated when
+    // interface instances are imported; used to expand an interface-array
+    // element connection (`.b(arr[0])`) into individual signal connections.
+    std::map<std::string, std::vector<std::string>> iface_inst_vars_;
+
     // Track module instances to avoid duplicates
     // Key: module_name + parameter signature
     std::set<std::string> imported_module_signatures;

--- a/test/interface_array/dut.sv
+++ b/test/interface_array/dut.sv
@@ -1,0 +1,32 @@
+// Minimal interface-array test mirroring rp32 degu/hamster SoC usage:
+// an array of interface instances, connected per-element to submodule modports.
+interface myif #(parameter int W = 8) (input logic clk, input logic rst);
+  logic         vld;
+  logic [W-1:0] dat;
+  modport man (input clk, input rst, output vld, output dat);
+  modport sub (input clk, input rst, input  vld, input  dat);
+endinterface
+
+module producer (myif.man b, input logic [7:0] seed);
+  assign b.vld = 1'b1;
+  assign b.dat = seed;
+endmodule
+
+module consumer (myif.sub b, output logic [7:0] o);
+  assign o = b.dat & {8{b.vld}};
+endmodule
+
+module dut (
+  input  logic       clk,
+  input  logic       rst,
+  input  logic [7:0] s0,
+  input  logic [7:0] s1,
+  output logic [7:0] o0,
+  output logic [7:0] o1
+);
+  myif #(.W(8)) arr [2-1:0] (.clk(clk), .rst(rst));
+  producer p0 (.b(arr[0]), .seed(s0));
+  producer p1 (.b(arr[1]), .seed(s1));
+  consumer c0 (.b(arr[0]), .o(o0));
+  consumer c1 (.b(arr[1]), .o(o1));
+endmodule


### PR DESCRIPTION
Add support for arrays of interface instances connected per element, e.g.

    myif arr [N] (...);
    consumer c0 (.b(arr[0]), ...);

Surelog elaborates `myif arr [N]` into per-element interface instances named "arr[0]","arr[1]" whose signals are created as "arr[<i>].<field>" wires.  The port connection `.b(arr[0])` arrives as a `bit_select` on the array base, which the connection handlers did not recognize as an interface connection — they fell through to `import_expression`, which failed with "Could not find wire 'arr' for bit select".

Both cell-creation paths (import_instance in module.cpp and the child-instance path in uhdm2rtlil.cpp) now detect a `bit_select` High_conn, resolve the element name "arr[<idx>]", and pair the target module's flattened `<port>.<field>` wires with the element's `arr[<idx>].<field>` wires — the same expansion already used for a single-interface `ref_obj` connection.  Interface-instance signal names are recorded in a new `iface_inst_vars_` map as they are created.

New test `interface_array` (an interface array driven/consumed per element) synthesises via UHDM and passes the Verilator co-sim (200 cycles, full activity). This is the first piece of interface-array support needed by the rp32 degu/hamster SoCs; whole-array connections (`.man(arr)`) are still to come.  No regressions (run_all_tests 667/669; all interface tests pass; 21 sim-equiv warnings unchanged).