### PR TITLE
uhdm: struct field access on interface ARRAY-element signals (arr[0].…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6312,23 +6312,40 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
         }
     }
 
-    // Interface-signal struct member: `s.req.adr` where "s" is an interface PORT,
-    // "s.req" is the flattened interface signal wire (a packed struct), and the
-    // remaining elements ("adr", ...) are struct members.  The interface flattens
-    // `req` to a wire named "s.req"; the general handler below keys off the bare
-    // base ("s", here only a 1-bit placeholder), so resolve the "<iface>.<sig>"
-    // join as the base and walk the struct members from the signal's typespec.
-    // Detect by name_map carrying the 2-element join (a plain union path like
-    // `dec.r.rd` has no "dec.r" wire, so this stays specific to interfaces).
+    // Interface-signal struct member: `s.req.adr` (single port) or
+    // `arr[0].req.adr` (array element) — "s"/"arr[0]" is an interface, "<>.req"
+    // is the flattened interface signal wire (a packed struct), and the remaining
+    // elements ("adr", ...) are struct members.  The interface flattens `req` to
+    // a wire named "<iface>.req"; the general handler below keys off the bare
+    // base (a 1-bit placeholder), so resolve the "<iface>.<sig>" join as the base
+    // and walk the struct members from the recorded signal typespec.  Detect by
+    // name_map carrying the 2-element join (a plain union path like `dec.r.rd`
+    // has no "dec.r" wire, so this stays specific to interfaces).
     if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 3) {
         auto& pe = *uhdm_hier->Path_elems();
-        bool all_ref = true;
-        for (auto e : pe)
-            if (e->UhdmType() != uhdmref_obj) { all_ref = false; break; }
-        if (all_ref) {
-            std::string iface = std::string(any_cast<const ref_obj*>(pe[0])->VpiName());
+        // pe[0] may be a ref_obj (single port "s") OR a bit_select (array element
+        // "arr[0]"); pe[1..] must be plain member refs.
+        bool rest_ref = true;
+        for (size_t i = 1; i < pe.size(); i++)
+            if (pe[i]->UhdmType() != uhdmref_obj) { rest_ref = false; break; }
+        std::string base;
+        if (rest_ref) {
+            if (pe[0]->UhdmType() == uhdmref_obj) {
+                base = std::string(any_cast<const ref_obj*>(pe[0])->VpiName());
+            } else if (pe[0]->UhdmType() == uhdmbit_select) {
+                auto bs = any_cast<const bit_select*>(pe[0]);
+                std::string bn = std::string(bs->VpiName());
+                int idx = -1;
+                if (bs->VpiIndex()) {
+                    RTLIL::SigSpec is = import_expression(bs->VpiIndex());
+                    if (is.is_fully_const()) idx = is.as_const().as_int();
+                }
+                if (idx >= 0) base = bn + "[" + std::to_string(idx) + "]";
+            }
+        }
+        if (!base.empty()) {
             std::string sig   = std::string(any_cast<const ref_obj*>(pe[1])->VpiName());
-            std::string wname = iface + "." + sig;          // "s.req"
+            std::string wname = base + "." + sig;          // "s.req" / "arr[0].req"
             if (name_map.count(wname) && iface_signal_struct_ts_.count(wname)) {
                 RTLIL::SigSpec base_sig = RTLIL::SigSpec(name_map[wname]);
                 // The path element pe[1] carries no typespec/Actual_group, so use

--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -179,7 +179,37 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
         for (auto interface : *source->Interfaces()) {
             std::string interface_name = std::string(interface->VpiName());
             log("UHDM: Processing interface instance: %s\n", interface_name.c_str());
-            log_flush();      
+            log_flush();
+            // Record the packed struct/union typespec of an interface signal
+            // (e.g. "arr[0].req") so a field access `arr[0].req.adr` can slice
+            // the member later.  The design-level interface instance carries the
+            // signal as a logic_net WITH the struct_typespec (the local element's
+            // net is often a typespec-less struct_net), so search AllInterfaces.
+            std::string iface_def = std::string(interface->VpiDefName());
+            if (iface_def.find("work@") == 0) iface_def = iface_def.substr(5);
+            auto record_struct_ts = [&](const std::string& wire_name,
+                                        const std::string& sig_name) {
+                if (iface_signal_struct_ts_.count(wire_name) || !uhdm_design ||
+                    !uhdm_design->AllInterfaces())
+                    return;
+                for (auto ii : *uhdm_design->AllInterfaces()) {
+                    std::string dn = std::string(ii->VpiDefName());
+                    if (dn.find("work@") == 0) dn = dn.substr(5);
+                    if (dn != iface_def || !ii->Nets()) continue;
+                    for (auto n : *ii->Nets()) {
+                        if (std::string(n->VpiName()) != sig_name) continue;
+                        if (n->UhdmType() != uhdmlogic_net) continue;
+                        auto rt = any_cast<const UHDM::logic_net*>(n)->Typespec();
+                        if (rt && rt->Actual_typespec()) {
+                            auto ats = rt->Actual_typespec();
+                            if (ats->UhdmType() == uhdmstruct_typespec ||
+                                ats->UhdmType() == uhdmunion_typespec)
+                                iface_signal_struct_ts_[wire_name] = ats;
+                        }
+                    }
+                    if (iface_signal_struct_ts_.count(wire_name)) break;
+                }
+            };
             // Get WIDTH parameter value - check module parameter first, then interface instance
             int interface_width = 8; // default
             
@@ -250,6 +280,7 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     add_src_attribute(wire->attributes, var);
                     name_map[full_name] = wire;
                     iface_inst_vars_[interface_name].push_back(var_name);
+                    record_struct_ts(full_name, var_name);
 
                     // Net-decl-assign initializer in the elaborated
                     // interface (`logic [W-1:0] start_addr = '1`) lives
@@ -291,6 +322,7 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     add_src_attribute(wire->attributes, net);
                     name_map[full_name] = wire;
                     iface_inst_vars_[interface_name].push_back(net_name);
+                    record_struct_ts(full_name, net_name);
                 }
             }
 

--- a/test/iface_array_struct/dut.sv
+++ b/test/iface_array_struct/dut.sv
@@ -1,0 +1,32 @@
+// Smallest struct-bus interface-array repro (mirrors rp32 tcb_lite_if's
+// req/rsp packed-struct signals on an array of interface ports).
+typedef struct packed { logic wen; logic [7:0] adr; } req_t;
+typedef struct packed { logic [7:0] rdt;            } rsp_t;
+
+interface myif (input logic clk, input logic rst);
+  req_t req;
+  rsp_t rsp;
+  modport man (input clk, input rst, output req, input  rsp);
+  modport sub (input clk, input rst, input  req, output rsp);
+endinterface
+
+// array of interface ports: drive req per element, read rsp back
+module drv (myif.man m [2-1:0]);
+  assign m[0].req = '{wen: 1'b1, adr: 8'd10};
+  assign m[1].req = '{wen: 1'b0, adr: 8'd20};
+endmodule
+
+// subordinate: echoes req.adr onto rsp.rdt
+module sub (myif.sub s);
+  assign s.rsp = '{rdt: s.req.adr};
+endmodule
+
+module dut (input logic clk, input logic rst,
+            output logic [7:0] o0, output logic [7:0] o1);
+  myif arr [2-1:0] (.clk(clk), .rst(rst));
+  drv  d  (.m(arr));
+  sub  s0 (.s(arr[0]));
+  sub  s1 (.s(arr[1]));
+  assign o0 = arr[0].rsp.rdt;   // = 10
+  assign o1 = arr[1].rsp.rdt;   // = 20
+endmodule

--- a/test/iface_array_struct_field/dut.sv
+++ b/test/iface_array_struct_field/dut.sv
@@ -1,0 +1,20 @@
+// Smallest repro: struct field access on an interface ARRAY ELEMENT signal
+// (`arr[0].req.adr`) — the first hier_path element is a bit_select.
+typedef struct packed { logic wen; logic [7:0] adr; } req_t;
+
+interface myif (input logic clk, input logic rst);
+  req_t req;
+  modport man (input clk, input rst, output req);
+  modport sub (input clk, input rst, input  req);
+endinterface
+
+module drv (myif.man m, input logic [7:0] a);
+  assign m.req = '{wen: 1'b1, adr: a};
+endmodule
+
+module dut (input logic clk, input logic rst,
+            input logic [7:0] a, output logic [7:0] o);
+  myif arr [2-1:0] (.clk(clk), .rst(rst));
+  drv  d0 (.m(arr[0]), .a(a));
+  assign o = arr[0].req.adr;     // array element + struct field
+endmodule


### PR DESCRIPTION
…rsp.rdt)

Extends the single-interface struct-field support to interface arrays: a field access on an array-element interface signal — `arr[0].req.adr` — returned X because the hier_path's first element is a bit_select (`arr[0]`), not a ref_obj, and no struct typespec was recorded for the array-element wire.

- import_interface_instances: record each array-element interface signal's packed struct/union typespec in iface_signal_struct_ts_ (keyed by the "arr[i].req" wire name), fetched from the design-level interface instance via AllInterfaces (the element's own net is a typespec-less struct_net).
- import_hier_path: the interface struct-member handler now accepts a bit_select base (array element) in addition to a ref_obj base (single port): it evaluates the constant index, forms "arr[idx].<sig>" as the base wire, and walks the struct members as before.

Tests: iface_array_struct_field (minimal array-element field read) and the full iface_array_struct (drv array port + per-element struct-bus req/rsp with field reads) both pass co-sim; all four struct-bus unit tests now pass.  No regressions (run_all_tests 674/676; struct/interface tests pass; 21 sim-equiv warnings unchanged).  Note: the degu SoC still has undriven bus wires — a separate bus-fabric (decoder/demux/arbiter) connectivity layer, not struct field access.