### PR TITLE
uhdm: drive clk/rst through interface-signal port connections and int…

### DIFF
--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -519,6 +519,17 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                         }
                     }
                     if (!lw) continue;
+                    // Record this interface PORT signal (clk/rst) so the
+                    // per-field connection of an interface-array element
+                    // (`.sub(tcb_per[0])`) also wires sub.clk/sub.rst — the
+                    // Variables/Nets loops only recorded the data signals, so
+                    // without this the degu SoC's cdc/uart leaf clk/rst stay
+                    // undriven.
+                    {
+                        auto& iv = iface_inst_vars_[interface_name];
+                        if (std::find(iv.begin(), iv.end(), port_name) == iv.end())
+                            iv.push_back(port_name);
+                    }
                     RTLIL::SigSpec lo(lw);
                     int w = std::min(hi.size(), lo.size());
                     if (hi.size() > w) hi = hi.extract(0, w);

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1280,6 +1280,36 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                             const expr* high_conn = any_cast<const expr*>(port->High_conn());
                             RTLIL::SigSpec conn = import_expression(high_conn);
 
+                            // Interface-signal connection (`.clk(sub.clk)`):
+                            // Surelog resolves the High_conn through the interface
+                            // to the TOP-LEVEL net (e.g. dut.clk), which isn't a
+                            // local wire here — import_port made the local wire
+                            // "\<ifaceport>.<sig>" (\sub.clk).  When the net didn't
+                            // resolve, match it to that interface-signal wire by
+                            // leaf name so the child's clk/rst get driven (degu
+                            // SoC tcb_dev_gpio / cdc).
+                            if (conn.empty() &&
+                                high_conn->UhdmType() == uhdmlogic_net) {
+                                std::string suffix =
+                                    "." + std::string(high_conn->VpiName());
+                                RTLIL::Wire* found = nullptr;
+                                int nmatch = 0;
+                                for (auto w : module->wires()) {
+                                    std::string wn = w->name.str();
+                                    if (wn.size() > suffix.size() + 1 &&
+                                        wn[0] == '\\' &&
+                                        wn.compare(wn.size() - suffix.size(),
+                                                   suffix.size(), suffix) == 0) {
+                                        found = w; nmatch++;
+                                    }
+                                }
+                                if (found && nmatch == 1) {
+                                    conn = RTLIL::SigSpec(found);
+                                    log("UHDM: interface-signal port %s -> %s\n",
+                                        port_name.c_str(), found->name.c_str());
+                                }
+                            }
+
                             // For signed constants connected to wider ports, create a signed
                             // intermediate wire so the hierarchy pass will sign-extend them.
                             // Unsigned constants are left as-is (hierarchy zero-extends).

--- a/test/iface_sig_in_child_port/dut.sv
+++ b/test/iface_sig_in_child_port/dut.sv
@@ -1,0 +1,18 @@
+// clk/rst layer: a child instance's port is connected to an INTERFACE SIGNAL
+// access (`.clk(sub.clk)`) where sub is the parent's interface port — like
+// tcb_dev_gpio `.clk(sub.clk)`.  Does sub.clk reach the child, or come out empty?
+interface myif (input logic clk, input logic rst);
+  logic sig;
+  modport s (input clk, input rst, output sig);
+endinterface
+module child (input logic clk, input logic rst, output logic q);
+  always_ff @(posedge clk, posedge rst) if (rst) q <= 1'b0; else q <= ~q;
+endmodule
+module mid (myif.s sub, output logic q);
+  child c (.clk(sub.clk), .rst(sub.rst), .q(q));
+  assign sub.sig = q;
+endmodule
+module dut (input logic clk, input logic rst, output logic q);
+  myif mif (.clk(clk), .rst(rst));
+  mid m (.sub(mif), .q(q));
+endmodule


### PR DESCRIPTION
…erface arrays

clk/rst reaching a leaf instance through an interface (`.clk(sub.clk)` where `sub` is the parent's interface/modport port) came out undriven.  Two gaps:

1. A child port connection `.clk(sub.clk)` has a High_conn that Surelog resolves THROUGH the interface to the top-level net (e.g. `dut.clk`), which is not a local wire in the parent — import_port made the local wire `\sub.clk`. import_expression returned empty, so the child's clk/rst port came out `{ }`. Fix (uhdm2rtlil.cpp): when a logic_net High_conn doesn't resolve, match it to the unique interface-signal wire `\<ifaceport>.<leaf>` by leaf name.

2. The interface-array element connection `.sub(tcb_per[0])` wires the interface data signals (vld/rdy/...) per-field from iface_inst_vars_, but the interface PORT signals clk/rst (created in the Ports() loop, not in Variables()/Nets()) were never recorded there — so sub.clk/sub.rst were skipped. Fix (interface.cpp): record each connected interface port signal in iface_inst_vars_ so the per-field connection wires them too.

New test iface_sig_in_child_port (a child clocked through `sub.clk`) passes formal equivalence.  No regressions (run_all_tests 684/686).  On the degu SoC this completes clk/rst distribution into the deeply gen-scope-nested cdc/uart leaf instances: SoC undriven 39 -> 0 — the whole r5p_degu_soc_top now connects (all outputs + clocks/resets driven).