### PR TITLE
uhdm: resolve interface struct-parameter field values via Surelog Vpi…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1487,9 +1487,16 @@ void UhdmImporter::import_parameter(const any* uhdm_param) {
             // yields a fully-X constant (is_fully_const() is TRUE for X), so test
             // is_fully_def() and resolve via the interface instead.
             std::string iface_val;
-            if (!value_spec.is_fully_def() && expr->UhdmType() == uhdmhier_path)
-                iface_val = eval_iface_param_field(
-                    any_cast<const UHDM::hier_path*>(expr), current_instance);
+            if (!value_spec.is_fully_def() && expr->UhdmType() == uhdmhier_path) {
+                // Prefer the parameter's own Surelog-resolved VpiValue (e.g.
+                // SYS_DAT -> "UINT:32"); fall back to walking the interface.
+                std::string vv = std::string(param_obj->VpiValue());
+                if (!vv.empty())
+                    iface_val = std::to_string(parse_vpi_value_to_int(vv));
+                else
+                    iface_val = eval_iface_param_field(
+                        any_cast<const UHDM::hier_path*>(expr), current_instance);
+            }
             if (!iface_val.empty()) {
                 // Interface struct-parameter field (`sub.CFG.BUS.DAT`): resolve so
                 // the specialized def's body uses the right value (not X), matching


### PR DESCRIPTION
…Value

Follow-up to the eval_iface_param_field foundation.  For a child parameter whose value is an interface struct-parameter field (degu SoC's tcb_dev_gpio `.SYS_DAT(sub.CFG.BUS.DAT)`), Surelog leaves the param_assign RHS an unevaluated hier_path so import_expression yields a fully-X constant — but Surelog DOES resolve the value onto the parameter object's own VpiValue ("UINT:32").

In import_parameter, within the existing hier_path-X branch (where import_expression isn't fully_def and the RHS is a hier_path), prefer the parameter's VpiValue before falling back to walking the interface instance. This is far more robust than the interface-array navigation (AllInterfaces only holds the interface TYPE, not the per-element instances), and unblocks the degu SoC's tcb_dev_gpio import (SYS_DAT now 32, not X).

The check is kept INSIDE the hier_path-X branch on purpose: an earlier attempt to also use the LHS-parameter VpiValue in the cell-type/def-name builders regressed ClogOf/OutputSizeWithParameterOfInstanceInitializedByStructMember (param_assign->Lhs()->VpiValue() returns the DEFINITION default for a local struct-member param, not the override) and was unnecessary — the SoC progresses with the import_parameter change alone.

No regressions (run_all_tests 682/684; the two *ParamOfInstanceInitializedBy StructMember* tests pass; sim-equiv warnings 19).  gpio_o still undriven: with SYS_DAT resolved, tcb_dev_gpio imports and uncovers the next blocker — "Signal gpio_t not found" (an unpacked array in an always_ff in tcb_dev_gpio_cdc), a separate follow-up.