### PR TITLE
uhdm: genvar-indexed interface-array element struct-field access (man…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6824,6 +6824,77 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
         }
     }
 
+    // Interface-ARRAY element STRUCT-FIELD access (`man[i].req.lck` where `man`
+    // is an array-of-modports port, `req` is a packed-struct interface signal,
+    // and `lck` is one of its fields).  Path_elems = [bit_select(man[i]),
+    // ref_obj(req), ref_obj(lck)].  import_port created `\man[idx].req` (the
+    // whole struct); resolve `man[idx].req` to that wire and slice the field via
+    // its struct typespec.  Covers the demultiplexer's `assign man[i].req.<field>
+    // = ...` (genvar i folds per gen_req[i]) AND constant reads `m[0].req.<f>`;
+    // without it both hit the generic fallback's "Could not resolve struct
+    // member access" and stay X (degu SoC bus fabric request routing).
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() == 3) {
+        auto& pe_sf = *uhdm_hier->Path_elems();
+        if (pe_sf[0]->UhdmType() == uhdmbit_select &&
+            pe_sf[1]->UhdmType() == uhdmref_obj &&
+            pe_sf[2]->UhdmType() == uhdmref_obj) {
+            auto bs = any_cast<const bit_select*>(pe_sf[0]);
+            std::string base  = std::string(bs->VpiName());
+            std::string sig   = std::string(any_cast<const ref_obj*>(pe_sf[1])->VpiName());
+            std::string field = std::string(any_cast<const ref_obj*>(pe_sf[2])->VpiName());
+            int idx = -1;
+            if (bs->VpiIndex()) {
+                RTLIL::SigSpec is = import_expression(bs->VpiIndex(), input_mapping);
+                if (is.is_fully_const()) idx = is.as_const().as_int();
+            }
+            if (idx >= 0 && !sig.empty() && !field.empty()) {
+                std::string wname = base + "[" + std::to_string(idx) + "]." + sig;
+                RTLIL::Wire* w = name_map.count(wname) ? name_map[wname]
+                    : module->wire(RTLIL::escape_id(wname));
+                const UHDM::typespec* ts = nullptr;
+                if (iface_signal_struct_ts_.count(wname))
+                    ts = iface_signal_struct_ts_[wname];
+                // Interface-ARRAY ports often don't resolve interface_type, so
+                // the struct typespec wasn't recorded — get it from the `req`
+                // ref_obj path element directly (its own typespec, else its
+                // Actual_group net's typespec).
+                if (!ts) {
+                    auto rref = any_cast<const ref_obj*>(pe_sf[1]);
+                    if (rref->Typespec() && rref->Typespec()->Actual_typespec())
+                        ts = rref->Typespec()->Actual_typespec();
+                    if (!ts && rref->Actual_group()) {
+                        if (auto nn = dynamic_cast<const UHDM::net*>(rref->Actual_group()))
+                            if (nn->Typespec()) ts = nn->Typespec()->Actual_typespec();
+                    }
+                }
+                if (w && !ts) {
+                    // Fall back to the wire's own UHDM struct typespec.
+                    for (auto& pr : wire_map) {
+                        if (pr.second != w) continue;
+                        const UHDM::ref_typespec* rt = nullptr;
+                        if (auto ln = dynamic_cast<const UHDM::logic_net*>(pr.first)) rt = ln->Typespec();
+                        else if (auto no = dynamic_cast<const UHDM::net*>(pr.first)) rt = no->Typespec();
+                        if (rt) ts = rt->Actual_typespec();
+                        break;
+                    }
+                }
+                if (w && ts) {
+                    int off = 0, mw = 0;
+                    if (calculate_struct_member_offset(ts, field, inst, off, mw)) {
+                        if (off + mw <= w->width) {
+                            log("    hier_path: iface-array struct field %s.%s -> \\%s[%d +: %d]\n",
+                                wname.c_str(), field.c_str(), wname.c_str(), off, mw);
+                            return RTLIL::SigSpec(w, off, mw);
+                        }
+                        log_warning("UHDM: iface-array struct slice %s.%s out of bounds "
+                                    "(off=%d w=%d, wire \\%s width=%d)\n",
+                                    wname.c_str(), field.c_str(), off, mw, wname.c_str(), w->width);
+                    }
+                }
+            }
+        }
+    }
+
     // Interface-port signal bit/part-select access (e.g. `bus.adr[3:0]`
     // where `bus` is a `tcb_if.sub` modport port and `adr` is one of the
     // interface's signals).  Path_elems = [ref_obj(bus),

