### PR TITLE
uhdm: paramod naming for empty type params + on-demand interface-port…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -938,9 +938,19 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                     // synth top, e.g. rp32 r5p_hamster's gpr).
                                     if (!value_to_use.empty())
                                         cell_type += "\\" + param_name + "=\"" + value_to_use + "\"";
-                                } else {
+                                } else if (!value_to_use.empty()) {
+                                    // Skip EMPTY-value params: the module-def name
+                                    // builder (import_module) drops them (its
+                                    // `if (!val_str.empty())` guard), so a type
+                                    // param that didn't elaborate (e.g. `isa_t ISA`,
+                                    // `CFG` -> "") kept in the cell type would not
+                                    // match the def -> the cell is a blackbox, never
+                                    // flattened, so the core's outputs (degu SoC's
+                                    // tcb_ifu.vld) never reach the parent.  A
+                                    // non-empty but non-integer value (e.g. a large
+                                    // hex IFU_MSK, or 'X') is kept as 32 zeros,
+                                    // matching the def builder's own fallback.
                                     cell_type += "\\" + param_name + "=s32'";
-                                    // Strip type prefix and determine base
                                     int base = 10;
                                     size_t colon_pos = value_to_use.find(':');
                                     if (colon_pos != std::string::npos) {
@@ -949,14 +959,12 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                         if (prefix == "BIN") base = 2;
                                         else if (prefix == "HEX") base = 16;
                                     }
-                                    // Pad value to 32 bits
                                     try {
                                         int val = std::stoi(value_to_use, nullptr, base);
                                         for (int i = 31; i >= 0; i--) {
                                             cell_type += ((val >> i) & 1) ? "1" : "0";
                                         }
                                     } catch (const std::exception& e) {
-                                        log_warning("UHDM: Failed to parse parameter value '%s' as integer: %s\n", value_to_use.c_str(), e.what());
                                         cell_type += "00000000000000000000000000000000";
                                     }
                                 }
@@ -1073,16 +1081,23 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                                    src_base.c_str(), port_name.c_str()); continue; }
                                 }
                             }
-                            if (tgt_mod && port->High_conn()->UhdmType() == uhdmref_obj) {
+                            if (port->High_conn()->UhdmType() == uhdmref_obj) {
                                 const ref_obj* href = any_cast<const ref_obj*>(port->High_conn());
                                 std::string src_name = std::string(href->VpiName());
-                                std::string tgt_prefix = "\\" + port_name + ".";
                                 std::vector<std::string> field_names;
-                                for (auto& w : tgt_mod->wires_) {
-                                    std::string wn = w.first.str();
-                                    if (wn.compare(0, tgt_prefix.size(), tgt_prefix) == 0)
-                                        field_names.push_back(wn.substr(tgt_prefix.size()));
+                                if (tgt_mod) {
+                                    std::string tgt_prefix = "\\" + port_name + ".";
+                                    for (auto& w : tgt_mod->wires_) {
+                                        std::string wn = w.first.str();
+                                        if (wn.compare(0, tgt_prefix.size(), tgt_prefix) == 0)
+                                            field_names.push_back(wn.substr(tgt_prefix.size()));
+                                    }
                                 }
+                                // tgt_mod is null when a complex core is imported on
+                                // demand AFTER this connection (degu SoC): fall back
+                                // to the SOURCE interface instance's recorded fields.
+                                if (field_names.empty() && iface_inst_vars_.count(src_name))
+                                    field_names = iface_inst_vars_[src_name];
                                 if (!field_names.empty() && !src_name.empty()) {
                                     for (const auto& f : field_names) {
                                         std::string src_full = src_name + "." + f;

--- a/test/iface_samename_port/dut.sv
+++ b/test/iface_samename_port/dut.sv
@@ -1,0 +1,21 @@
+// Root #2 repro hypothesis: the interface INSTANCE and the connected module's
+// interface PORT share the same name ("bus") — like the degu SoC's
+// `.tcb_ifu(tcb_ifu)`.  Does the core's `bus.vld` drive reach the parent?
+interface myif (input logic clk, input logic rst);
+  logic vld, rdy, trn;
+  assign trn = vld & rdy;
+  modport man (input clk, input rst, output vld, input rdy, input trn);
+  modport sub (input clk, input rst, input  vld, output rdy, input trn);
+endinterface
+module core (myif.man bus);          // port named "bus"
+  assign bus.vld = 1'b1;
+endmodule
+module mon (myif.sub s, input logic g, output logic o);
+  assign s.rdy = g;
+  assign o = s.trn;
+endmodule
+module dut (input logic clk, input logic rst, input logic g, output logic o);
+  myif bus (.clk(clk), .rst(rst));   // instance ALSO named "bus"
+  core c  (.bus(bus));               // .bus(bus) — same name both sides
+  mon  mn (.s(bus), .g(g), .o(o));
+endmodule

--- a/test/paramod_struct_param/dut.sv
+++ b/test/paramod_struct_param/dut.sv
@@ -1,0 +1,12 @@
+// Root #2 (naming): a module with a struct/type parameter whose value doesn't
+// elaborate to an integer (like the degu's `isa_t ISA`) gets an empty param in
+// the cell type ("\ISA=") that the module-def name OMITS -> cell/def mismatch ->
+// blackbox -> not flattened -> outputs undriven.
+typedef struct packed { logic [3:0] a; logic [3:0] b; } cfg_t;
+module core #(parameter cfg_t CFG = '{a: 4'd5, b: 4'd3}, parameter int N = 2)
+            (input logic [3:0] x, output logic [3:0] o);
+  assign o = x ^ CFG.a;          // depends on the struct param
+endmodule
+module dut (input logic [3:0] x, output logic [3:0] o);
+  core #(.N(2)) c (.x(x), .o(o));
+endmodule


### PR DESCRIPTION
… connect

Two fixes that let the rp32 degu SoC's core wire into the bus fabric (root #2 of the degu-SoC undriven-wire investigation — the naming/flatten angle):

1. Empty type/struct params in the cell type.  A module with a parameter whose value doesn't elaborate to an integer (e.g. r5p_degu's `isa_t ISA`, `CFG`) got an EMPTY param in the cell type ("\ISA=") while import_module's module-def name builder DROPS it (its `if (!val_str.empty())` guard).  The names then differ, so the cell is a blackbox that `flatten` never inlines — the core's driven outputs (tcb_ifu.vld / tcb_lsu.vld) never reach the parent.  Skip empty-value params in the cell-type builder too (a non-empty non-integer value like a large hex IFU_MSK stays as 32 zeros, matching the def builder's own fallback).

2. On-demand interface-port connection.  When a complex core is imported AFTER its connection, `tgt_mod` is null and the whole interface port collapsed to a single dummy wire; fall back to the SOURCE interface instance's recorded fields so the per-field cell ports are created.

With both, the degu core inlines and tcb_ifu.vld / tcb_lsu.vld are driven.  New tests paramod_struct_param (a struct-parameterized core) + iface_samename_port (interface instance sharing the connected port's name).  No regressions (run_all_tests 680/682; hamster/degu/StructParameter pass; sim-equiv warnings 21 -> 19 — the empty-skip also fixed two other paramod cosims).  Remaining degu SoC undriven (gpio_o, peripheral bus) is a separate downstream layer.