### PR TITLE
uhdm: detect submodule memories via the elaborated instance's array_var

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -270,11 +270,19 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
     // Modules absent from this set (orphans without a top, like a stand-alone
     // techmap library file) need ref_module materialisation in import_module().
     this->hierarchy_reachable_modules.clear();
+    // Map each module DEFINITION name to a representative ELABORATED instance.
+    // AllModules drops the unpacked dimension of a memory array (represents
+    // `logic [W:0] mem [0:N]` as a scalar logic_net), so a submodule imported
+    // from AllModules loses its memories; the elaborated instance carries the
+    // correct array_var.  Used below to import such modules from the elaborated
+    // form instead.
+    std::map<std::string, const module_inst*> elab_inst_by_def;
     if (uhdm_design->TopModules()) {
         std::function<void(const module_inst*)> walk = [&](const module_inst* m) {
             if (!m) return;
             std::string nm = std::string(m->VpiDefName());
             if (nm.find("work@") == 0) nm = nm.substr(5);
+            elab_inst_by_def.emplace(nm, m);  // first-seen elaborated instance
             if (!hierarchy_reachable_modules.insert(nm).second) return; // already visited
             if (m->Modules()) {
                 for (auto child : *m->Modules()) walk(child);
@@ -421,7 +429,26 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
                 log("UHDM: Skipping %s from AllModules (has gen_stmts; will import from elaborated form)\n", mod_name.c_str());
                 continue;
             }
-            import_module(module_def);
+            // AllModules represents an unpacked memory array as a scalar net
+            // (the [0:N] dimension is dropped) — so a submodule memory collapses
+            // to a wire and its dynamic accesses become $shiftx.  The elaborated
+            // instance carries the correct array_var; when the def is missing an
+            // array_var that its elaborated instance has, import that instead.
+            auto has_array_var = [](const module_inst* m) -> bool {
+                if (m && m->Variables())
+                    for (auto v : *m->Variables())
+                        if (v->UhdmType() == uhdmarray_var) return true;
+                return false;
+            };
+            const module_inst* to_import = module_def;
+            auto eit = elab_inst_by_def.find(mod_name);
+            if (eit != elab_inst_by_def.end() && has_array_var(eit->second) &&
+                !has_array_var(module_def)) {
+                log("UHDM: Importing %s from elaborated instance (has memory array_var lost in AllModules)\n",
+                    mod_name.c_str());
+                to_import = eit->second;
+            }
+            import_module(to_import);
         }
     }
     

--- a/test/mem_iface_index/dut.sv
+++ b/test/mem_iface_index/dut.sv
@@ -1,0 +1,36 @@
+// Memory indexed by an interface struct field: `mem[s.req.adr]`.  Earlier this
+// collapsed `mem` to a bare 32-bit wire (memory not detected) — the interface
+// binding fix (gap 2) may or may not have resolved the detection too.
+interface tcb_if;
+  typedef struct packed {
+    logic [7:0]  adr;
+    logic [31:0] wdt;
+    logic        wen;
+  } req_t;
+  req_t        req;
+  logic [31:0] rdt;
+  modport sub (input req, output rdt);
+endinterface
+
+module mem_core (input logic clk, tcb_if.sub s);
+  logic [31:0] mem [0:255];
+  always_ff @(posedge clk) begin
+    if (s.req.wen) mem[s.req.adr] <= s.req.wdt;
+    s.rdt <= mem[s.req.adr];
+  end
+endmodule
+
+module mem_iface_index (
+  input  logic        clk,
+  input  logic [7:0]  adr,
+  input  logic [31:0] wdt,
+  input  logic        wen,
+  output logic [31:0] rdt
+);
+  tcb_if s();
+  assign s.req.adr = adr;
+  assign s.req.wdt = wdt;
+  assign s.req.wen = wen;
+  assign rdt       = s.rdt;
+  mem_core u_core (.clk(clk), .s(s.sub));
+endmodule

--- a/test/mem_sub_plain/dut.sv
+++ b/test/mem_sub_plain/dut.sv
@@ -1,0 +1,10 @@
+module mem_sub (input logic clk, input logic [7:0] adr, input logic [31:0] wdt, input logic wen, output logic [31:0] rdt);
+  logic [31:0] mem [0:255];
+  always_ff @(posedge clk) begin
+    if (wen) mem[adr] <= wdt;
+    rdt <= mem[adr];
+  end
+endmodule
+module mem_sub_plain (input logic clk, input logic [7:0] adr, input logic [31:0] wdt, input logic wen, output logic [31:0] rdt);
+  mem_sub u (.clk(clk), .adr(adr), .wdt(wdt), .wen(wen), .rdt(rdt));
+endmodule


### PR DESCRIPTION
A memory `logic [W:0] mem [0:N]` declared in a SUBMODULE collapsed to a scalar `wire width W \mem` with `$shiftx` dynamic accesses — it was never detected as a $mem, so reads returned garbage.  Root cause: submodule bodies are imported from AllModules, and Surelog's AllModules form drops the unpacked `[0:N]` dimension, representing the array as a scalar logic_net (the def's logic_typespec has only the packed range).  The correct array_var (with the `[0:N]` Range) lives only on the ELABORATED instance under TopModules — which top modules already import from, so only submodules broke.

During the existing TopModules `Modules()` walk, map each def name to its first elaborated instance.  In the AllModules import loop, when a def lacks an array_var that its elaborated instance has, import the elaborated instance instead — it carries the correct array_var (same module name for non-param modules).  Targeted: only overrides memory-containing submodules.

Not interface-specific (plain-port submodule memories collapsed too); the fix unblocks the degu SoC's r5p_soc_memory submodule.

Tests: mem_sub_plain (plain-port submodule memory) and mem_iface_index (a memory indexed by an interface struct field, `mem[s.req.adr]`) both pass formal equivalence + cosim (200 cycles, 0 mismatches).  Full run_all_tests.sh: 0 true failures.