### PR TITLE
uhdm: import children of generate-scope-nested parameterized modules

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2812,6 +2812,29 @@ void UhdmImporter::import_gen_scope(const gen_scope* uhdm_scope) {
             log("UHDM: Importing module instance '%s' of type '%s' in generate scope\n",
                 std::string(mod_inst->VpiName()).c_str(), std::string(mod_inst->VpiDefName()).c_str());
             import_instance(mod_inst);
+            // import_instance -> import_module imports the instance's OWN body but
+            // NOT its child instantiations (that recursion lives only in
+            // import_module_hierarchy).  For a generate-scope-nested parameterized
+            // module that left the paramod body EMPTY — e.g. degu SoC's
+            // gen_gpio.gpio (tcb_lite_dev_gpio paramod) never instantiated its
+            // tcb_dev_gpio child, so gpio_o was undriven.  Recurse into the
+            // elaborated instance's children so their cells are created in the
+            // paramod body — but ONLY for children whose cell is actually MISSING,
+            // so submodules already imported through the normal path aren't
+            // double-instantiated (which produced duplicate cells -> cosim
+            // mismatch on the *InGenScope* / *PassedToSubmodule* tests).
+            if (mod_inst->Modules()) {
+                RTLIL::Module* inst_mod = nullptr;
+                auto mn = inst_to_modname_.find(mod_inst);
+                if (mn != inst_to_modname_.end())
+                    inst_mod = design->module(RTLIL::escape_id(mn->second));
+                for (auto child : *mod_inst->Modules()) {
+                    if (inst_mod && inst_mod->cell(
+                            RTLIL::escape_id(std::string(child->VpiName()))))
+                        continue;  // already instantiated
+                    import_module_hierarchy(child, true);
+                }
+            }
         }
     }
     

--- a/test/paramod_genscope_child/dut.sv
+++ b/test/paramod_genscope_child/dut.sv
@@ -1,0 +1,15 @@
+// gpio_o device-output root: a PARAMETERIZED module instantiated inside a
+// GENERATE scope, which itself instantiates a CHILD module — like the degu SoC's
+// gen_gpio.gpio (tcb_lite_dev_gpio paramod) -> gpio (tcb_dev_gpio).  Does the
+// paramod's child get imported, or is the paramod body incomplete?
+module child (input logic x, output logic o);
+  assign o = ~x;
+endmodule
+module mid #(parameter int N = 4) (input logic x, output logic o);
+  child c (.x(x), .o(o));        // child instantiation inside the paramod
+endmodule
+module dut (input logic x, output logic o);
+  generate if (1) begin: g
+    mid #(8) m (.x(x), .o(o));   // parameterized mid inside a generate scope
+  end endgenerate
+endmodule


### PR DESCRIPTION
A parameterized module instantiated inside a generate scope got an EMPTY paramod body — its own child instantiations were never imported, so its outputs were undriven.  The degu SoC's gen_gpio.gpio (tcb_lite_dev_gpio paramod) never instantiated its tcb_dev_gpio child, leaving gpio_o/gpio_e dead.

Root: the generate-scope import loop calls import_instance(mod_inst), which goes through import_module — that imports a module's OWN body (ports, assigns, processes) but NOT its child instantiations; the child recursion lives only in import_module_hierarchy (used for the top-level / direct-child hierarchy).

Fix (import_gen_scope): after import_instance, recurse into the elaborated instance's Modules() children via import_module_hierarchy so their cells are created in the paramod body — but ONLY for children whose cell is actually MISSING.  Submodules already imported through the normal path must not be double-instantiated: an unconditional recursion created duplicate cells and regressed 7 *InGenScope* / *PassedToSubmodule* cosim tests; gating on `inst_mod->cell(child)` absent keeps them intact.

New test paramod_genscope_child (a parameterized module in a generate scope that instantiates a child) passes formal equivalence.  No regressions (run_all_tests 682/684; the *InGenScope*/*PassedToSubmodule* tests pass; sim-equiv warnings unchanged at 19).  This is necessary-but-not-sufficient for the SoC's gpio_o: tcb_dev_gpio additionally needs its interface-derived SYS_DAT parameter (sub.CFG.BUS.DAT, currently empty) resolved — a separate follow-up.