--- a/src/frontends/uhdm/interface.cpp
+++ b/src/frontends/uhdm/interface.cpp
@@ -187,28 +187,34 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
             // net is often a typespec-less struct_net), so search AllInterfaces.
             std::string iface_def = std::string(interface->VpiDefName());
             if (iface_def.find("work@") == 0) iface_def = iface_def.substr(5);
+            // Record the packed-struct/union typespec for an interface signal
+            // and RETURN it (so the caller can size the wire to the struct
+            // width, not the 1-bit default).  Handles logic_net AND struct_net
+            // (the `net` base carries Typespec()).
             auto record_struct_ts = [&](const std::string& wire_name,
-                                        const std::string& sig_name) {
-                if (iface_signal_struct_ts_.count(wire_name) || !uhdm_design ||
-                    !uhdm_design->AllInterfaces())
-                    return;
+                                        const std::string& sig_name)
+                    -> const UHDM::typespec* {
+                if (iface_signal_struct_ts_.count(wire_name))
+                    return iface_signal_struct_ts_[wire_name];
+                if (!uhdm_design || !uhdm_design->AllInterfaces())
+                    return nullptr;
                 for (auto ii : *uhdm_design->AllInterfaces()) {
                     std::string dn = std::string(ii->VpiDefName());
                     if (dn.find("work@") == 0) dn = dn.substr(5);
                     if (dn != iface_def || !ii->Nets()) continue;
                     for (auto n : *ii->Nets()) {
                         if (std::string(n->VpiName()) != sig_name) continue;
-                        if (n->UhdmType() != uhdmlogic_net) continue;
-                        auto rt = any_cast<const UHDM::logic_net*>(n)->Typespec();
-                        if (rt && rt->Actual_typespec()) {
-                            auto ats = rt->Actual_typespec();
-                            if (ats->UhdmType() == uhdmstruct_typespec ||
-                                ats->UhdmType() == uhdmunion_typespec)
-                                iface_signal_struct_ts_[wire_name] = ats;
-                        }
+                        auto net_n = dynamic_cast<const UHDM::net*>(n);
+                        if (!net_n || !net_n->Typespec()) continue;
+                        auto ats = net_n->Typespec()->Actual_typespec();
+                        if (ats && (ats->UhdmType() == uhdmstruct_typespec ||
+                                    ats->UhdmType() == uhdmunion_typespec))
+                            iface_signal_struct_ts_[wire_name] = ats;
                     }
                     if (iface_signal_struct_ts_.count(wire_name)) break;
                 }
+                return iface_signal_struct_ts_.count(wire_name)
+                    ? iface_signal_struct_ts_[wire_name] : nullptr;
             };
             // Get WIDTH parameter value - check module parameter first, then interface instance
             int interface_width = 8; // default
@@ -336,13 +342,28 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                 }
             }
             // Then try Nets
-            else if (interface->Nets()) {
+            // NOT `else if`: an interface can have signals in BOTH Variables()
+            // (e.g. `logic vld`) and Nets() (e.g. a `struct_net req`); with an
+            // else-if the struct nets were skipped, so `\<iface>.req` never
+            // existed and `s.req.<field>` couldn't resolve.  Run both; the dup
+            // guard skips anything the Variables loop already made.
+            if (interface->Nets()) {
                 for (auto net : *interface->Nets()) {
                     std::string net_name = std::string(net->VpiName());
                     std::string full_name = interface_name + "." + net_name;
+                    if (name_map.count(full_name)) continue;
 
                     int width = get_width(net, current_instance);
                     if (width <= 0) width = interface_width;
+                    // A packed-STRUCT signal (`req`) is wider than the 1-bit
+                    // default get_width gives the typespec-less local net — size
+                    // it from the struct typespec (also records it for the
+                    // field-slice handler).
+                    const UHDM::typespec* sts = record_struct_ts(full_name, net_name);
+                    if (sts) {
+                        int w = get_width_from_typespec(sts, current_instance);
+                        if (w > 0) width = w;
+                    }
 
                     if (mode_debug)
                         log("UHDM: Creating interface signal from Nets: %s (width=%d)\n", full_name.c_str(), width);
@@ -351,7 +372,6 @@ void UhdmImporter::import_interface_instances(const UHDM::module_inst* uhdm_modu
                     add_src_attribute(wire->attributes, net);
                     name_map[full_name] = wire;
                     iface_inst_vars_[interface_name].push_back(net_name);
-                    record_struct_ts(full_name, net_name);
                 }
             }
 

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -405,7 +405,64 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                                 }
                             }
                         }
