### PR TITLE
uhdm: resolve cross-module reference (XMR) reads (github #450)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6217,6 +6217,30 @@ RTLIL::SigSpec UhdmImporter::import_concat(const operation* uhdm_concat, const U
     return result;
 }
 
+// XMR read resolution (github #450): expose the child signal `sig` as an OUTPUT
+// PORT of `cell`'s module and wire it to the parent's `\<inst>.<sig>` reader.
+// This makes the source survive `opt` (a port is kept) and flatten connect it
+// to the reader — matching what slang produces for `monitor_flag =
+// u_processor.internal_ready`.
+void UhdmImporter::resolve_xmr_read(RTLIL::Module* mod, RTLIL::Cell* cell, const std::string& sig) {
+    if (!mod || !cell || sig.empty()) return;
+    RTLIL::Module* child = design->module(cell->type);
+    if (!child) return;
+    RTLIL::Wire* cw = child->wire(RTLIL::escape_id(sig));
+    if (!cw) return;
+    if (!cw->port_output && !cw->port_input) {
+        cw->port_output = true;
+        child->fixup_ports();
+    }
+    std::string inst = cell->name.str();
+    if (!inst.empty() && inst[0] == '\\') inst = inst.substr(1);
+    std::string pn = inst + "." + sig;
+    RTLIL::Wire* pw = mod->wire(RTLIL::escape_id(pn));
+    if (!pw) pw = mod->addWire(RTLIL::escape_id(pn), cw->width);
+    if (!cell->hasPort(RTLIL::escape_id(sig)))
+        cell->setPort(RTLIL::escape_id(sig), pw);
+}
+
 // Import hierarchical path (e.g., bus.a, interface.signal)
 RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const scope* inst, const std::map<std::string, RTLIL::SigSpec>* input_mapping) {
     if (mode_debug)
@@ -6235,6 +6259,60 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
     
     log("    hier_path: VpiName='%s', VpiFullName='%s', using='%s'\n",
         std::string(name_view).c_str(), std::string(full_name_view).c_str(), path_name.c_str());
+    // Cross-module reference (XMR) READ: `u_processor.internal_ready` where
+    // `u_processor` is a child INSTANCE in this module and `internal_ready` is
+    // an INTERNAL signal of it (github #450).  Yosys can't resolve this through
+    // the normal synth flow: the source is opt'd away (unused WITHIN the child)
+    // and a plain parent wire collides with the flattened name.  Resolve it the
+    // way slang does — expose the child signal as an OUTPUT PORT and wire the
+    // cell through — so the source survives opt and drives the reader after
+    // flatten.  Only fires when the first element is genuinely a cell instance
+    // (interface-port `sub.clk` and struct-field `s.f` reads fall through: their
+    // base is a wire/port, not a cell).
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() == 2) {
+        auto& xpe = *uhdm_hier->Path_elems();
+        if (xpe[0]->UhdmType() == uhdmref_obj &&
+            xpe[1]->UhdmType() == uhdmref_obj) {
+            std::string inst = std::string(any_cast<const ref_obj*>(xpe[0])->VpiName());
+            std::string sig  = std::string(any_cast<const ref_obj*>(xpe[1])->VpiName());
+            RTLIL::Cell* xcell = inst.empty() ? nullptr
+                               : module->cell(RTLIL::escape_id(inst));
+            RTLIL::Module* xchild = xcell ? design->module(xcell->type) : nullptr;
+            if (xchild && !sig.empty()) {
+                if (xchild->wire(RTLIL::escape_id(sig))) {
+                    resolve_xmr_read(module, xcell, sig);
+                    log("    XMR read %s.%s: exposed child output port\n",
+                        inst.c_str(), sig.c_str());
+                    return RTLIL::SigSpec(module->wire(RTLIL::escape_id(inst + "." + sig)));
+                }
+            } else if (!xcell && !inst.empty() && !sig.empty() &&
+                       !module->wire(RTLIL::escape_id(inst)) &&
+                       any_cast<const ref_obj*>(xpe[0])->Actual_group() &&
+                       any_cast<const ref_obj*>(xpe[0])->Actual_group()->UhdmType()
+                           == uhdmmodule_inst) {
+                // The cell doesn't exist yet — cont_assigns are imported BEFORE
+                // instances.  The first element resolves to a MODULE INSTANCE
+                // (not a parameter `CFG.field`, struct, or interface — those
+                // resolve elsewhere), so this is a genuine XMR.
+                // Record it + create the reader wire now and RETURN it (rather
+                // than falling through, which would leave a spurious same-named
+                // signal in this module); resolve the child port + drive the
+                // reader at the end of import_design once every cell exists.
+                pending_xmr_reads_.push_back({module, inst, sig});
+                int xw = 1;
+                if (auto ag = any_cast<const ref_obj*>(xpe[1])->Actual_group()) {
+                    int w = get_width(ag, current_instance);
+                    if (w > 0) xw = w;
+                }
+                std::string pn = inst + "." + sig;
+                RTLIL::Wire* pw = module->wire(RTLIL::escape_id(pn));
+                if (!pw) pw = module->addWire(RTLIL::escape_id(pn), xw);
+                log("    XMR read %s.%s: deferred (cell not yet created, width=%d)\n",
+                    inst.c_str(), sig.c_str(), xw);
+                return RTLIL::SigSpec(pw);
+            }
+        }
+    }
 
     // Hierarchical function call: `module_scope_func_top.incr(10)`.
     // Surelog represents this as a hier_path whose last Path_elem is a

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -546,9 +546,22 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
         }
     }
     
