### PR TITLE
uhdm: struct buses on array interface ports — size from a signal-carr…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -210,17 +210,24 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                 // elaborated instance of this interface type in the design (for
                 // field widths) and its named modport (for field directions), so
                 // the per-element field ports below can still be created.
-                if ((!mp || !iface_inst) && !interface_type.empty() &&
+                auto has_signals = [](const UHDM::interface_inst* ii) {
+                    return ii && ((ii->Nets() && !ii->Nets()->empty()) ||
+                                  (ii->Variables() && !ii->Variables()->empty()));
+                };
+                if ((!mp || !has_signals(iface_inst)) && !interface_type.empty() &&
                     uhdm_design && uhdm_design->AllInterfaces()) {
                     for (auto ii : *uhdm_design->AllInterfaces()) {
                         std::string dn = std::string(ii->VpiDefName());
                         if (dn.find("work@") == 0) dn = dn.substr(5);
                         if (dn != interface_type) continue;
-                        if (!iface_inst) iface_inst = ii;
+                        // Prefer an instance that actually carries its signals
+                        // (so per-field WIDTHS resolve — a stub from Low_conn /
+                        // mp->VpiParent has none, which sized struct buses to 1).
+                        if (!iface_inst || (!has_signals(iface_inst) && has_signals(ii)))
+                            iface_inst = ii;
                         if (!mp && !modport_name.empty() && ii->Modports())
                             for (auto m : *ii->Modports())
                                 if (std::string(m->VpiName()) == modport_name) { mp = m; break; }
-                        if (iface_inst && (mp || modport_name.empty())) break;
                     }
                 }
 
@@ -286,7 +293,12 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                             if (auto r = find(t)) { elab = r; break; }
                         eii = eii_from(elab);
                     }
-                    if (eii) iface_inst = eii;
+                    // Don't swap a signal-carrying iface_inst for a signal-less
+                    // stub: for an ARRAY interface port the elaborated High_conn
+                    // is the whole array, whose representative interface_inst has
+                    // no per-element signal nets (which sized struct buses to 1).
+                    if (eii && (has_signals(eii) || !has_signals(iface_inst)))
+                        iface_inst = eii;
                 }
 
                 // When the interface signal's typespec refers to an

--- a/test/iface_array_struct_whole/dut.sv
+++ b/test/iface_array_struct_whole/dut.sv
@@ -1,0 +1,19 @@
+// Struct-bus interface array WITHOUT struct field access — verifies struct
+// signal WIDTH + whole-struct connection through array interface ports.
+typedef struct packed { logic wen; logic [7:0] adr; } req_t;
+interface myif (input logic clk, input logic rst);
+  req_t req;
+  modport man (input clk, input rst, output req);
+  modport sub (input clk, input rst, input  req);
+endinterface
+module drv (myif.man m [2-1:0]);
+  assign m[0].req = '{wen: 1'b1, adr: 8'd10};
+  assign m[1].req = '{wen: 1'b0, adr: 8'd20};
+endmodule
+module dut (input logic clk, input logic rst,
+            output logic [8:0] o0, output logic [8:0] o1);
+  myif arr [2-1:0] (.clk(clk), .rst(rst));
+  drv  d (.m(arr));
+  assign o0 = arr[0].req;   // 9'b1_00001010 = 266
+  assign o1 = arr[1].req;   // 9'b0_00010100 = 20
+endmodule


### PR DESCRIPTION
…ying inst

A packed-struct interface signal (e.g. tcb_lite_if's req/rsp) on an ARRAY of interface ports was sized to 1 bit instead of its real width, so whole-struct buses didn't propagate (drove X).

Root cause: import_port samples each modport field's width from an `interface_inst`, but for an array port that instance came from a signal-less stub — the Low_conn / `mp->VpiParent` resolution, and especially the parameter-resolution swap (whose elaborated High_conn for an array port is the WHOLE array, whose representative interface_inst has no per-element signal nets). With no matching net/variable, the field width fell back to 1.

Fix: prefer an interface_inst that actually carries signals — the AllInterfaces fallback now skips empty stubs, and the parameter-resolution swap no longer replaces a signal-carrying instance with a signal-less one (a `has_signals` guard).  Single interface ports are unaffected (their Low_conn instance already has signals).

New test iface_array_struct_whole (a req struct driven per element through an array interface port and read whole) synthesises via UHDM and passes co-sim (struct widths 9/8 now correct).  No regressions (run_all_tests 670/672; all interface tests pass; 21 sim-equiv warnings unchanged).  Still TODO: struct FIELD access on interface signals (`s.req.adr`) — a pre-existing interface limitation, not array-specific.