### PR TITLE
uhdm: fix interface struct-field continuous assign (Surelog/UHDM bump)

### DIFF
--- a/test/iface_field_assign/dut.sv
+++ b/test/iface_field_assign/dut.sv
@@ -1,0 +1,34 @@
+// Continuous assignment to an interface struct FIELD in the parent:
+// `assign s.req.adr = adr;`  The LHS is a hier_path (iface s -> field req ->
+// subfield adr).  These assigns drive slices of the packed `req` struct wire;
+// if dropped, the interface signal is undriven and the consumer reads X.
+interface tcb_if;
+  typedef struct packed {
+    logic [7:0]  adr;
+    logic [31:0] wdt;
+    logic        wen;
+  } req_t;
+  req_t        req;
+  logic [31:0] rsp;
+  modport sub (input req, output rsp);
+endinterface
+
+module dev (input logic clk, tcb_if.sub s);
+  always_ff @(posedge clk)
+    s.rsp <= s.req.wen ? (s.req.wdt + {24'b0, s.req.adr}) : s.rsp;
+endmodule
+
+module iface_field_assign (
+  input  logic        clk,
+  input  logic [7:0]  adr,
+  input  logic [31:0] wdt,
+  input  logic        wen,
+  output logic [31:0] rsp
+);
+  tcb_if s();
+  assign s.req.adr = adr;
+  assign s.req.wdt = wdt;
+  assign s.req.wen = wen;
+  assign rsp       = s.rsp;
+  dev u_dev (.clk(clk), .s(s.sub));
+endmodule

--- a/test/iface_field_assign_nocol/dut.sv
+++ b/test/iface_field_assign_nocol/dut.sv
@@ -1,0 +1,34 @@
+// Continuous assignment to an interface struct FIELD in the parent:
+// `assign s.req.adr = a_i;`  The LHS is a hier_path (iface s -> field req ->
+// subfield adr).  These assigns drive slices of the packed `req` struct wire;
+// if dropped, the interface signal is undriven and the consumer reads X.
+interface tcb_if;
+  typedef struct packed {
+    logic [7:0]  adr;
+    logic [31:0] wdt;
+    logic        wen;
+  } req_t;
+  req_t        req;
+  logic [31:0] rsp;
+  modport sub (input req, output rsp);
+endinterface
+
+module dev (input logic clk, tcb_if.sub s);
+  always_ff @(posedge clk)
+    s.rsp <= s.req.wen ? (s.req.wdt + {24'b0, s.req.adr}) : s.rsp;
+endmodule
+
+module iface_field_assign_nocol (
+  input  logic        clk,
+  input  logic [7:0]  a_i,
+  input  logic [31:0] d_i,
+  input  logic        e_i,
+  output logic [31:0] rsp
+);
+  tcb_if s();
+  assign s.req.adr = a_i;
+  assign s.req.wdt = d_i;
+  assign s.req.wen = e_i;
+  assign rsp       = s.rsp;
+  dev u_dev (.clk(clk), .s(s.sub));
+endmodule


### PR DESCRIPTION
A continuous assignment to an interface struct FIELD in the parent — `assign s.req.adr = adr;` where `s` is an interface instance (with a modport) and the field's leaf name collides with a module port/signal — was silently dropped: the interface signal stayed undriven, so a consumer read X.

The root cause was in UHDM's hier_path::DeepClone: resolving `s.req.adr` element-by-element, the interface case matched `req` against the modport's `input req` io_decl before the interface's own net, so `adr` could no longer resolve within it and fell back to the global bind, hitting the same-named enclosing port.  Fixed upstream (UHDM: resolve interface nets before modport io_decls); this bumps the Surelog submodule to pick it up.

Note: read_uhdm re-runs UHDM's elaboration/binding on the reader side, so the plugin must be relinked (`make uhdm2rtlil`) to pick up a UHDM-lib fix, not just the surelog binary.

Tests: iface_field_assign (collision: `assign s.req.adr = adr` with port `adr`) now passes formal equivalence + cosim (200 cycles, 0 mismatches); iface_field_assign_nocol (no collision) confirms the general case.  Full run_all_tests.sh: 0 true failures.