### PR TITLE
uhdm: resolve implicit cont-assign nets read inside generate scopes (…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -3130,6 +3130,29 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
     log("UHDM: Finished importing interface instances\n");
     log_flush();
     
+    // Pre-create the implicit nets that are the LHS of module-level continuous
+    // assigns, BEFORE importing generate scopes (which happens next, but the
+    // actual continuous-assign import runs after).  Otherwise a reference to
+    // such an implicit net inside a generate-scope always block resolves to a
+    // disconnected gen-scope-local copy (e.g. `gen.INTERNAL1`) instead of the
+    // parent module net, leaving the driven register's input floating (#437).
+    if (uhdm_module->Cont_assigns()) {
+        for (auto ca : *uhdm_module->Cont_assigns()) {
+            auto lhs = ca->Lhs();
+            if (!lhs || lhs->UhdmType() != uhdmref_obj) continue;
+            std::string lname = std::string(any_cast<const ref_obj*>(lhs)->VpiName());
+            if (lname.empty() || name_map.count(lname) ||
+                module->wire(RTLIL::escape_id(lname)))
+                continue;
+            int w = get_width(lhs, uhdm_module);
+            if (w <= 0) w = 1;
+            RTLIL::Wire* iw = module->addWire(RTLIL::escape_id(lname), w);
+            name_map[lname] = iw;
+            log("UHDM: Pre-created implicit cont-assign net '%s' (width=%d) for "
+                "generate-scope visibility\n", lname.c_str(), w);
+        }
+    }
+
     // Import generate scopes (generate blocks)
     log("UHDM: About to import generate scopes for module %s\n", log_id(module->name));
     log_flush();

--- a/test/generate_scope_implicit_net/dut.sv
+++ b/test/generate_scope_implicit_net/dut.sv
@@ -1,0 +1,16 @@
+// Issue #437: an implicit wire from a module-level continuous assign
+// (INTERNAL1) read inside an always block in a nested generate scope must
+// resolve to the PARENT net, not a disconnected gen-scope-local net.
+module dut #(parameter Q_RESET_VAL = 0) (
+    output reg Q,
+    input D, CP, RN, TI, TE
+);
+    assign INTERNAL1 = TE ? TI : D;   // implicit/deferred wire in parent scope
+
+    generate if (Q_RESET_VAL == 0) begin : sync_flipflop_low_reset_gen
+        always @(posedge CP or negedge RN) begin
+            if (RN == 1'b0)  Q <= 1'b0;
+            else             Q <= INTERNAL1;   // read parent's implicit wire
+        end
+    end endgenerate
+endmodule


### PR DESCRIPTION
…#437)

A net implicitly declared by a module-level continuous assign (`assign INTERNAL1 = TE ? TI : D;`) and read inside an always block in a nested generate scope (`Q <= INTERNAL1;`) resolved to a NEW disconnected gen-scope-local net (`\<gen>.INTERNAL1`) instead of the parent module net.  The register's D input was left floating, so `opt` removed the register.

Cause: generate scopes are imported before the module's continuous assigns, and the implicit net is created on first use — which happens inside the generate scope, where the reference resolver prepends the gen-scope prefix.  Surelog gives the read a gen-scope-qualified VpiFullName and no Actual_group, so the net's true module scope isn't visible at the reference.

Fix: before importing generate scopes, pre-create the implicit nets that are the LHS of module-level continuous assigns (a simple ref_obj with no existing wire), at module scope.  The gen-scope reference then resolves to the parent net via the unprefixed name_map lookup, and the later continuous-assign import drives it.

New test generate_scope_implicit_net (the issue's reproducer) passes formal equivalence.  No regressions (run_all_tests 672/674; all generate-scope tests pass; 21 sim-equiv warnings unchanged).

Fixes #437