### PR TITLE
uhdm: generate-scope-local signal in async-reset always_ff (#441)

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -1044,6 +1044,21 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                 }
             }
 
+            // A signal declared INSIDE a generate block (`begin : g ... logic
+            // rr_ptr; always_ff ... rr_ptr <= ...`) is stored as the wire
+            // "<gen_scope>.rr_ptr", but extract_assigned_signals records the bare
+            // ref name "rr_ptr".  Resolve each to its actual wire so the
+            // async-reset register temp-wire / sync-rule path below finds it
+            // (issue #441 — else "Signal rr_ptr not found in module").
+            {
+                std::string gs = get_current_gen_scope();
+                if (!gs.empty())
+                    for (auto& sig : assigned_signals)
+                        if (!module->wire(RTLIL::escape_id(sig.name)) &&
+                            module->wire(RTLIL::escape_id(gs + "." + sig.name)))
+                            sig.name = gs + "." + sig.name;
+            }
+
             // Create ONE temp wire per unique signal (not per assignment)
             std::set<std::string> processed_signals;
             for (const auto& sig : assigned_signals) {
@@ -9027,6 +9042,17 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
             }
         }
 
+        // A generate-scope-local signal's LHS ref carries the bare name
+        // ("rr_ptr") but its temp wire is keyed by "<gen_scope>.rr_ptr" (the
+        // wire name).  Resolve it so the body write is redirected to the temp
+        // wire (issue #441 — else the FF body assigns the real wire directly and
+        // the sync update overwrites it with the stale temp value).
+        if (!signal_name.empty() && !current_signal_temp_wires.count(signal_name)) {
+            std::string gs = get_current_gen_scope();
+            if (!gs.empty() && current_signal_temp_wires.count(gs + "." + signal_name))
+                signal_name = gs + "." + signal_name;
+        }
+
         // If we have a temp wire for this signal, assign to it
         log("      Looking for signal '%s' in temp wires map (map size=%zu)\n",
             signal_name.c_str(), current_signal_temp_wires.size());
@@ -9373,6 +9399,17 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
             } else if (!full_name.empty()) {
                 signal_name = full_name;
             }
+        }
+
+        // A generate-scope-local signal's LHS ref carries the bare name
+        // ("rr_ptr") but its temp wire is keyed by "<gen_scope>.rr_ptr" (the
+        // wire name).  Resolve it so the body write is redirected to the temp
+        // wire (issue #441 — else the FF body assigns the real wire directly and
+        // the sync update overwrites it with the stale temp value).
+        if (!signal_name.empty() && !current_signal_temp_wires.count(signal_name)) {
+            std::string gs = get_current_gen_scope();
+            if (!gs.empty() && current_signal_temp_wires.count(gs + "." + signal_name))
+                signal_name = gs + "." + signal_name;
         }
 
         // If we have a temp wire for this signal, assign to it
@@ -10481,6 +10518,19 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                                     }
                                 }
 
+                                // A generate-scope-local signal's LHS ref name is
+                                // bare ("rr_ptr") but its temp wire is keyed by the
+                                // full wire name "<gen_scope>.rr_ptr".  Resolve so
+                                // the FF body write retargets the temp wire (#441 —
+                                // else it writes the real wire and the sync update
+                                // overwrites it with the stale temp value).
+                                if (!signal_name.empty() &&
+                                    !current_signal_temp_wires.count(signal_name)) {
+                                    std::string gs = get_current_gen_scope();
+                                    if (!gs.empty() &&
+                                        current_signal_temp_wires.count(gs + "." + signal_name))
+                                        signal_name = gs + "." + signal_name;
+                                }
                                 // If we have a temp wire for this signal, use it
                                 if (!signal_name.empty() && current_signal_temp_wires.count(signal_name)) {
                                     RTLIL::Wire* temp_wire = current_signal_temp_wires[signal_name];

--- a/test/genscope_async_ff_signal/dut.sv
+++ b/test/genscope_async_ff_signal/dut.sv
@@ -1,0 +1,19 @@
+// Issue #441: an async-reset always_ff inside a GENERATE scope assigns a
+// generate-scope-LOCAL signal (rr_ptr).  The async-reset path looked for the
+// bare name "rr_ptr" instead of the gen-scope-prefixed wire -> "Signal rr_ptr
+// not found in module".
+module dut #(parameter int N = 4) (
+    input  logic                  clk,
+    input  logic                  rst_n,
+    input  logic                  upd,
+    output logic [$clog2(N)-1:0]  o
+);
+    generate if (N > 1) begin : g_rr
+        logic [$clog2(N)-1:0] rr_ptr;       // generate-scope-local
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n)      rr_ptr <= '0;
+            else if (upd)    rr_ptr <= rr_ptr + 1'b1;
+        end
+        assign o = rr_ptr;
+    end endgenerate
+endmodule


### PR DESCRIPTION
A signal declared inside a generate block and assigned by an async-reset always_ff in that scope — e.g. `begin : g_rr; logic rr_ptr; always_ff @(posedge clk or negedge rst_n) rr_ptr <= ...; end` — aborted with "ERROR: Signal rr_ptr not found in module": its wire is named "g_rr.rr_ptr" but the LHS ref / extract_assigned_signals record the bare "rr_ptr".

Resolve the gen-scope prefix in the async-reset register path (process.cpp):
- before creating the per-signal temp wire, map the assigned-signal name to its actual wire ("g_rr.rr_ptr") so the lookup succeeds instead of erroring;
- in the FF-body assignment handler(s), resolve the bare LHS name to the prefixed temp-wire key so the body write retargets "$0\g_rr.rr_ptr" (else it wrote the real wire directly and the posedge sync update overwrote it with the stale temp value, so the register never updated).

New test genscope_async_ff_signal passes formal equivalence; the issue's full noc_router design now synthesises (was the "Signal not found" abort).  No regressions (run_all_tests 678/680; async-ff/generate-scope tests pass).

Fixes #441