+    // Resolve deferred cross-module reference (XMR) reads now that every cell
+    // exists (cont_assigns were imported before instances).  github #450.
+    for (auto& xr : pending_xmr_reads_) {
+        RTLIL::Module* mod = std::get<0>(xr);
+        const std::string& inst = std::get<1>(xr);
+        const std::string& sig = std::get<2>(xr);
+        if (RTLIL::Cell* cell = mod->cell(RTLIL::escape_id(inst))) {
+            resolve_xmr_read(mod, cell, sig);
+            log("UHDM: resolved deferred XMR read %s.%s\n", inst.c_str(), sig.c_str());
+        }
+    }
+    pending_xmr_reads_.clear();
+
     log("UHDM: Finished import_design\n");
     log_flush();
-    
+
     // Debug: Log all created wires and memories
     log("UHDM: Final debug - listing all created objects\n");
     log_flush();

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -215,6 +215,11 @@ struct UhdmImporter {
     // interface instances are imported; used to expand an interface-array
     // element connection (`.b(arr[0])`) into individual signal connections.
     std::map<std::string, std::vector<std::string>> iface_inst_vars_;
+    // Cross-module reference (XMR) reads `u_processor.internal_ready` recorded
+    // during cont_assign import (when the child cell doesn't exist yet) as
+    // (parent module, instance name, signal name); resolved at the end of
+    // import_design once every cell exists (github #450).
+    std::vector<std::tuple<RTLIL::Module*, std::string, std::string>> pending_xmr_reads_;
     // Interface signal wire name ("s.req") -> its packed struct/union typespec,
     // recorded when the interface port's field wires are created so a struct
     // field access (`s.req.adr`) in import_hier_path can slice the member.
@@ -531,6 +536,9 @@ struct UhdmImporter {
     void import_net(const UHDM::net* uhdm_net, const UHDM::instance* inst = nullptr);
     void import_process(const UHDM::process_stmt* uhdm_process);
     void import_continuous_assign(const UHDM::cont_assign* uhdm_assign);
+    // XMR read resolution: expose `sig` as an output port of `cell`'s child
+    // module and wire it to the parent's `\<inst>.<sig>` reader (github #450).
+    void resolve_xmr_read(RTLIL::Module* mod, RTLIL::Cell* cell, const std::string& sig);
     void import_instance(const UHDM::module_inst* uhdm_inst);
     void import_ref_module(const UHDM::ref_module* ref_mod);
     void create_parameterized_modules();

--- a/test/xmr_read/dut.sv
+++ b/test/xmr_read/dut.sv
@@ -1,0 +1,30 @@
+// XMR (cross-module reference) read: the top reaches into a submodule INSTANCE
+// to grab an internal signal — `assign monitor_flag = u_processor.internal_ready`
+// (github issue #450).  The UHDM frontend silently dropped it (monitor_flag
+// undriven); the Verilog frontend implicitly declares \u_processor.internal_ready
+// and lets flatten resolve it.
+module DataProcessor (
+    input  wire       clk,
+    input  wire [7:0] data_in,
+    output reg  [7:0] data_out
+);
+    reg internal_ready;
+    always @(posedge clk) begin
+        data_out <= data_in + 8'h01;
+        internal_ready <= (data_in > 8'h0A);
+    end
+endmodule
+
+module dut (
+    input  wire       clk,
+    input  wire [7:0] system_in,
+    output wire [7:0] system_out,
+    output wire       monitor_flag
+);
+    DataProcessor u_processor (
+        .clk(clk),
+        .data_in(system_in),
+        .data_out(system_out)
+    );
+    assign monitor_flag = u_processor.internal_ready;
+endmodule


### PR DESCRIPTION
`assign monitor_flag = u_processor.internal_ready;` — reaching into a child INSTANCE to read one of its internal signals — was effectively dropped: the reader connected to an undriven `\u_processor.internal_ready`, so monitor_flag came out X.  The source `internal_ready` is opt'd away (unused WITHIN the child) and a plain parent wire collides with the flattened name, so neither flatten nor Yosys's hierarchy pass links them.

Ground truth (all agree the XMR is meaningful): iverilog and Verilator simulate it correctly; sv2v preserves it; slang SYNTHESISES it (its netlist has the source FF driving the reader).  This fix matches slang: expose the child signal as an OUTPUT PORT and wire the cell through, so the source survives opt and flatten connects it to the reader.

- import_hier_path detects a 2-element `ref_obj.ref_obj` whose FIRST element resolves to a `module_inst` (a genuine child instance — NOT a parameter `CFG.field`, struct `s.f`, interface `sub.clk`, or gen-scope ref, which all resolve elsewhere).  cont_assigns are imported BEFORE instances, so the RTLIL cell doesn't exist yet: record the XMR + create the reader wire and return it.
- resolve_xmr_read (run for every recorded XMR at the end of import_design, once all cells exist) marks the child signal port_output, fixup_ports, and connects the cell's new port to the parent reader wire.

The module_inst guard is essential — without it the handler fired on parameter struct-field reads and regressed genblk_order / matching_end_labels / OutputSizeWithParameterOfInstanceInitializedByStructMember.

New test xmr_read passes formal equivalence; child gets a clean internal_ready output port, the reader is driven, and dut keeps exactly its 4 ports.  No regressions (run_all_tests 686/688).

Fixes #450