+                        // Sample the struct typespec from the design-level
+                        // interface (the local iface_inst's struct_net usually
+                        // lacks a typespec) so a STRUCT signal (e.g. `req`) gets
+                        // its real width — not the 1-bit default — and the
+                        // field-slice handler can resolve `man[i].req.<field>`.
+                        const UHDM::typespec* found_struct_ts = nullptr;
+                        // The matched net's own typespec (net base carries it for
+                        // logic_net AND struct_net) works even when interface_type
+                        // didn't resolve, as for array modport ports.
+                        if (auto net_w = dynamic_cast<const UHDM::net*>(width_obj)) {
+                            if (auto wrt = net_w->Typespec())
+                                if (auto ats = wrt->Actual_typespec())
+                                    if (ats->UhdmType() == uhdmstruct_typespec ||
+                                        ats->UhdmType() == uhdmunion_typespec)
+                                        found_struct_ts = ats;
+                        }
+                        // Else the modport io_decl's own typespec.
+                        if (!found_struct_ts)
+                        if (auto io_rt = io->Typespec()) {
+                            if (auto ats = io_rt->Actual_typespec())
+                                if (ats->UhdmType() == uhdmstruct_typespec ||
+                                    ats->UhdmType() == uhdmunion_typespec)
+                                    found_struct_ts = ats;
+                        }
+                        // Match by interface_type, or fall back to the iface_inst's
+                        // own def name (array modport ports often leave
+                        // interface_type empty, and the first/stub creation pass
+                        // has a null width_obj — without this `\man[i].req` stays
+                        // 1-bit and the field slices overflow).
+                        std::string search_def = interface_type;
+                        if (search_def.empty() && iface_inst) {
+                            search_def = std::string(iface_inst->VpiDefName());
+                            if (search_def.find("work@") == 0) search_def = search_def.substr(5);
+                        }
+                        if (!found_struct_ts && !search_def.empty() && uhdm_design &&
+                            uhdm_design->AllInterfaces()) {
+                            for (auto ii : *uhdm_design->AllInterfaces()) {
+                                std::string dn = std::string(ii->VpiDefName());
+                                if (dn.find("work@") == 0) dn = dn.substr(5);
+                                if (dn != search_def || !ii->Nets()) continue;
+                                for (auto n : *ii->Nets()) {
+                                    if (std::string(n->VpiName()) != sig_name) continue;
+                                    auto net_n = dynamic_cast<const UHDM::net*>(n);
+                                    if (!net_n || !net_n->Typespec()) continue;
+                                    auto ats = net_n->Typespec()->Actual_typespec();
+                                    if (ats && (ats->UhdmType() == uhdmstruct_typespec ||
+                                                ats->UhdmType() == uhdmunion_typespec))
+                                        found_struct_ts = ats;
+                                }
+                                if (found_struct_ts) break;
+                            }
+                        }
                         int sig_w = width_obj ? compute_signal_width(width_obj) : 1;
+                        if (found_struct_ts) {
+                            int sw_ts = get_width_from_typespec(found_struct_ts, current_instance);
+                            if (sw_ts > 0) sig_w = sw_ts;
+                            iface_signal_struct_ts_[full_name] = found_struct_ts;
+                        }
                         RTLIL::Wire* sw = module->addWire(
                             RTLIL::escape_id(full_name), sig_w);
                         if (width_obj) add_src_attribute(sw->attributes, width_obj);
