### PR TITLE
uhdm: per-field modport direction for ARRAY modport ports

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -343,7 +343,29 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                     int sw = get_width(const_cast<UHDM::any*>(obj), ctx);
                     return (sw > 0) ? sw : 1;
                 };
-
+                // For an ARRAY modport port the interface TYPE name often doesn't
+                // resolve (interface_type empty), so the AllInterfaces search far
+                // above is skipped and `mp` stays null — and the iface_inst found
+                // by the elaborated swap is a modport-less stub.  Resolve the named
+                // modport from the interface DEFINITION in AllInterfaces (matched by
+                // the stub's def name) so the per-field modport DIRECTIONS get
+                // recorded below (degu SoC demux's `man[IFN-1:0]`: `man[i].vld` must
+                // be output, not the port's blanket input, or the demux can't drive
+                // tcb_per[i].vld).
+                if (!mp && !modport_name.empty() && iface_inst &&
+                    uhdm_design && uhdm_design->AllInterfaces()) {
+                    std::string want_def = std::string(iface_inst->VpiDefName());
+                    for (auto ii : *uhdm_design->AllInterfaces()) {
+                        if (!want_def.empty() &&
+                            std::string(ii->VpiDefName()) != want_def) continue;
+                        if (ii->Modports())
+                            for (auto m : *ii->Modports())
+                                if (std::string(m->VpiName()) == modport_name) {
+                                    mp = m; break;
+                                }
+                        if (mp) break;
+                    }
+                }
                 if (mp && mp->Io_decls() && iface_inst) {
                   // An ARRAY of interface ports (`myif.man m [N]`) reports a
                   // width of -N (-1 is a single interface); create the modport
@@ -356,6 +378,14 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                     for (auto io : *mp->Io_decls()) {
                         std::string sig_name = std::string(io->VpiName());
                         if (sig_name.empty()) continue;
+                        // Record the per-field modport direction unconditionally
+                        // (keyed by base port + field) so expand_interfaces can
+                        // give the ARRAY elements `portname[i].sig` the right
+                        // direction — even when this scalar wire already exists
+                        // (created by the interface-instance import) and the
+                        // creation below is skipped.
+                        modport_field_dir_[module->name.str() + ":" + portname +
+                                           ":" + sig_name] = io->VpiDirection();
                         std::string full_name = elem_prefix + "." + sig_name;
                         if (name_map.count(full_name)) continue;
                         // Find the matching net/variable in the interface

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -4022,6 +4022,20 @@ void UhdmImporter::expand_interfaces() {
                     if (signal_wire->attributes.count(dir_id)) {
                         dir = signal_wire->attributes.at(dir_id).as_int();
                         signal_wire->attributes.erase(dir_id);
+                    } else {
+                        // Array element `<port>[i].<field>`: the modport direction
+                        // wasn't stamped on the wire (it's created by the
+                        // interface-instance import).  Inherit it from the
+                        // per-field map recorded (module:port:field) by import_port.
+                        std::string n = signal_wire->name.str();
+                        if (!n.empty() && n[0] == '\\') n = n.substr(1);
+                        size_t dot = n.rfind('.');
+                        if (dot != std::string::npos) {
+                            std::string key = module->name.str() + ":" + port_name +
+                                              ":" + n.substr(dot + 1);
+                            auto it = modport_field_dir_.find(key);
+                            if (it != modport_field_dir_.end()) dir = it->second;
+                        }
                     }
                     if (dir == 1) {            // vpiInput
                         signal_wire->port_input = true;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -220,6 +220,14 @@ struct UhdmImporter {
     // field access (`s.req.adr`) in import_hier_path can slice the member.
     std::map<std::string, const UHDM::typespec*> iface_signal_struct_ts_;
 
+    // Per-field modport direction for a modport port, keyed
+    // "module:port:field" -> VpiDirection (1=in,2=out,3=inout).  Recorded by
+    // import_port's modport field loop; read by expand_interfaces so the ARRAY
+    // elements `port[i].field` (created by the interface-instance import without a
+    // modport direction, and expanded in a different iteration) inherit the right
+    // per-signal direction.
+    std::map<std::string, int> modport_field_dir_;
+
     // Track module instances to avoid duplicates
     // Key: module_name + parameter signature
     std::set<std::string> imported_module_signatures;


### PR DESCRIPTION
The field DIRECTION of an array-of-modports port was wrong: the degu SoC demultiplexer's `man[i].vld` (man modport: `output vld`) came out `input`, so the demux couldn't drive `tcb_per[i].vld` and the whole peripheral bus stayed undriven.

Root: for an ARRAY modport port (`tcb_lite_if.man man[IFN-1:0]`) the interface TYPE name doesn't resolve (interface_type empty), so import_port's existing AllInterfaces modport search is skipped and `mp` stays null; the elaborated swap finds an `iface_inst` but it's a modport-less stub.  With `mp` null, the modport field loop never records any per-field direction, and the array elements `man[i].<sig>` — created by the interface-instance import without a direction — fall back in expand_interfaces to the port's blanket `input`.

Fix:
- import_port (module.cpp): just before the modport field loop (where the elaborated `iface_inst` is finalised), if `mp` is still null resolve the named modport from the interface DEFINITION in AllInterfaces, matched by the stub's VpiDefName.  Record each field's VpiDirection in a persistent map `modport_field_dir_["module:port:field"]` unconditionally (even when the scalar wire already exists and creation is skipped).
- expand_interfaces (uhdm2rtlil.cpp): for an array element `port[i].field` with no `modport_direction` attribute, inherit the direction from that map instead of the port's blanket direction.

Result: `man[i].vld` is now `output`; the degu SoC's `tcb_per.vld`/`tcb_lsd.vld` are driven (undriven 170 -> 168).  No regressions (run_all_tests 681/683; all interface tests pass incl. iface_array_modport_drive/iface_modport_out; sim-equiv warnings unchanged at 19).  Remaining SoC undriven (gpio_o/gpio_e/ uart_txd) is a separate device-output self-loop layer.