### PR TITLE
uhdm: struct field access on interface signals (s.req.adr)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6312,6 +6312,73 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
         }
     }
 
+    // Interface-signal struct member: `s.req.adr` where "s" is an interface PORT,
+    // "s.req" is the flattened interface signal wire (a packed struct), and the
+    // remaining elements ("adr", ...) are struct members.  The interface flattens
+    // `req` to a wire named "s.req"; the general handler below keys off the bare
+    // base ("s", here only a 1-bit placeholder), so resolve the "<iface>.<sig>"
+    // join as the base and walk the struct members from the signal's typespec.
+    // Detect by name_map carrying the 2-element join (a plain union path like
+    // `dec.r.rd` has no "dec.r" wire, so this stays specific to interfaces).
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 3) {
+        auto& pe = *uhdm_hier->Path_elems();
+        bool all_ref = true;
+        for (auto e : pe)
+            if (e->UhdmType() != uhdmref_obj) { all_ref = false; break; }
+        if (all_ref) {
+            std::string iface = std::string(any_cast<const ref_obj*>(pe[0])->VpiName());
+            std::string sig   = std::string(any_cast<const ref_obj*>(pe[1])->VpiName());
+            std::string wname = iface + "." + sig;          // "s.req"
+            if (name_map.count(wname) && iface_signal_struct_ts_.count(wname)) {
+                RTLIL::SigSpec base_sig = RTLIL::SigSpec(name_map[wname]);
+                // The path element pe[1] carries no typespec/Actual_group, so use
+                // the struct/union typespec recorded when the field wire was made.
+                const UHDM::typespec* cur_ts = iface_signal_struct_ts_[wname];
+                if (cur_ts) {
+                    int off = 0, field_w = 0;
+                    bool ok = true;
+                    for (size_t lvl = 2; lvl < pe.size() && ok; lvl++) {
+                        std::string mname =
+                            std::string(any_cast<const ref_obj*>(pe[lvl])->VpiName());
+                        const UHDM::VectorOftypespec_member* members = nullptr;
+                        bool is_struct = false;
+                        if (cur_ts->UhdmType() == uhdmstruct_typespec) {
+                            members = any_cast<const UHDM::struct_typespec*>(cur_ts)->Members();
+                            is_struct = true;
+                        } else if (cur_ts->UhdmType() == uhdmunion_typespec) {
+                            members = any_cast<const UHDM::union_typespec*>(cur_ts)->Members();
+                        }
+                        if (!members) { ok = false; break; }
+                        int moff = 0, mw = 0;
+                        const UHDM::typespec* mts = nullptr;
+                        bool found = false;
+                        for (int i = (int)members->size() - 1; i >= 0; i--) {
+                            auto m = (*members)[i];
+                            int w = 0;
+                            const UHDM::typespec* ts2 = nullptr;
+                            if (auto mt = m->Typespec())
+                                if (auto a2 = mt->Actual_typespec()) {
+                                    ts2 = a2;
+                                    w = get_width_from_typespec(a2, inst);
+                                }
+                            if (std::string(m->VpiName()) == mname) {
+                                mw = w; mts = ts2; found = true; break;
+                            }
+                            if (is_struct) moff += w;
+                        }
+                        if (!found) { ok = false; break; }
+                        off += moff; field_w = mw; cur_ts = mts;
+                    }
+                    if (ok && field_w > 0 && off + field_w <= base_sig.size()) {
+                        log("    hier_path: interface signal struct member %s.* -> [%d+:%d]\n",
+                            wname.c_str(), off, field_w);
+                        return base_sig.extract(off, field_w);
+                    }
+                }
+            }
+        }
+    }
+
     // General packed union/struct member chain `base.m1.m2...field` where each
     // level is a struct or union member (rp32 dec32: `op.r.opcode.opc` — union
     // -> struct -> struct -> enum field; and imm_i_f's `op.imm_11_0` — a simple

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -350,6 +350,33 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                         RTLIL::Wire* sw = module->addWire(
                             RTLIL::escape_id(full_name), sig_w);
                         if (width_obj) add_src_attribute(sw->attributes, width_obj);