@@ -424,8 +481,12 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                                 if (dn != interface_type || !ii->Nets()) continue;
                                 for (auto n : *ii->Nets()) {
                                     if (std::string(n->VpiName()) != sig_name) continue;
-                                    if (n->UhdmType() != uhdmlogic_net) continue;
-                                    auto rt = any_cast<const UHDM::logic_net*>(n)->Typespec();
+                                    // The struct signal may be a logic_net OR a
+                                    // struct_net (e.g. `req` of type req_t); the
+                                    // `net` base carries Typespec() for both.
+                                    auto net_n = dynamic_cast<const UHDM::net*>(n);
+                                    if (!net_n) continue;
+                                    auto rt = net_n->Typespec();
                                     if (rt && rt->Actual_typespec()) {
                                         auto ats = rt->Actual_typespec();
                                         if (ats->UhdmType() == uhdmstruct_typespec ||

--- a/test/genvar_iface_struct/dut.sv
+++ b/test/genvar_iface_struct/dut.sv
@@ -1,0 +1,33 @@
+// Genvar-indexed interface-ARRAY element STRUCT-FIELD assignment in a generate
+// loop: `for(genvar i) assign man[i].req.field = ...` — the demux pattern from
+// the degu SoC's tcb_lite_lib_demultiplexer gen_req loop.  The genvar i must
+// fold (0/1 in gen_req[i]) so man[i].req.<field> resolves to \man[i].req's slice.
+interface myif (input logic clk, input logic rst);
+  typedef struct packed { logic lck; logic [7:0] adr; } req_t;
+  logic  vld;
+  req_t  req;
+  modport man (input clk, input rst, output vld, output req);
+  modport sub (input clk, input rst, input  vld, input  req);
+endinterface
+
+module demux #(parameter int IFN=2) (myif.sub sub, myif.man man[IFN-1:0], input logic sel);
+  for (genvar i=0; i<IFN; i++) begin: gen_req
+    assign man[i].vld     = (sel == i) ? sub.vld     : 1'b0;
+    assign man[i].req.lck = (sel == i) ? sub.req.lck : 1'b0;
+    assign man[i].req.adr = (sel == i) ? sub.req.adr : 8'h00;
+  end
+endmodule
+
+module dut #(parameter int IFN=2)(input logic clk, input logic rst, input logic sel,
+           input logic svld, input logic slck, input logic [7:0] sadr,
+           output logic [1:0] mvld, output logic [1:0] mlck, output logic [15:0] madr);
+  myif s(.clk(clk), .rst(rst));
+  myif m[IFN-1:0](.clk(clk), .rst(rst));
+  assign s.vld = svld;
+  assign s.req.lck = slck;
+  assign s.req.adr = sadr;
+  demux #(2) d(.sub(s), .man(m), .sel(sel));
+  assign mvld = {m[1].vld, m[0].vld};
+  assign mlck = {m[1].req.lck, m[0].req.lck};
+  assign madr = {m[1].req.adr, m[0].req.adr};
+endmodule


### PR DESCRIPTION
…[i].req.<f>)

The demultiplexer's `for (genvar i) assign man[i].req.<field> = ...` left the struct fields undriven ("Could not resolve struct member access 'man[i].req.lck'") — the degu SoC bus-fabric's request routing.  Several intertwined gaps:

1. No handler for the 3-element path [bit_select(man[i]), ref_obj(req), ref_obj(<field>)].  Add one (expression.cpp): fold the genvar index via import_expression, resolve `man[idx].req` to the per-element struct wire, and slice the field via its struct typespec (with a bounds guard).  Covers the genvar assign LHS AND constant reads `m[0].req.<field>`.

2. The struct typespec wasn't recorded: the recording only handled `logic_net`, but a struct signal is a `struct_net`.  Generalise to the `net` base (which carries Typespec()) in module.cpp's port path and interface.cpp's record_struct_ts; get the typespec from the `req` ref_obj when the array modport port leaves interface_type empty.

3. Interface INSTANCES never created the struct-signal wire: interface.cpp used `if (Variables()) else if (Nets())`, so when a signal is in each (logic vld / struct_net req) the struct net was skipped and `\s.req` never existed.  Run both loops (dup-guarded).

4. Struct-signal WIDTH was the 1-bit default (the typespec-less local net), so field slices overflowed and asserted.  Size from the struct typespec at both the port (module.cpp — net typespec, io_decl typespec, else AllInterfaces by the iface_inst def name; the first/stub creation pass has a null width_obj) and the instance (interface.cpp record_struct_ts now returns the typespec).

New test genvar_iface_struct (a demux gen_req loop + observation through the interface array) passes co-simulation.  No regressions (run_all_tests 687/689). This is the request-routing gap the whole-SoC cosim flagged in the demux.