### PR TITLE
uhdm: detect interface-ARRAY port width; add full degu SoC as a uhdm-…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2112,6 +2112,43 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
         // Check if it's a port and try to get typespec
         if (auto port = dynamic_cast<const UHDM::port*>(uhdm_obj)) {
             log("UHDM: Found port object\n");
+            // An ARRAY of interface ports (`myif.man m [N]`): the array
+            // dimension is NOT in the port typespec (which resolves to a single
+            // interface_typespec) — it lives on the Low_conn's interface_array.
+            // Return -N so import_port creates per-element wires m[0..N-1].<sig>
+            // for EVERY modport signal (degu SoC demux's man[IFN]; else req/rsp/
+            // clk/rst come out scalar \man.req and mismatch the per-element
+            // connections, aborting the hierarchical netlist).
+            if (auto lc = port->Low_conn()) {
+                if (lc->UhdmType() == uhdmref_obj) {
+                    auto a = any_cast<const UHDM::ref_obj*>(lc)->Actual_group();
+                    if (a && a->UhdmType() == uhdminterface_array) {
+                        auto ia = any_cast<const UHDM::interface_array*>(a);
+                        int n = 0;
+                        if (ia->Instances()) n = (int)ia->Instances()->size();
+                        if (n < 1 && ia->Ranges()) {
+                            n = 1;
+                            for (auto r : *ia->Ranges()) {
+                                int l = 0, rr = 0;
+                                if (r->Left_expr()) {
+                                    auto s = import_expression(r->Left_expr());
+                                    if (s.is_fully_const()) l = s.as_const().as_int();
+                                }
+                                if (r->Right_expr()) {
+                                    auto s = import_expression(r->Right_expr());
+                                    if (s.is_fully_const()) rr = s.as_const().as_int();
+                                }
+                                n *= std::abs(l - rr) + 1;
+                            }
+                        }
+                        if (n >= 1) {
+                            log("UHDM: interface-array port '%s', %d element(s) -> width %d\n",
+                                std::string(port->VpiName()).c_str(), n, -n);
+                            return -n;
+                        }
+                    }
+                }
+            }
             if (auto typespec = port->Typespec()) {
                 log("UHDM: Port has typespec, calling get_width_from_typespec\n");
                 return get_width_from_typespec(typespec, inst);
@@ -2299,7 +2336,41 @@ int UhdmImporter::get_width_from_typespec(const UHDM::any* typespec, const UHDM:
             // They represent a bundle of signals
             return -1;  // Special value to indicate interface type
         }
-        
+
+        // An ARRAY of interface ports (`myif.man m [N]`): the typespec is an
+        // array_typespec wrapping an interface_typespec.  Return -N so
+        // import_port creates per-element wires m[0..N-1].<sig> for EVERY
+        // modport signal.  Without this the array isn't detected (-1 single
+        // interface) and req/rsp/clk/rst are created SCALAR (\man.req), which
+        // mismatches the per-element connections (degu SoC demux's man[IFN]).
+        if (typespec->UhdmType() == uhdmarray_typespec) {
+            auto at = any_cast<const UHDM::array_typespec*>(typespec);
+            bool elem_is_iface = false;
+            if (at->Elem_typespec() && at->Elem_typespec()->Actual_typespec())
+                elem_is_iface = at->Elem_typespec()->Actual_typespec()->UhdmType()
+                                == uhdminterface_typespec;
+            if (elem_is_iface) {
+                int n = 1;
+                if (at->Ranges()) {
+                    for (auto r : *at->Ranges()) {
+                        int l = 0, rr = 0;
+                        if (r->Left_expr()) {
+                            auto s = import_expression(r->Left_expr());
+                            if (s.is_fully_const()) l = s.as_const().as_int();
+                        }
+                        if (r->Right_expr()) {
+                            auto s = import_expression(r->Right_expr());
+                            if (s.is_fully_const()) rr = s.as_const().as_int();
+                        }
+                        n *= std::abs(l - rr) + 1;
+                    }
+                }
+                if (n < 1) n = 1;
+                log("UHDM: interface-array typespec, %d element(s) -> width %d\n", n, -n);
+                return -n;
+            }
+        }
+
         // Check if this is an enum typespec - need to get the base type
         if (typespec->UhdmType() == uhdmenum_typespec) {
             log("UHDM: Found enum_typespec, getting base type\n");

--- a/test/rp32_r5p_degu_soc_top/project.f
+++ b/test/rp32_r5p_degu_soc_top/project.f
@@ -1,0 +1,47 @@
+# rp32 r5p_degu_soc_top — the complete Degu SoC: the r5p_degu core + the full TCB
+# lite bus fabric (decoder/demux/arbiter/register) + GPIO/UART devices + SoC
+# memory.  File list from jeras/rp32 sim/sources-degu.mk.  Hand-written.
+# top: r5p_degu_soc_top
+# mode: uhdm-only
+# surelog: -top r5p_degu_soc_top
+
+# --- TCB bus (jeras/TCB, imported into test/rp32/tcb/) ---
+../rp32/tcb/tcb_lite_pkg.sv
+../rp32/tcb/tcb_lite_if.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_passthrough.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_logsize2byteena.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_arbiter.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_multiplexer.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_decoder.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_demultiplexer.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_register_request.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_error.sv
+../rp32/tcb/dev/gpio/tcb_dev_gpio_cdc__generic.sv
+../rp32/tcb/dev/gpio/tcb_dev_gpio.sv
+../rp32/tcb/lite_dev/gpio/tcb_lite_dev_gpio.sv
+../rp32/tcb/dev/uart/tcb_dev_uart_ser.sv
+../rp32/tcb/dev/uart/tcb_dev_uart_des.sv
+../rp32/tcb/dev/uart/tcb_dev_uart_fifo.sv
+../rp32/tcb/dev/uart/tcb_dev_uart.sv
+../rp32/tcb/lite_dev/uart/tcb_lite_dev_uart.sv
+
+# --- R5P core ---
+../rp32/riscv/riscv_isa_pkg.sv
+../rp32/riscv/riscv_priv_pkg.sv
+../rp32/riscv/riscv_isa_i_pkg.sv
+../rp32/riscv/riscv_isa_c_pkg.sv
+../rp32/riscv/rv32_csr_pkg.sv
+../rp32/riscv/rv64_csr_pkg.sv
+../rp32/core/r5p_gpr_2r1w.sv
+../rp32/degu/r5p_pkg.sv
+../rp32/degu/r5p_bru.sv
+../rp32/degu/r5p_alu.sv
+../rp32/degu/r5p_mdu.sv
+../rp32/degu/r5p_lsu.sv
+../rp32/degu/r5p_wbu.sv
+../rp32/degu/r5p_degu_pkg.sv
+../rp32/degu/r5p_degu.sv
+
+# --- SoC ---
+../rp32/soc/r5p_soc_memory__gowin_inference.sv
+../rp32/soc/r5p_degu_soc_top.sv


### PR DESCRIPTION
…only test

An ARRAY of interface ports (`tcb_lite_if.man man[IFN]`) was sized as a SINGLE interface (-1) by get_width, because the array dimension is NOT in the port's typespec (which resolves to a lone interface_typespec) — it lives on the port's Low_conn `interface_array`.  As a result import_port created only the scalar `\man.<sig>` wires, while the per-element connections/genvar assigns referenced `man[0].<sig>`/`man[1].<sig>`; the data flags happened to materialise per-element but req/rsp/clk/rst stayed scalar.  The FLATTENED netlist hid this (0 undriven), but the HIERARCHICAL netlist aborted: "Module $paramod\tcb_lite_lib_demultiplexer \IFN=2 ... does not have a port named man[1].rst".

Fix (module.cpp get_width): when a port's Low_conn resolves to an `interface_array`, return -N (N = Instances()->size(), else the Ranges product) so import_port creates per-element `man[0..N-1].<sig>` wires for EVERY modport signal.  A companion case in get_width_from_typespec handles the typespec-wrapped form (`array_typespec` over an interface) that import_port already unwraps.

Also add the complete Degu SoC (r5p_degu core + full TCB lite bus fabric + GPIO/UART devices + SoC memory) as test rp32_r5p_degu_soc_top.  The frontend matrix confirms it is genuinely uhdm-only: verilog, sv2v and slang all READ_FAIL on it (struct params in generate-if, interface arrays, genvar struct-field access), while the UHDM frontend reads + synthesises it (7593 gates, hierarchical netlist now consistent).  project.f references the already-tracked rp32 RTL.

run_all_tests 685/687 (no regressions; interface-array + iface_sig_in_child_port tests unaffected); the SoC test passes (UHDM succeeds where Verilog fails).