### PR TITLE
uhdm: unpacked array written in an always_ff (whole-array/element/slice)

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10439,6 +10439,20 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                                     if (!bs->VpiName().empty()) {
                                         signal_name = std::string(bs->VpiName());
                                         is_partial = true;
+                                        // Constant bit-select of an UNPACKED array
+                                        // (`arr[0] <= ...`, per-element wires):
+                                        // target the element wire \arr[0] so its
+                                        // $0\arr[0] temp is found (tcb_dev_gpio_cdc).
+                                        auto bidx = bs->VpiIndex();
+                                        if (bidx && bidx->VpiType() == vpiConstant &&
+                                            module->wire(RTLIL::escape_id(signal_name + "[0]"))) {
+                                            RTLIL::SigSpec is = import_expression(bidx);
+                                            if (is.is_fully_const()) {
+                                                signal_name += "[" +
+                                                    std::to_string(is.as_const().as_int()) + "]";
+                                                is_partial = false;
+                                            }
+                                        }
                                     }
                                 } else if (lhs->VpiType() == vpiPartSelect) {
                                     const part_select* ps = any_cast<const part_select*>(lhs);
@@ -10554,6 +10568,35 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                                     if (mode_debug)
                                         log("        Using temp wire %s for signal %s in async reset context (partial=%d)\n",
                                             temp_wire->name.c_str(), signal_name.c_str(), is_partial ? 1 : 0);
+                                }
+                                // UNPACKED-array whole-array / slice writes: the
+                                // LHS lowered to a concat of per-element wires
+                                // ({\arr[1] \arr[0]} for `arr <= '{default:'0}`,
+                                // or \arr[i] for the slice-shift), which the
+                                // single-signal remap above can't retarget.  Remap
+                                // EACH chunk on a per-element wire \arr[i] to its
+                                // own $0\arr[i] temp so the sync update carries it
+                                // (tcb_dev_gpio_cdc; else the write hits \arr[i]
+                                // directly and the sync overwrites it -> 0).
+                                {
+                                    RTLIL::SigSpec mapped;
+                                    bool any = false;
+                                    for (const auto& ch : target_sig.chunks()) {
+                                        std::string wn;
+                                        if (ch.wire) {
+                                            wn = ch.wire->name.str();
+                                            if (!wn.empty() && wn[0] == '\\') wn = wn.substr(1);
+                                        }
+                                        auto it = current_signal_temp_wires.find(wn);
+                                        if (ch.wire && it != current_signal_temp_wires.end() &&
+                                            ch.wire != it->second) {
+                                            mapped.append(RTLIL::SigChunk(it->second, ch.offset, ch.width));
+                                            any = true;
+                                        } else {
+                                            mapped.append(ch);
+                                        }
+                                    }
+                                    if (any) target_sig = mapped;
                                 }
                             } else if (!current_temp_wires.empty()) {
                                 // Check if this exact LHS expression has a temp wire

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -328,10 +328,31 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                         extract_lhs_signals(lhs_expr, signals);
                     } else if (lhs_expr->VpiType() == vpiRefObj) {
                         auto ref = any_cast<const ref_obj*>(lhs_expr);
-                        sig.name = std::string(ref->VpiName());
-                        sig.is_part_select = false;
-                        signals.push_back(sig);
-                        log("extract_assigned_signals: Found assignment to '%s' (ref_obj)\n", ref->VpiName().data());
+                        std::string nm = std::string(ref->VpiName());
+                        // Whole-array write to an UNPACKED array (`arr <=
+                        // '{default:'0}`): `arr` is not a wire — it was
+                        // materialised as per-element registers \arr[0..N-1].
+                        // Expand to per-element so the async-ff temp-wire path
+                        // finds them (tcb_dev_gpio_cdc; else "Signal arr not
+                        // found in module").  lhs_expr stays the whole-array LHS.
+                        if (!module->wire(RTLIL::escape_id(nm)) &&
+                            module->wire(RTLIL::escape_id(nm + "[0]"))) {
+                            for (int i = 0; module->wire(RTLIL::escape_id(
+                                     nm + "[" + std::to_string(i) + "]")); i++) {
+                                AssignedSignal es;
+                                es.name = nm + "[" + std::to_string(i) + "]";
+                                es.lhs_expr = lhs_expr;
+                                es.is_part_select = false;
+                                signals.push_back(es);
+                            }
+                            log("extract_assigned_signals: expanded whole unpacked "
+                                "array '%s' to per-element\n", nm.c_str());
+                        } else {
+                            sig.name = nm;
+                            sig.is_part_select = false;
+                            signals.push_back(sig);
+                            log("extract_assigned_signals: Found assignment to '%s' (ref_obj)\n", ref->VpiName().data());
+                        }
                     } else if (lhs_expr->VpiType() == vpiNetBit) {
                         auto net_bit = any_cast<const UHDM::net_bit*>(lhs_expr);
                         sig.name = std::string(net_bit->VpiName());
@@ -391,6 +412,20 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                                 RTLIL::SigSpec s = import_expression(re);
                                 if (s.is_fully_const()) er = s.as_const().as_int();
                             }
