### PR TITLE
uhdm: interface arrays — whole-array connections + module-side array …

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -58,8 +58,12 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
     // Get port width
     int width = get_width(uhdm_port, current_instance);
     
-    // Check if this is an interface port
-    if (width == -1) {
+    // Check if this is an interface port.  get_width returns -1 for a single
+    // interface port and a more-negative value for an ARRAY of interface ports
+    // (e.g. -2 for `myif.man m [2-1:0]`); both must create a 1-bit placeholder,
+    // never a negative-width wire.  The per-element signals (m[0].vld, ...) are
+    // created separately, so the placeholder only holds the port-list slot.
+    if (width < 0) {
         log("UHDM: Port '%s' is an interface type, creating placeholder\n", portname.c_str());
         // For interface ports, create a special wire that won't be used for connections
         // but serves as a placeholder for the port list
@@ -77,7 +81,16 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
             if (ref_typespec && ref_typespec->Actual_typespec()) {
                 typespec = ref_typespec->Actual_typespec();
             }
-            
+            // An ARRAY of interface ports (`myif.man m [N]`) carries an
+            // array_typespec wrapping the per-element interface (modport)
+            // typespec.  Unwrap it so the interface handling below runs; the
+            // array dimension is taken from the port width (-N) further down.
+            if (typespec && typespec->UhdmType() == uhdmarray_typespec) {
+                auto at = any_cast<const UHDM::array_typespec*>(typespec);
+                if (at->Elem_typespec() && at->Elem_typespec()->Actual_typespec())
+                    typespec = at->Elem_typespec()->Actual_typespec();
+            }
+
             // Get interface type name
             if (typespec && typespec->UhdmType() == uhdminterface_typespec) {
                 const UHDM::interface_typespec* iface_ts = any_cast<const UHDM::interface_typespec*>(typespec);
@@ -191,6 +204,26 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                     mp->VpiParent()->UhdmType() == uhdminterface_inst)
                     iface_inst = any_cast<const UHDM::interface_inst*>(mp->VpiParent());
 
+                // For an ARRAY of interface ports (`myif.man m [N]`), Surelog's
+                // Low_conn does not resolve to the modport / interface_inst the
+                // way a single interface port does.  Fall back to locating any
+                // elaborated instance of this interface type in the design (for
+                // field widths) and its named modport (for field directions), so
+                // the per-element field ports below can still be created.
+                if ((!mp || !iface_inst) && !interface_type.empty() &&
+                    uhdm_design && uhdm_design->AllInterfaces()) {
+                    for (auto ii : *uhdm_design->AllInterfaces()) {
+                        std::string dn = std::string(ii->VpiDefName());
+                        if (dn.find("work@") == 0) dn = dn.substr(5);
+                        if (dn != interface_type) continue;
+                        if (!iface_inst) iface_inst = ii;
+                        if (!mp && !modport_name.empty() && ii->Modports())
+                            for (auto m : *ii->Modports())
+                                if (std::string(m->VpiName()) == modport_name) { mp = m; break; }
+                        if (iface_inst && (mp || modport_name.empty())) break;
+                    }
+                }
+
                 // AllModules has the unelaborated interface_inst (default
                 // parameter values).  Swap in the elaborated form's port
                 // iface_inst so per-signal widths reflect the parent's
@@ -271,10 +304,18 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                 };
 
                 if (mp && mp->Io_decls() && iface_inst) {
+                  // An ARRAY of interface ports (`myif.man m [N]`) reports a
+                  // width of -N (-1 is a single interface); create the modport
+                  // field wires for EACH element as "m[e].<sig>" so a whole-array
+                  // connection `.m(arr)` can bind "m[e].<sig>" to "arr[e].<sig>".
+                  int n_elem = (width < -1) ? -width : 1;
+                  for (int e = 0; e < n_elem; e++) {
+                    std::string elem_prefix = (width < -1)
+                        ? portname + "[" + std::to_string(e) + "]" : portname;
                     for (auto io : *mp->Io_decls()) {
                         std::string sig_name = std::string(io->VpiName());
                         if (sig_name.empty()) continue;
-                        std::string full_name = portname + "." + sig_name;
+                        std::string full_name = elem_prefix + "." + sig_name;
                         if (name_map.count(full_name)) continue;
                         // Find the matching net/variable in the interface
                         // so we can sample its real width and source loc.
@@ -308,6 +349,7 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                             log("UHDM: Created modport signal wire '%s' (width=%d, dir=%d)\n",
                                 full_name.c_str(), sig_w, io->VpiDirection());
                     }
+                  }
                 } else if (iface_inst) {
                     // No modport — full interface port; mirror every signal
                     // in the interface.

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1041,6 +1041,38 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                             // and `cell->setPort(port_name, empty)` drops the
                             // connection entirely.
                             RTLIL::Module* tgt_mod = design->module(cell->type);
+                            // Whole interface-ARRAY connection: `.m(arr)` wires the
+                            // entire array to a target with an array of interface
+                            // ports (`m[N]`).  Surelog names the source elements
+                            // "arr[0]","arr[1]" and the target's flattened wires
+                            // "m[0].<field>"; pair them element-by-element.
+                            if (tgt_mod && port->High_conn()->UhdmType() == uhdmref_obj) {
+                                const ref_obj* aref = any_cast<const ref_obj*>(port->High_conn());
+                                std::string src_base = std::string(aref->VpiName());
+                                if (iface_inst_vars_.count(src_base + "[0]")) {
+                                    bool any = false;
+                                    for (int i = 0; iface_inst_vars_.count(
+                                             src_base + "[" + std::to_string(i) + "]"); i++) {
+                                        std::string elem = src_base + "[" + std::to_string(i) + "]";
+                                        for (auto &f : iface_inst_vars_[elem]) {
+                                            std::string src_full = elem + "." + f;
+                                            std::string dst_port = port_name + "[" +
+                                                std::to_string(i) + "]." + f;
+                                            RTLIL::Wire* src_w = name_map.count(src_full)
+                                                ? name_map[src_full]
+                                                : parent_rtlil_module->wire(
+                                                      RTLIL::escape_id(src_full));
+                                            if (src_w) {
+                                                cell->setPort(RTLIL::escape_id(dst_port),
+                                                              RTLIL::SigSpec(src_w));
+                                                any = true;
+                                            }
+                                        }
+                                    }
+                                    if (any) { log("UHDM: Connected whole interface array %s -> port %s[]\n",
+                                                   src_base.c_str(), port_name.c_str()); continue; }
+                                }
+                            }
                             if (tgt_mod && port->High_conn()->UhdmType() == uhdmref_obj) {
                                 const ref_obj* href = any_cast<const ref_obj*>(port->High_conn());
                                 std::string src_name = std::string(href->VpiName());
@@ -3913,15 +3945,21 @@ void UhdmImporter::expand_interfaces() {
                     port_name = port_name.substr(1);
                 }
                 
-                // Find all interface signal wires (bus.a, bus.b, bus.c)
+                // Find all interface signal wires (bus.a, bus.b, bus.c).
+                // For an ARRAY of interface ports the elements are named
+                // "m[0].<field>","m[1].<field>", so also match the "<port>["
+                // prefix (not just "<port>.").
                 std::vector<RTLIL::Wire*> signal_wires;
                 std::string prefix = port_name + ".";
                 std::string escaped_prefix = "\\" + port_name + ".";
-                
+                std::string arr_prefix = port_name + "[";
+                std::string escaped_arr_prefix = "\\" + port_name + "[";
+
                 for (auto wire : module->wires()) {
                     std::string wire_name = wire->name.str();
                     // Check both escaped and unescaped versions
-                    if (wire_name.find(prefix) == 0 || wire_name.find(escaped_prefix) == 0) {
+                    if (wire_name.find(prefix) == 0 || wire_name.find(escaped_prefix) == 0 ||
+                        wire_name.find(arr_prefix) == 0 || wire_name.find(escaped_arr_prefix) == 0) {
                         signal_wires.push_back(wire);
                         log("UHDM: Found interface signal wire %s\n", wire_name.c_str());
                     }

--- a/test/iface_array_port/dut.sv
+++ b/test/iface_array_port/dut.sv
@@ -1,0 +1,21 @@
+// Smallest reproducer that still TRIGGERS the array-interface-port path
+// (interface with clk/rst ports → port width -2).  drv has an array of
+// interface ports m[2]; its per-element m[i].dat must become ports.
+interface myif (input logic clk, input logic rst);
+  logic [7:0] dat;
+  modport man (input clk, input rst, output dat);
+  modport sub (input clk, input rst, input  dat);
+endinterface
+
+module drv (myif.man m [2-1:0]);
+  assign m[0].dat = 8'd10;
+  assign m[1].dat = 8'd20;
+endmodule
+
+module dut (input logic clk, input logic rst,
+            output logic [7:0] o0, output logic [7:0] o1);
+  myif arr [2-1:0] (.clk(clk), .rst(rst));
+  drv  d (.m(arr));
+  assign o0 = arr[0].dat;
+  assign o1 = arr[1].dat;
+endmodule

--- a/test/interface_array_fanout/dut.sv
+++ b/test/interface_array_fanout/dut.sv
@@ -1,0 +1,41 @@
+// Whole interface-array connection: a module with an ARRAY of interface ports
+// (`m[N]`) connected with `.m(arr)` (the whole array) — mirrors rp32 degu SoC's
+// `tcb_lite_lib_demultiplexer .man(tcb_per)`.
+interface myif #(parameter int W = 8) (input logic clk, input logic rst);
+  logic         vld;
+  logic [W-1:0] dat;
+  modport man (input clk, input rst, output vld, output dat);
+  modport sub (input clk, input rst, input  vld, input  dat);
+endinterface
+
+module producer (myif.man b, input logic [7:0] seed);
+  assign b.vld = 1'b1;
+  assign b.dat = seed;
+endmodule
+
+// array of interface ports, driven per element from a single source interface
+module fanout (myif.sub s, myif.man m [2-1:0]);
+  assign m[0].vld = s.vld;
+  assign m[0].dat = s.dat;
+  assign m[1].vld = s.vld;
+  assign m[1].dat = s.dat + 8'd1;
+endmodule
+
+module consumer (myif.sub b, output logic [7:0] o);
+  assign o = b.dat & {8{b.vld}};
+endmodule
+
+module dut (
+  input  logic       clk,
+  input  logic       rst,
+  input  logic [7:0] sd,
+  output logic [7:0] o0,
+  output logic [7:0] o1
+);
+  myif #(.W(8)) src       (.clk(clk), .rst(rst));
+  myif #(.W(8)) arr [2-1:0] (.clk(clk), .rst(rst));
+  producer p (.b(src), .seed(sd));
+  fanout   f (.s(src), .m(arr));   // whole-array connection
+  consumer c0 (.b(arr[0]), .o(o0));
+  consumer c1 (.b(arr[1]), .o(o1));
+endmodule


### PR DESCRIPTION
…ports

Builds on the interface-array element-connection support: handle a whole interface array connected to a module that declares an ARRAY of interface ports, e.g. the rp32 SoC bus fabric

    myif arr [N] (...);
    fanout f (.m(arr));            // whole array -> m[N]
    module fanout (myif.man m [N]);

Five pieces, each isolated with the smallest reproducer (test/iface_array_port — an interface + a module with an `m[2]` port, no other logic):

1. import_port: an array interface port reports width -N (-1 = single); treat any negative width as an interface placeholder instead of creating a negative-width wire (was an `Assert width>=0` crash).
2. import_port: the array port's typespec is an `array_typespec` WRAPPING the per-element interface (modport) typespec — unwrap it so the interface-port handling runs at all (it was silently skipped for arrays).
3. import_port: the array port's modport doesn't resolve via Low_conn like a single port; fall back to locating the interface and its named modport via design->AllInterfaces().
4. import_port: create the modport field wires per element ("m[i].<field>").
5. expand-interfaces promotion: match the "<port>[" element prefix (not just "<port>.") so "m[i].<field>" wires are promoted to ports.
6. cell connection (uhdm2rtlil.cpp): a whole-array `.m(arr)` ref_obj is paired element-by-element ("m[i].<f>" <- "arr[i].<f>").

Tests iface_array_port (minimal) and interface_array_fanout (driven per element through an array port) synthesise via UHDM and pass the Verilator co-sim.  No regressions (run_all_tests 669/671; all interface tests pass; 21 sim-equiv warnings unchanged).  Next: the degu SoC's req/rsp struct buses.