### PR TITLE
test: sub-hierarchy behavioural cosim of the degu register file (r5p_…

### DIFF
--- a/test/r5p_gpr_cosim/project.f
+++ b/test/r5p_gpr_cosim/project.f
@@ -1,0 +1,3 @@
+# Sub-hierarchy cosim: degu register file (simple vector ports, no structs).
+# top: r5p_gpr_2r1w
+../rp32/core/r5p_gpr_2r1w.sv


### PR DESCRIPTION
…gpr_2r1w)

Whole-SoC behavioural cosim is blocked at the tool level: Verilator can't build the SoC gold — root errors are tcb_lite_if's `for (genvar i=1; i<=CFG.HSK.DLY; i++)` (can't unroll) and r5p_degu's `if (ISA.spec.ext.C)` (must be constant), which cascade into "can't convert defparam to constant" for every interface and ISA.  Minimal reductions of each pattern build cleanly in Verilator 5.048, so it is a subtle SoC-level interaction (likely a Verilator-version difference from the original degu makefile's environment).

So validate behaviourally via SUB-HIERARCHY instead.  r5p_gpr_2r1w (the register file — simple vector ports, no interfaces/decode) passes co-simulation (200 cycles).  Decode-driven leaf modules (alu/bru/mdu/wbu) mismatch only because the harness feeds random `dec` (invalid opcodes -> X-divergence, not a frontend bug — the dec_t port width is correct); they need constrained stimulus.  The bus-fabric/device modules use tcb_lite_if (unbuildable by Verilator here) and interface ports, but are already covered by formal-equivalence isolated tests.