### PR TITLE
uhdm: interface-array element plain-field access (man[i].vld)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6710,6 +6710,42 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
         }
     }
 
+    // Interface-ARRAY element plain-field access (`man[i].vld` where `man` is an
+    // array-of-modports port `man[N-1:0]` and `vld` is a plain interface signal).
+    // Path_elems = [bit_select(man[i]), ref_obj(vld)] — the MIRROR of the
+    // `bus.field[bits]` case below.  import_port created the per-element wire
+    // `\man[i].vld`; resolve directly to it.  Without this the generic walker
+    // builds a spurious instance-prefixed `\drv.man[i].vld` that does not match
+    // the port wire, so the demultiplexer's `assign man[i].vld = ...` (in a
+    // genvar loop) never drives tcb_per[i].vld and the degu SoC's peripheral bus
+    // is dead.  Works for both reads and the assign LHS.
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() == 2) {
+        auto& pe_af = *uhdm_hier->Path_elems();
+        if (pe_af[0]->UhdmType() == uhdmbit_select &&
+            pe_af[1]->UhdmType() == uhdmref_obj) {
+            auto bs = any_cast<const bit_select*>(pe_af[0]);
+            std::string base_name = std::string(bs->VpiName());
+            std::string field_name =
+                std::string(any_cast<const ref_obj*>(pe_af[1])->VpiName());
+            int idx = -1;
+            if (bs->VpiIndex()) {
+                RTLIL::SigSpec is = import_expression(bs->VpiIndex(), input_mapping);
+                if (is.is_fully_const()) idx = is.as_const().as_int();
+            }
+            if (idx >= 0 && !field_name.empty()) {
+                std::string wname =
+                    base_name + "[" + std::to_string(idx) + "]." + field_name;
+                RTLIL::Wire* w = name_map.count(wname) ? name_map[wname]
+                    : module->wire(RTLIL::escape_id(wname));
+                if (w) {
+                    log("    hier_path: interface-array element field %s -> wire %s\n",
+                        wname.c_str(), w->name.c_str());
+                    return RTLIL::SigSpec(w);
+                }
+            }
+        }
+    }
+
     // Interface-port signal bit/part-select access (e.g. `bus.adr[3:0]`
     // where `bus` is a `tcb_if.sub` modport port and `adr` is one of the
     // interface's signals).  Path_elems = [ref_obj(bus),

--- a/test/iface_array_modport_drive/dut.sv
+++ b/test/iface_array_modport_drive/dut.sv
@@ -1,0 +1,22 @@
+// Peripheral-bus root: a module drives `man[i].vld` (a FIELD of an array-of-
+// modports port element) inside a genvar for-loop — like tcb_lite_lib_
+// demultiplexer driving tcb_per[i].vld.  Does the drive reach arr[i].vld?
+interface myif (input logic clk);
+  logic vld, rdy;
+  modport man (output vld, input rdy);
+  modport sub (input  vld, output rdy);
+endinterface
+module driver #(parameter int N = 2) (myif.man man [N-1:0], input logic [N-1:0] v);
+  for (genvar i = 0; i < N; i++) begin: g
+    assign man[i].vld = v[i];
+  end
+endmodule
+module reader (myif.sub s, output logic o);
+  assign o = s.vld;
+endmodule
+module dut (input logic clk, input logic [1:0] v, output logic [1:0] o);
+  myif arr [2-1:0] (.clk(clk));
+  driver #(2) drv (.man(arr), .v(v));
+  reader r0 (.s(arr[0]), .o(o[0]));
+  reader r1 (.s(arr[1]), .o(o[1]));
+endmodule


### PR DESCRIPTION
A reference to a plain field of an array-of-modports element — `man[i].vld` where `man` is an interface-array port `man[N-1:0]` and `vld` is a simple interface signal — is a hier_path with 2 Path_elems: bit_select `man[i]` + ref_obj `vld`.  No import_hier_path handler covered this shape (the struct-field handler needs >=3 elems; the general member-chain handler needs an all-ref path, but here Path_elems[0] is a bit_select), so it fell to the generic walker which fabricated a spurious instance-prefixed wire `\drv.man[i].vld` that did not match the actual port wire `\man[i].vld`.  As an assign LHS that meant the demux's `for (genvar i) assign man[i].vld = ...` never drove the port.

Add a 2-elem handler (the mirror of the existing `bus.field[bits]` case) that resolves the bit_select index, builds `base[idx].field`, and returns the existing wire from name_map / module->wire — for both reads and the assign LHS.

New test iface_array_modport_drive (a genvar loop driving man[i].vld through an interface array, read back by per-element subordinates) passes co-simulation. No regressions (run_all_tests 681/683; all interface tests pass; sim-equiv warnings unchanged at 19).