### PR TITLE
uhdm: connect interface modport ports passed as hier_path (`.s(s.sub)`)

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1290,6 +1290,52 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                     continue;
                                 }
                             }
+                            // Interface MODPORT connection: `.s(s.sub)`.  Surelog
+                            // represents the actual as a hier_path <iface>.<modport>,
+                            // which — unlike the whole-interface ref_obj case above —
+                            // resolves through import_expression to 1'x, leaving the
+                            // child's flattened `<port>.<field>` ports undriven (so a
+                            // memory/logic indexed by an interface signal reads X).
+                            // Pair the target's `<port>.<field>` ports with the source
+                            // interface's `<iface>.<field>` signals, exactly like the
+                            // whole-interface ref_obj case.
+                            if (port->High_conn()->UhdmType() == uhdmhier_path) {
+                                const hier_path* hp =
+                                    any_cast<const hier_path*>(port->High_conn());
+                                std::string src_name;
+                                if (hp && hp->Path_elems() && !hp->Path_elems()->empty())
+                                    src_name = std::string((*hp->Path_elems())[0]->VpiName());
+                                std::vector<std::string> field_names;
+                                if (tgt_mod && !src_name.empty()) {
+                                    std::string tgt_prefix = "\\" + port_name + ".";
+                                    for (auto& w : tgt_mod->wires_) {
+                                        std::string wn = w.first.str();
+                                        if (wn.compare(0, tgt_prefix.size(), tgt_prefix) == 0)
+                                            field_names.push_back(wn.substr(tgt_prefix.size()));
+                                    }
+                                }
+                                if (field_names.empty() && iface_inst_vars_.count(src_name))
+                                    field_names = iface_inst_vars_[src_name];
+                                if (!field_names.empty() && !src_name.empty()) {
+                                    for (const auto& f : field_names) {
+                                        std::string src_full = src_name + "." + f;
+                                        std::string dst_port = port_name + "." + f;
+                                        RTLIL::Wire* src_w = nullptr;
+                                        if (name_map.count(src_full))
+                                            src_w = name_map[src_full];
+                                        if (!src_w && parent_rtlil_module)
+                                            src_w = parent_rtlil_module->wire(
+                                                RTLIL::escape_id(src_full));
+                                        if (src_w) {
+                                            cell->setPort(RTLIL::escape_id(dst_port),
+                                                          RTLIL::SigSpec(src_w));
+                                            log("UHDM: Connected interface modport port %s to wire %s\n",
+                                                dst_port.c_str(), src_full.c_str());
+                                        }
+                                    }
+                                    continue;
+                                }
+                            }
                             const expr* high_conn = any_cast<const expr*>(port->High_conn());
                             RTLIL::SigSpec conn = import_expression(high_conn);
 

--- a/test/iface_modport_conn/dut.sv
+++ b/test/iface_modport_conn/dut.sv
@@ -1,0 +1,29 @@
+// Interface modport port connection: a submodule instantiated with an
+// interface modport port passed as `.s(s.sub)`.  Surelog represents the
+// actual as a UHDM hier_path <iface>.<modport>; the child carries the
+// interface as flattened `<port>.<field>` ports.  The counter is driven
+// INSIDE the child (through the modport output) and read by the top, so
+// this isolates the modport port-connection path.
+interface tcb_if;
+  logic [31:0] cnt;
+  logic        act;
+  modport sub (output cnt, output act);
+endinterface
+
+module dev (input logic clk, input logic rst, tcb_if.sub s);
+  always_ff @(posedge clk)
+    if (rst) begin s.cnt <= 32'd0; s.act <= 1'b0; end
+    else     begin s.cnt <= s.cnt + 32'd1; s.act <= 1'b1; end
+endmodule
+
+module iface_modport_conn (
+  input  logic        clk,
+  input  logic        rst,
+  output logic [31:0] cnt,
+  output logic        act
+);
+  tcb_if s();
+  dev u_dev (.clk(clk), .rst(rst), .s(s.sub));
+  assign cnt = s.cnt;
+  assign act = s.act;
+endmodule


### PR DESCRIPTION
Instantiating a submodule with an interface MODPORT port passed as `.s(s.sub)` left the child's flattened `<port>.<field>` ports undriven — the parent emitted `connect \s 1'x` and hierarchy either failed or the child read X.  Root cause: Surelog represents the actual `s.sub` as a UHDM hier_path <iface>.<modport> (UhdmType uhdmhier_path), which — unlike the whole-interface ref_obj form and the interface-array bit_select form, both already handled in import_module_hierarchy's port-connection loop — fell through to import_expression and resolved to 1'x.

Add a hier_path branch that takes the source interface name from Path_elems()[0]->VpiName() and pairs the target module's `<port>.<field>` ports with the parent's `<iface>.<field>` signals (name_map or parent module wire), exactly like the whole-interface ref_obj case just above it.

New test iface_modport_conn: a counter driven inside a submodule through an interface modport output and read by the top — passes formal equivalence, and its Verilator co-sim matches (200 cycles, 0 mismatches).  Before the fix the design collapsed (`connect \s 1'x`, hierarchy failure).

This is the first of the frontend gaps behind the degu SoC's memory importing to X (r5p_soc_memory's `sub` interface was undriven).  Still open, tracked separately: continuous assign to an interface struct FIELD in the parent, memory indexed by an interface struct field, and $readmemh->$meminit.

No regressions: full run_all_tests.sh has 0 true failures; the existing interface tests (iface_modport / iface_modport_out / iface_modport_passthrough) still pass.