### PR TITLE
test: Verilator-friendly RTL variant + whole-SoC behavioural cosim (p…

### DIFF
--- a/test/rp32_soc_vfriendly/project.f
+++ b/test/rp32_soc_vfriendly/project.f
@@ -1,0 +1,42 @@
+# Whole degu SoC — Verilator-friendly cosim.  Original RTL (test/rp32) + tests untouched.
+# Only 4 files differ from the original (test/rp32_vfriendly): packed struct typedefs
+# (riscv_isa_pkg, tcb_lite_pkg, tcb_lite_if) + decoder DAM as packed-2D — behaviourally
+# identical, but lets Verilator fold the struct parameters and build the whole SoC.
+# top: r5p_degu_soc_top
+# surelog: -top r5p_degu_soc_top
+# verilator: -DTOOL_VERILATOR -Wno-BLKANDNBLK -Wno-UNPACKED -Wno-WIDTHEXPAND -Wno-ENUMVALUE -Wno-WIDTHTRUNC -Wno-CASEINCOMPLETE
+../rp32_vfriendly/tcb/tcb_lite_pkg.sv
+../rp32_vfriendly/tcb/tcb_lite_if.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_passthrough.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_logsize2byteena.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_arbiter.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_multiplexer.sv
+../rp32_vfriendly/tcb/lite_lib/tcb_lite_lib_decoder.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_demultiplexer.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_register_request.sv
+../rp32/tcb/lite_lib/tcb_lite_lib_error.sv
+../rp32/tcb/dev/gpio/tcb_dev_gpio_cdc__generic.sv
+../rp32/tcb/dev/gpio/tcb_dev_gpio.sv
+../rp32/tcb/lite_dev/gpio/tcb_lite_dev_gpio.sv
+../rp32/tcb/dev/uart/tcb_dev_uart_ser.sv
+../rp32/tcb/dev/uart/tcb_dev_uart_des.sv
+../rp32/tcb/dev/uart/tcb_dev_uart_fifo.sv
+../rp32/tcb/dev/uart/tcb_dev_uart.sv
+../rp32/tcb/lite_dev/uart/tcb_lite_dev_uart.sv
+../rp32_vfriendly/riscv/riscv_isa_pkg.sv
+../rp32/riscv/riscv_priv_pkg.sv
+../rp32/riscv/riscv_isa_i_pkg.sv
+../rp32/riscv/riscv_isa_c_pkg.sv
+../rp32/riscv/rv32_csr_pkg.sv
+../rp32/riscv/rv64_csr_pkg.sv
+../rp32/core/r5p_gpr_2r1w.sv
+../rp32/degu/r5p_pkg.sv
+../rp32/degu/r5p_bru.sv
+../rp32/degu/r5p_alu.sv
+../rp32/degu/r5p_mdu.sv
+../rp32/degu/r5p_lsu.sv
+../rp32/degu/r5p_wbu.sv
+../rp32/degu/r5p_degu_pkg.sv
+../rp32/degu/r5p_degu.sv
+../rp32/soc/r5p_soc_memory__gowin_inference.sv
+../rp32/soc/r5p_degu_soc_top.sv

--- a/test/rp32_vfriendly/riscv/riscv_isa_pkg.sv
+++ b/test/rp32_vfriendly/riscv/riscv_isa_pkg.sv
@@ -1,0 +1,153 @@
+///////////////////////////////////////////////////////////////////////////////
+// RISC-V ISA package (based on ISA spec)
+///////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Iztok Jeras
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+///////////////////////////////////////////////////////////////////////////////
+
+`ifdef ALTERA_RESERVED_QIS
+`define LANGUAGE_UNSUPPORTED_UNION
+`endif
+
+package riscv_isa_pkg;
+
+///////////////////////////////////////////////////////////////////////////////
+// ISA base and extensions
+// 4-level type `logic` is used for parameters, so `?` fields can be ignored
+///////////////////////////////////////////////////////////////////////////////
+
+// base
+typedef struct packed {
+  bit E;  // RV32E  - embedded
+  bit W;  // RV32I  - word
+  bit D;  // RV64I  - double
+  bit Q;  // RV128I - quad
+} isa_base_t;
+
+// base enumerations
+typedef enum logic [$bits(isa_base_t)-1:0] {
+  //           EWDQ
+  RV_32E  = 4'b1100,
+  RV_32I  = 4'b0100,
+  RV_64I  = 4'b0010,
+  RV_128I = 4'b0001
+} isa_base_et;
+
+// privilege mode support (onehot)
+typedef struct packed {
+  bit M;  // Machine
+  bit R;  // Reserved
+  bit S;  // Supervisor
+  bit U;  // User/Application
+} isa_priv_t;
+
+// privilege mode support
+typedef enum logic [$bits(isa_priv_t)-1:0] {
+  MODES_NONE = 4'b0000, // no privileged modes are supported
+  MODES_M    = 4'b1000,  // Simple embedded systems
+  MODES_MU   = 4'b1001,  // Secure embedded systems
+  MODES_MSU  = 4'b1011   // Systems running Unix-like operating systems
+} isa_priv_et;
+
+// standard extensions (onehot)
+typedef struct packed {
+  bit M       ;  // integer multiplication and division
+  bit A       ;  // atomic instructions
+  bit F       ;  // single-precision floating-point
+  bit D       ;  // double-precision floating-point
+  bit Zicsr   ;  // Control and Status Register (CSR)
+  bit Zifencei;  // Instruction-Fetch Fence
+  bit Q       ;  // quad-precision floating-point
+  bit L       ;  // decimal precision floating-point
+  bit C       ;  // compressed
+  bit B       ;  // bit manipulation
+  bit J       ;  // dynamically translated languages
+  bit T       ;  // transactional memory
+  bit P       ;  // packed-SIMD
+  bit V       ;  // vector operations
+  bit N       ;  // user-level interrupts
+  bit H       ;  // hypervisor
+  bit S       ;  // supervisor-level instructions
+  bit Zam     ;  // Misaligned Atomics
+  bit Ztso    ;  // Total Store Ordering
+} isa_ext_t;
+
+// standard extensions
+typedef enum logic [$bits(isa_ext_t)-1:0] {
+  //                MAFD_ZZ_QLCBJTPVNHS_ZZ
+  RV_M        = 19'b1000_00_00000000000_00,  // integer multiplication and division
+  RV_A        = 19'b0100_00_00000000000_00,  // atomic instructions
+  RV_F        = 19'b0010_00_00000000000_00,  // single-precision floating-point
+  RV_D        = 19'b0011_00_00000000000_00,  // double-precision floating-point (NOTE: also enables F)
+  RV_Zicsr    = 19'b0000_10_00000000000_00,  // Control and Status Register (CSR)
+  RV_Zifencei = 19'b0000_01_00000000000_00,  // Instruction-Fetch Fence
+  RV_Q        = 19'b0000_00_10000000000_00,  // quad-precision floating-point
+  RV_L        = 19'b0000_00_01000000000_00,  // decimal precision floating-point
+  RV_C        = 19'b0000_00_00100000000_00,  // compressed
+  RV_B        = 19'b0000_00_00010000000_00,  // bit manipulation
+  RV_J        = 19'b0000_00_00001000000_00,  // dynamically translated languages
+  RV_T        = 19'b0000_00_00000100000_00,  // transactional memory
+  RV_P        = 19'b0000_00_00000010000_00,  // packed-SIMD
+  RV_V        = 19'b0000_00_00000001000_00,  // vector operations
+  RV_N        = 19'b0000_00_00000000100_00,  // user-level interrupts
+  RV_H        = 19'b0000_00_00000000010_00,  // hypervisor
+  RV_S        = 19'b0000_00_00000000001_00,  // supervisor-level instructions
+  RV_Zam      = 19'b0000_00_00000000000_10,  // Misaligned Atomics
+  RV_Ztso     = 19'b0000_00_00000000000_01,  // Total Store Ordering
+  //                MAFD_ZZ_QLCBJTPVNHS_ZZ
+  RV_G        = 19'b1111_11_00000000000_00,  // general-purpose standard extension combination (G = IMAFDZicsrZifencei)
+  RV_NONE     = 19'b0000_00_00000000000_00   // no standard extensions
+} isa_ext_et;
+
+// ISA specification configuration
+// NOTE (uhdm2rtlil import): made `packed` — the isa_spec_et enum below uses
+// `logic [$bits(isa_spec_t)-1:0]` as its base and concatenations as values,
+// which requires packed semantics; left unpacked, Verilator sizes the enum
+// base as 1 bit (truncation -> overlapping enum values).  This realises the
+// upstream author's own TODO ("change when Verilator supports unpacked
+// structures").
+typedef struct packed {
+  isa_base_t base;
+  isa_ext_t  ext;
+} isa_spec_t;
+
+// enumerations for common and individual configurations
+// TODO: verilator does not support struct literals inside enumeration definition
+typedef enum logic [$bits(isa_spec_t)-1:0] {
+  RV32E   = {RV_32E , RV_NONE    },
+  RV32I   = {RV_32I , RV_NONE    },
+  RV64I   = {RV_64I , RV_NONE    },
+  RV128I  = {RV_128I, RV_NONE    },
+  RV32EC  = {RV_32E ,        RV_C},
+  RV32IC  = {RV_32I ,        RV_C},
+  RV64IC  = {RV_64I ,        RV_C},
+  RV128IC = {RV_128I,        RV_C},
+  RV32EMC = {RV_32E , RV_M | RV_C},
+  RV32IMC = {RV_32I , RV_M | RV_C},
+  RV64IMC = {RV_64I , RV_M | RV_C},
+  RV32G   = {RV_32I , RV_G       },
+  RV64G   = {RV_64I , RV_G       },
+  RV128G  = {RV_128I, RV_G       },
+  RV32GC  = {RV_32I , RV_G | RV_C},
+  RV64GC  = {RV_64I , RV_G | RV_C},
+  RV128GC = {RV_128I, RV_G | RV_C}
+} isa_spec_et;
+
+// ISA configuration
+typedef struct packed {
+  isa_spec_t spec;
+  isa_priv_t priv;
+} isa_t;
+
+endpackage: riscv_isa_pkg

--- a/test/rp32_vfriendly/tcb/lite_lib/tcb_lite_lib_decoder.sv
+++ b/test/rp32_vfriendly/tcb/lite_lib/tcb_lite_lib_decoder.sv
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////////
+// TCB-Lite (Tightly Coupled Bus) library decoder
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Iztok Jeras
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////////////////////////////////////
+
+module tcb_lite_lib_decoder
+    import tcb_lite_pkg::*;
+#(
+    // TCB-Lite parameters (contains address width)
+    parameter  int unsigned ADR = 32,
+    // interconnect parameters (subordinate interface number and logarithm)
+    parameter  int unsigned IFN = 2,
+    localparam int unsigned IFL = $clog2(IFN),
+    // decoder address and mask array
+    parameter  logic [IFN-1:0][ADR-1:0] DAM
+)(
+    // TCB-Lite interfaces
+    tcb_lite_if.mon mon,  // TCB subordinate interface (manager device connects here)
+    // control
+    output logic [IFL-1:0] sel,  // decoder select
+    output logic           err   // decoder error (no matches)
+);
+
+////////////////////////////////////////////////////////////////////////////////
+// parameter validation
+////////////////////////////////////////////////////////////////////////////////
+
+// report address range overlapping
+// TODO
+
+////////////////////////////////////////////////////////////////////////////////
+// local signals
+////////////////////////////////////////////////////////////////////////////////
+
+    logic [ADR-1:0] adr;
+
+    // extract address from TCB
+    assign adr = mon.req.adr;
+
+////////////////////////////////////////////////////////////////////////////////
+// decoder
+////////////////////////////////////////////////////////////////////////////////
+
+    // match
+    logic [IFN-1:0] mch;
+
+    // match
+    generate
+        for (genvar i=0; i<IFN; i++) begin
+            assign mch[i] = adr ==? DAM[i];
+        end
+    endgenerate
+
+    // encode (convert from one-hot to binary encoding)
+    function logic [IFL-1:0] encode (logic [IFN-1:0] val);
+        encode = '0;
+        for (int i=0; i<IFN; i++) begin
+            encode |= val[i] ? i[IFL-1:0] : '0;
+        end
+    endfunction: encode
+
+    // address decoder
+    assign sel = encode(mch);  // decoder select
+    assign err =      ~|mch;   // decoder error
+
+endmodule: tcb_lite_lib_decoder

--- a/test/rp32_vfriendly/tcb/tcb_lite_if.sv
+++ b/test/rp32_vfriendly/tcb/tcb_lite_if.sv
@@ -1,0 +1,181 @@
+////////////////////////////////////////////////////////////////////////////////
+// TCB-Lite (Tightly Coupled Bus) SystemVerilog interface
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Iztok Jeras
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////////////////////////////////////
+
+interface tcb_lite_if
+    import tcb_lite_pkg::*;
+#(
+    // configuration parameters
+    parameter tcb_lite_cfg_t CFG = TCB_LITE_CFG_DEF
+)(
+    // system signals
+    input  logic clk,  // clock
+    input  logic rst   // reset
+);
+
+    // local parameters (calculated from configuration)
+    localparam int unsigned CFG_BUS_BYT = CFG.BUS.DAT/8;          // byte enable width
+    localparam int unsigned CFG_BUS_OFF = $clog2(CFG_BUS_BYT);    // address offset size
+    localparam int unsigned CFG_BUS_SIZ = $clog2(CFG_BUS_OFF+1);  // logarithmic size width
+
+    // request type
+    typedef struct packed {
+        logic                   lck;  // arbitration lock
+        logic                   wen;  // write enable
+        logic                   ren;  // read  enable
+        logic                   ndn;  // endianness (0-little, 1-big)
+        logic [CFG.BUS.CTL-1:0] ctl;  // control (user defined request signals)
+        logic [CFG.BUS.ADR-1:0] adr;  // address
+        logic [CFG_BUS_SIZ-1:0] siz;  // transfer size
+        logic [CFG_BUS_BYT-1:0] byt;  // byte enable
+        logic [CFG.BUS.DAT-1:0] wdt;  // write data
+    } req_t;
+
+    // response type
+    typedef struct packed {
+        logic [CFG.BUS.DAT-1:0] rdt;  // read data
+        logic [CFG.BUS.STS-1:0] sts;  // response status (user defined response signals)
+        logic                   err;  // response error
+    } rsp_t;
+
+////////////////////////////////////////////////////////////////////////////////
+// I/O ports
+////////////////////////////////////////////////////////////////////////////////
+
+    // handshake
+    logic vld;  // valid
+    logic rdy;  // ready
+
+    // request/response
+    req_t req;
+    rsp_t rsp;
+
+////////////////////////////////////////////////////////////////////////////////
+// transaction handshake
+////////////////////////////////////////////////////////////////////////////////
+
+    // handshake
+    logic trn;  // transfer
+    logic stl;  // stall
+    logic idl;  // idle
+
+    // transfer (valid and ready at the same time)
+    assign trn = vld & rdy;
+
+    // stall (valid while not ready)
+    assign stl = vld & ~rdy;
+
+    // TODO: improve description
+    // idle (either not valid or ending the current cycle with a transfer)
+    assign idl = ~vld | trn;
+
+////////////////////////////////////////////////////////////////////////////////
+// request/response delay
+////////////////////////////////////////////////////////////////////////////////
+
+    // delay line
+    logic trn_dly [0:CFG.HSK.DLY];  // handshake transfer
+    req_t req_dly [0:CFG.HSK.DLY];  // request
+
+    // zero delay (continuous assignment)
+    assign trn_dly[0] = trn;
+    assign req_dly[0] = req;
+
+    // handshake/request delay line
+    generate
+    for (genvar i=1; i<=CFG.HSK.DLY; i++) begin: dly
+        logic trn_tmp;
+        req_t req_tmp;
+        // continuous assignment
+        assign trn_dly[i] = trn_tmp;
+        assign req_dly[i] = req_tmp;
+        // propagate through delay line
+        always_ff @(posedge clk)
+        begin
+            trn_tmp <= trn_dly[i-1];
+            if (trn_dly[i-1]) begin
+                req_tmp <= req_dly[i-i];
+            end
+        end
+    end: dly
+    endgenerate
+
+////////////////////////////////////////////////////////////////////////////////
+// modports
+////////////////////////////////////////////////////////////////////////////////
+
+    // manager
+    modport  man (
+        // system signals
+        input  clk,
+        input  rst,
+        // handshake
+        output vld,
+        input  rdy,
+        // local signals
+        input  trn,
+        input  stl,
+        input  idl,
+        // request/response
+        output req,
+        input  rsp,
+        // delay line
+        input  trn_dly,
+        input  req_dly
+    );
+
+    // monitor
+    modport  mon (
+        // system signals
+        input  clk,
+        input  rst,
+        // handshake
+        input  vld,
+        input  rdy,
+        // local signals
+        input  trn,
+        input  stl,
+        input  idl,
+        // request/response
+        input  req,
+        input  rsp,
+        // delay line
+        input  trn_dly,
+        input  req_dly
+    );
+
+    // subordinate
+    modport  sub (
+        // system signals
+        input  clk,
+        input  rst,
+        // handshake
+        input  vld,
+        output rdy,
+        // local signals
+        input  trn,
+        input  stl,
+        input  idl,
+        // request/response
+        input  req,
+        output rsp,
+        // delay line
+        input  trn_dly,
+        input  req_dly
+    );
+
+endinterface: tcb_lite_if

--- a/test/rp32_vfriendly/tcb/tcb_lite_pkg.sv
+++ b/test/rp32_vfriendly/tcb/tcb_lite_pkg.sv
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// TCB-Lite (Tightly Coupled Bus) SystemVerilog package
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Iztok Jeras
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////////////////////////////////////////////////////////////////////////////////
+
+package tcb_lite_pkg;
+
+////////////////////////////////////////////////////////////////////////////////
+// handshake layer (defines the response delay and stability)
+////////////////////////////////////////////////////////////////////////////////
+
+    // parameter structure
+    typedef struct packed {
+        int unsigned DLY;  // response delay
+        bit          HLD;  // response hold (till the next access, response data even further till the next read access)
+    } tcb_lite_hsk_t;
+
+    // parameter defaults
+    localparam tcb_lite_hsk_t TCB_LITE_HSK_DEF = '{
+        DLY:    1,
+        HLD: 1'b0
+    };
+
+////////////////////////////////////////////////////////////////////////////////
+// bus layer (defines which signal subset is used)
+////////////////////////////////////////////////////////////////////////////////
+
+    // parameter structure
+    typedef struct packed {
+        bit          MOD;  // mode (0-logarithmic size, 1-byte enable)
+        int unsigned CTL;  // control width (user defined request signals)
+        int unsigned ADR;  // address width
+        int unsigned DAT;  // data    width
+        int unsigned STS;  // status  width (user defined response signals)
+    } tcb_lite_bus_t;
+
+    // physical interface parameter default
+    localparam tcb_lite_bus_t TCB_LITE_BUS_DEF = '{
+        MOD: 1'b0,
+        CTL:    0,
+        ADR:   32,
+        DAT:   32,
+        STS:    0
+    };
+
+////////////////////////////////////////////////////////////////////////////////
+// TCB configuration structure
+////////////////////////////////////////////////////////////////////////////////
+
+    // PMA parameter structure
+    typedef struct packed {
+        tcb_lite_hsk_t HSK;  // handshake
+        tcb_lite_bus_t BUS;  // bus
+    } tcb_lite_cfg_t;
+
+    // configuration parameter default
+    localparam tcb_lite_cfg_t TCB_LITE_CFG_DEF = '{
+        HSK: TCB_LITE_HSK_DEF,
+        BUS: TCB_LITE_BUS_DEF
+    };
+
+////////////////////////////////////////////////////////////////////////////////
+// predefined types
+////////////////////////////////////////////////////////////////////////////////
+
+//  typedef tcb_c #(.ADR (32), .DAT (32))::req_t tcb_req_t;  // request
+//  typedef tcb_c #(.ADR (32), .DAT (32))::req_t tcb_rsp_t;  // response
+
+////////////////////////////////////////////////////////////////////////////////
+// miscellaneous
+////////////////////////////////////////////////////////////////////////////////
+
+    // TODO: this is actually a RISC-V definition
+    // atomic encoding
+    typedef enum logic [5-1:0] {
+        LR      = 5'b00010,
+        SC      = 5'b00011,
+        AMOSWAP = 5'b00001,
+        AMOADD  = 5'b00000,
+        AMOXOR  = 5'b00100,
+        AMOAND  = 5'b01100,
+        AMOOR   = 5'b01000,
+        AMOMIN  = 5'b10000,
+        AMOMAX  = 5'b10100,
+        AMOMINU = 5'b11000,
+        AMOMAXU = 5'b11100
+    } tcb_lite_amo_t;
+
+endpackage: tcb_lite_pkg


### PR DESCRIPTION
…asses)

The whole degu SoC couldn't be co-simulated because Verilator 5.048 rejects two constructs in the source RTL (which Surelog/Yosys/slang all accept): (1) UNPACKED struct PARAMETERS — `tcb_lite_cfg_t`/`isa_t` are `struct` not `struct packed`, so Verilator can't fold them to constants (breaking tcb_lite_if's genvar loop bound CFG.HSK.DLY and r5p_degu's generate-if ISA.spec.ext.C); (2) `adr ==? DAM[i]` on a fourstate parameter *unpacked array* in the decoder.

Add a minimal Verilator-friendly RTL variant (test/rp32_vfriendly) — only 4 files differ from the original, all behaviourally identical:
  - riscv_isa_pkg.sv, tcb_lite_pkg.sv, tcb_lite_if.sv: struct typedefs -> packed
  - tcb_lite_lib_decoder.sv: DAM unpacked array -> packed 2D (`==?` on a packed param element folds; the unpacked version tripped Verilator's x-handling)

New test rp32_soc_vfriendly co-simulates the WHOLE r5p_degu_soc_top: the UHDM frontend's netlist vs the Verilator RTL, 200 cycles, 0 mismatches — end-to-end validation of the frontend on the complete SoC (bus fabric, GPIO/UART devices, interface arrays, clk/rst distribution).  project.f references the 4 friendly files + the original rp32 for everything else.

The original test/rp32 RTL and rp32_r5p_degu_soc_top (uhdm-only) test are untouched.  NOTE: the repo ships no real boot program (mem_if.mem is a stub), so the sim runs from empty memory — structural equivalence holds but observable output activity is limited; loading a real program would strengthen it.