+                            // A range bound that's a module-parameter expression
+                            // (`arr[CDC-1:1]`, CDC a param) doesn't const-fold in
+                            // this context.  CDC-1 is the array's TOP index, so
+                            // fall back to the element-wire count for an
+                            // unresolved bound (tcb_dev_gpio_cdc's shift).
+                            if (el < 0 || er < 0) {
+                                int n = 0;
+                                while (module->wire(RTLIL::escape_id(
+                                           sig.name + "[" + std::to_string(n) + "]"))) n++;
+                                if (n > 0) {
+                                    if (el < 0) el = n - 1;
+                                    if (er < 0) er = n - 1;
+                                }
+                            }
                             if (el >= 0 && er >= 0) {
                                 int lo = std::min(el, er), hi = std::max(el, er);
                                 for (int i = lo; i <= hi; i++) {
@@ -445,6 +480,17 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                                     log("extract_assigned_signals: Skipping dynamic write to expanded array '%s'\n",
                                         sig.name.c_str());
                                     break;
+                                }
+                            } else if (module->wire(RTLIL::escape_id(sig.name + "[0]"))) {
+                                // Constant bit-select of an UNPACKED array
+                                // (`arr[0] <= ...`): the element is its OWN wire
+                                // \arr[0] — name the signal after it (a full wire),
+                                // not `\arr` which isn't a wire and trips "Signal
+                                // arr not found" (tcb_dev_gpio_cdc).
+                                RTLIL::SigSpec is = import_expression(idx);
+                                if (is.is_fully_const()) {
+                                    sig.name += "[" + std::to_string(is.as_const().as_int()) + "]";
+                                    sig.is_part_select = false;
                                 }
                             }
                         }

--- a/test/unpacked_array_shift_ff/dut.sv
+++ b/test/unpacked_array_shift_ff/dut.sv
@@ -1,0 +1,19 @@
+// gpio_t layer: an UNPACKED ARRAY written in an always_ff with whole-array
+// reset, element write, and array slice-shift — like tcb_dev_gpio_cdc's
+// `logic [DAT-1:0] gpio_t [CDC-1:0]`.  Triggered "Signal gpio_t not found".
+module dut #(parameter int W = 8, parameter int N = 2) (
+    input  logic           clk,
+    input  logic           rst,
+    input  logic [W-1:0]   din,
+    output logic [W-1:0]   dout
+);
+    logic [W-1:0] arr [N-1:0];           // unpacked array (CDC stages)
+    always_ff @(posedge clk, posedge rst)
+    if (rst) begin
+        arr <= '{default: '0};           // whole-array reset
+    end else begin
+        arr[0]      <= din;              // element write
+        arr[N-1:1]  <= arr[N-2:0];       // array slice-shift
+    end
+    assign dout = arr[N-1];
+endmodule


### PR DESCRIPTION
An UNPACKED array written inside an always_ff — whole-array `arr <= '{default:'0}`, element `arr[0] <= x`, and array slice-shift `arr[N-1:1] <= arr[N-2:0]` — aborted with "Signal arr not found in module".  The array is materialised as per-element registers \arr[0..N-1], so the whole name \arr is not a wire, and the async-ff lowering looked it up directly.  tcb_dev_gpio_cdc's CDC synchroniser hits this, which blocked the degu SoC's tcb_dev_gpio (and thus gpio_o/gpio_e/uart_txd).

Four coordinated fixes (all mirror the #441 signal_name pattern):
1. extract_assigned_signals (process_helper.cpp): a ref_obj whole-array LHS expands to per-element arr[0..N-1]; a CONST bit-select arr[0] is named after the element wire \arr[0] (not \arr).
2. async-ff body handler (process.cpp): a const bit-select arr[0] uses the element-wire signal_name so the write retargets $0\arr[0].
3. per-element remap (process.cpp): the whole-array '{default:'0} lowers to a concat {\arr[1] \arr[0]} and the slice-shift to per-element chunks — remap EACH chunk on a \arr[i] wire to its own $0\arr[i] temp, since the existing single-signal remap can't handle the multi-wire concat (else the writes hit \arr[i] directly and the sync update overwrites them -> opt collapses to 0).
4. part-select range (process_helper.cpp): a parameter-expression high bound (`arr[CDC-1:1]`, CDC a module param) doesn't const-fold in this context; CDC-1 is the array's top index, so fall back to the element-wire count.

New test unpacked_array_shift_ff (a 2-stage shift register through an unpacked array) passes co-simulation.  No regressions (run_all_tests 683/685; MemorySlice/ mem2reg/issue326 pass; sim-equiv warnings 19).  On the degu SoC this drives gpio_o/gpio_e/uart_txd at last — undriven 168 -> 39 (the remainder is clk/rst distribution to the cdc/uart sub-instances, a separate layer).