+                        // Record a packed struct/union typespec for this interface
+                        // signal so a field access (`s.req.adr`) can slice the
+                        // member later in import_hier_path.  The local iface_inst's
+                        // net is often a `struct_net` (no typespec accessor); the
+                        // design-level interface instance carries it as a logic_net
+                        // WITH the struct_typespec, so search AllInterfaces.
+                        if (!interface_type.empty() && uhdm_design &&
+                            uhdm_design->AllInterfaces() &&
+                            !iface_signal_struct_ts_.count(full_name)) {
+                            for (auto ii : *uhdm_design->AllInterfaces()) {
+                                std::string dn = std::string(ii->VpiDefName());
+                                if (dn.find("work@") == 0) dn = dn.substr(5);
+                                if (dn != interface_type || !ii->Nets()) continue;
+                                for (auto n : *ii->Nets()) {
+                                    if (std::string(n->VpiName()) != sig_name) continue;
+                                    if (n->UhdmType() != uhdmlogic_net) continue;
+                                    auto rt = any_cast<const UHDM::logic_net*>(n)->Typespec();
+                                    if (rt && rt->Actual_typespec()) {
+                                        auto ats = rt->Actual_typespec();
+                                        if (ats->UhdmType() == uhdmstruct_typespec ||
+                                            ats->UhdmType() == uhdmunion_typespec)
+                                            iface_signal_struct_ts_[full_name] = ats;
+                                    }
+                                }
+                                if (iface_signal_struct_ts_.count(full_name)) break;
+                            }
+                        }
                         // Remember the modport's direction for this
                         // signal so `expand_interfaces` can promote
                         // it to an input/output (rather than blanket

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -215,6 +215,10 @@ struct UhdmImporter {
     // interface instances are imported; used to expand an interface-array
     // element connection (`.b(arr[0])`) into individual signal connections.
     std::map<std::string, std::vector<std::string>> iface_inst_vars_;
+    // Interface signal wire name ("s.req") -> its packed struct/union typespec,
+    // recorded when the interface port's field wires are created so a struct
+    // field access (`s.req.adr`) in import_hier_path can slice the member.
+    std::map<std::string, const UHDM::typespec*> iface_signal_struct_ts_;
 
     // Track module instances to avoid duplicates
     // Key: module_name + parameter signature

--- a/test/iface_struct_field/dut.sv
+++ b/test/iface_struct_field/dut.sv
@@ -1,0 +1,20 @@
+// Smallest repro: struct FIELD access on a SINGLE interface port signal.
+// reader reads s.req.adr (a field of a packed-struct interface signal).
+typedef struct packed { logic wen; logic [7:0] adr; } req_t;
+
+interface myif (input logic clk, input logic rst);
+  req_t req;
+  modport man (input clk, input rst, output req);
+  modport sub (input clk, input rst, input  req);
+endinterface
+
+module reader (myif.sub s, output logic [7:0] o);
+  assign o = s.req.adr;          // <-- struct field access (returns X today)
+endmodule
+
+module dut (input logic clk, input logic rst,
+            input  logic [7:0] a, output logic [7:0] o);
+  myif inst (.clk(clk), .rst(rst));
+  assign inst.req = '{wen: 1'b1, adr: a};
+  reader r (.s(inst), .o(o));
+endmodule


### PR DESCRIPTION
A struct field access on a packed-struct interface signal — `s.req.adr` where `s` is an interface port and `req` a `struct packed` — returned X: the interface flattens `req` to a wire named "s.req", but the hier_path member-chain handlers key off the bare base ("s", only a 1-bit interface placeholder), and the path element for `req` carries no typespec/Actual_group to slice the member from.

Fix, two parts:
- import_port: when creating an interface modport field wire, record its packed struct/union typespec in a new `iface_signal_struct_ts_` map (keyed by the "s.req" wire name).  The local iface_inst's net is often a `struct_net` with no typespec accessor, so the typespec is fetched from the design-level interface instance (a logic_net carrying the struct_typespec) via AllInterfaces.
- import_hier_path: a new handler for a >=3-element all-ref path whose first two elements join to an interface signal wire ("s.req") — use that as the base and walk the recorded struct/union members (LSB-first offsets) to extract the slice.

New test iface_struct_field (read a struct field of a single interface-port signal) synthesises via UHDM and passes co-sim.  No regressions (run_all_tests 671/673; all struct/interface tests pass; 21 sim-equiv warnings unchanged). Still TODO: field access on an interface ARRAY element (`arr[0].rsp.rdt`, where the first path element is a bit_select).