### PR TITLE
uhdm: resolve memory dimensions from nested interface struct parameters

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6259,6 +6259,23 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
     
     log("    hier_path: VpiName='%s', VpiFullName='%s', using='%s'\n",
         std::string(name_view).c_str(), std::string(full_name_view).c_str(), path_name.c_str());
+
+    // Nested interface struct-parameter field: `s.CFG.BUS.DAT` where `s` is a
+    // modport port and `CFG` is a (nested struct) parameter on the connected
+    // interface.  eval_iface_param_field walks the field chain to a constant.
+    // Needed for a memory width `logic [s.CFG.BUS.DAT-1:0] mem [...]` (the degu
+    // SoC's r5p_soc_memory) — resolving it via the bare 2-element param handler
+    // below would stop at `CFG` (the whole struct) and never reach `.BUS.DAT`.
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 3 &&
+        current_instance) {
+        std::string v = eval_iface_param_field(uhdm_hier, current_instance);
+        if (!v.empty()) {
+            int iv = atoi(v.c_str());
+            log("    hier_path: %s -> %d via interface struct parameter\n",
+                path_name.c_str(), iv);
+            return RTLIL::SigSpec(RTLIL::Const(iv, 32));
+        }
+    }
     // Cross-module reference (XMR) READ: `u_processor.internal_ready` where
     // `u_processor` is a child INSTANCE in this module and `internal_ready` is
     // an INTERNAL signal of it (github #450).  Yosys can't resolve this through

--- a/src/frontends/uhdm/memory_analysis.cpp
+++ b/src/frontends/uhdm/memory_analysis.cpp
@@ -486,6 +486,11 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
     int width = 1; // Default bit width
     int size = 1;  // Default array size
     int start_offset = 0;
+    // Memory dimensions may be interface struct-parameter expressions
+    // (`SIZ/(sub.CFG.BUS.DAT/8)`, `sub.CFG.BUS.DAT-1`); force constant folding
+    // so those operations collapse to constants during range evaluation.
+    bool mem_fcf_save = force_const_fold;
+    force_const_fold = true;
     
     // Get unpacked dimension (array size) from array_net ranges
     if (uhdm_array->Ranges() && !uhdm_array->Ranges()->empty()) {
@@ -523,8 +528,14 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
                 if (logic_typespec->Ranges() && !logic_typespec->Ranges()->empty()) {
                     auto range = (*logic_typespec->Ranges())[0];
                     if (range->Left_expr() && range->Right_expr()) {
+                        // The packed width may be an interface struct-parameter
+                        // expression like `s.CFG.BUS.DAT-1`; force constant folding
+                        // so the `-1` operation collapses to a constant.
+                        bool saved_fcf = force_const_fold;
+                        force_const_fold = true;
                         RTLIL::SigSpec left_spec = import_expression(range->Left_expr());
                         RTLIL::SigSpec right_spec = import_expression(range->Right_expr());
+                        force_const_fold = saved_fcf;
                         
                         if (left_spec.is_fully_const() && right_spec.is_fully_const()) {
                             int left = left_spec.as_int();
@@ -566,6 +577,7 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
                 width, size, start_offset);
     }
 
+    force_const_fold = mem_fcf_save;
     // Create RTLIL memory object
     RTLIL::IdString mem_id = RTLIL::escape_id(array_name);
     RTLIL::Memory *memory = new RTLIL::Memory;
@@ -597,6 +609,11 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
     int width = 1; // Default bit width
     int size = 1;  // Default array size
     int start_offset = 0;
+    // Memory dimensions may be interface struct-parameter expressions
+    // (`SIZ/(sub.CFG.BUS.DAT/8)`, `sub.CFG.BUS.DAT-1`); force constant folding
+    // so those operations collapse to constants during range evaluation.
+    bool mem_fcf_save = force_const_fold;
+    force_const_fold = true;
     
     // Get unpacked dimension (array size) from array_var ranges
     if (uhdm_array->Ranges() && !uhdm_array->Ranges()->empty()) {
@@ -636,8 +653,14 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
                 if (logic_typespec->Ranges() && !logic_typespec->Ranges()->empty()) {
                     auto range = (*logic_typespec->Ranges())[0];
                     if (range->Left_expr() && range->Right_expr()) {
+                        // The packed width may be an interface struct-parameter
+                        // expression like `s.CFG.BUS.DAT-1`; force constant folding
+                        // so the `-1` operation collapses to a constant.
+                        bool saved_fcf = force_const_fold;
+                        force_const_fold = true;
                         RTLIL::SigSpec left_spec = import_expression(range->Left_expr());
                         RTLIL::SigSpec right_spec = import_expression(range->Right_expr());
+                        force_const_fold = saved_fcf;
                         
                         if (left_spec.is_fully_const() && right_spec.is_fully_const()) {
                             int left = left_spec.as_int();
@@ -679,6 +702,7 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
                 width, size, start_offset);
     }
 
+    force_const_fold = mem_fcf_save;
     // Create RTLIL memory object
     RTLIL::IdString mem_id = RTLIL::escape_id(array_name);
     RTLIL::Memory *memory = new RTLIL::Memory;

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -675,28 +675,94 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
     auto& pe = *hp->Path_elems();
     std::string base  = std::string(pe[0]->VpiName());   // "sub"
     std::string pname = std::string(pe[1]->VpiName());   // "CFG"
-    auto parent = dynamic_cast<const module_inst*>(child_inst->VpiParent());
-    if (!parent || !parent->Ports()) return "";
     const interface_inst* iface = nullptr;
-    for (auto p : *parent->Ports()) {
-        if (std::string(p->VpiName()) != base) continue;
-        if (auto hc = p->High_conn())
-            if (hc->UhdmType() == uhdmref_obj)
-                if (auto a = any_cast<const ref_obj*>(hc)->Actual_group())
-                    if (a->UhdmType() == uhdminterface_inst)
-                        iface = any_cast<const interface_inst*>(a);
-        break;
+    // Prefer the base ref_obj's own binding: a modport port `s` resolves via
+    // Actual_group -> modport -> parent interface_inst (works when the interface
+    // is a local instance, not a parent port — e.g. a memory width
+    // `logic [s.CFG.BUS.DAT-1:0] mem`).
+    if (auto bref = dynamic_cast<const ref_obj*>(pe[0])) {
+        auto a = bref->Actual_group();
+        if (a) {
+            if (a->UhdmType() == uhdminterface_inst)
+                iface = any_cast<const interface_inst*>(a);
+            else if (a->UhdmType() == uhdmmodport) {
+                auto mp = any_cast<const modport*>(a);
+                if (mp && mp->VpiParent() &&
+                    mp->VpiParent()->UhdmType() == uhdminterface_inst)
+                    iface = any_cast<const interface_inst*>(mp->VpiParent());
+            }
+        }
     }
-    if (!iface || !iface->Param_assigns()) return "";
+    // Fallback: the parent module's port `<base>` connected to an interface.
+    if (!iface) {
+        auto parent = dynamic_cast<const module_inst*>(child_inst->VpiParent());
+        if (parent && parent->Ports())
+            for (auto p : *parent->Ports()) {
+                if (std::string(p->VpiName()) != base) continue;
+                if (auto hc = p->High_conn())
+                    if (hc->UhdmType() == uhdmref_obj)
+                        if (auto a = any_cast<const ref_obj*>(hc)->Actual_group())
+                            if (a->UhdmType() == uhdminterface_inst)
+                                iface = any_cast<const interface_inst*>(a);
+                break;
+            }
+    }
+    // The interface copy reachable from the ref_obj often lacks parameter data
+    // (empty Param_assigns/Parameters).  Find the elaborated interface instance
+    // in the parent module that actually carries `pname`.
+    auto has_param = [&](const interface_inst* ii) -> bool {
+        if (!ii) return false;
+        if (ii->Param_assigns())
+            for (auto pa : *ii->Param_assigns())
+                if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
+                    if (std::string(l->VpiName()) == pname) return true;
+        if (ii->Parameters())
+            for (auto p : *ii->Parameters())
+                if (std::string(p->VpiName()) == pname) return true;
+        return false;
+    };
+    if (!has_param(iface))
+        if (auto parent = dynamic_cast<const module_inst*>(child_inst->VpiParent()))
+            if (parent->Interfaces())
+                for (auto ii : *parent->Interfaces())
+                    if (has_param(ii)) { iface = ii; break; }
+    if (!iface) return "";
     const expr* val = nullptr;
     const typespec* cur_ts = nullptr;
-    for (auto pa : *iface->Param_assigns()) {
-        auto lhs = dynamic_cast<const parameter*>(pa->Lhs());
-        if (!lhs || std::string(lhs->VpiName()) != pname) continue;
-        val = dynamic_cast<const expr*>(pa->Rhs());
-        if (auto rt = lhs->Typespec()) cur_ts = rt->Actual_typespec();
-        break;
-    }
+    // Explicit override (elaborated value) in Param_assigns.
+    if (iface->Param_assigns())
+        for (auto pa : *iface->Param_assigns()) {
+            auto lhs = dynamic_cast<const parameter*>(pa->Lhs());
+            if (!lhs || std::string(lhs->VpiName()) != pname) continue;
+            val = dynamic_cast<const expr*>(pa->Rhs());
+            if (auto rt = lhs->Typespec()) cur_ts = rt->Actual_typespec();
+            break;
+        }
+    // Otherwise the parameter's own default value (Expr / assignment pattern).
+    if (!val && iface->Parameters())
+        for (auto p : *iface->Parameters()) {
+            if (std::string(p->VpiName()) != pname) continue;
+            auto par = dynamic_cast<const parameter*>(p);
+            if (!par) break;
+            val = par->Expr();
+            if (auto rt = par->Typespec()) cur_ts = rt->Actual_typespec();
+            break;
+        }
+    // If the interface copy reachable from the ref_obj lacks the parameter
+    // value (its Parameters()/Param_assigns() are empty), bind directly to the
+    // CFG element (pe[1]) whose Actual_group is the parameter object.
+    if (!val && pe.size() >= 2)
+        if (auto cref = dynamic_cast<const ref_obj*>(pe[1]))
+            if (auto ca = cref->Actual_group())
+                if (ca->UhdmType() == uhdmparameter) {
+                    auto par = any_cast<const parameter*>(ca);
+                    val = par->Expr();
+                    if (auto rt = par->Typespec()) cur_ts = rt->Actual_typespec();
+                    if (!val && par->VpiParent() &&
+                        par->VpiParent()->UhdmType() == uhdmparam_assign)
+                        val = dynamic_cast<const expr*>(
+                            any_cast<const param_assign*>(par->VpiParent())->Rhs());
+                }
     // Walk the field path (pe[2..]).  At each level the value is an assignment-
     // pattern operation; resolve the field by name (tagged_pattern) or by
     // struct-member index (positional, the elaborated form).

--- a/test/iface_cfg_mem/dut.sv
+++ b/test/iface_cfg_mem/dut.sv
@@ -1,0 +1,28 @@
+// Memory sized by an interface STRUCT PARAMETER field accessed through a modport
+// port: `logic [s.CFG.BUS.DAT-1:0] mem [0:...]`.  Mirrors the degu SoC's
+// r5p_soc_memory (`logic [sub.CFG.BUS.DAT-1:0] mem [0:SIZ/(DAT/8)-1]`).
+package tpkg;
+  typedef struct packed { int unsigned DAT; } bus_t;
+  typedef struct packed { bus_t BUS; } cfg_t;
+endpackage
+
+interface tif #(parameter tpkg::cfg_t CFG = '{BUS: '{DAT: 32}});
+  logic [CFG.BUS.DAT-1:0] req;
+  logic [CFG.BUS.DAT-1:0] rsp;
+  modport sub (input req, output rsp);
+endinterface
+
+module mem_core (input logic clk, input logic [7:0] adr, tif.sub s);
+  logic [s.CFG.BUS.DAT-1:0] mem [0:255];
+  always_ff @(posedge clk) begin
+    mem[adr] <= s.req;
+    s.rsp   <= mem[adr];
+  end
+endmodule
+
+module iface_cfg_mem (input logic clk, input logic [7:0] adr, input logic [31:0] din, output logic [31:0] dout);
+  tif s();
+  assign s.req = din;
+  assign dout  = s.rsp;
+  mem_core u (.clk(clk), .adr(adr), .s(s.sub));
+endmodule


### PR DESCRIPTION
A memory sized by a nested interface struct parameter — `logic [s.CFG.BUS.DAT-1:0] mem [0:SIZ/(s.CFG.BUS.DAT/8)-1]` where `s` is a modport port and CFG is a (struct) parameter on the connected interface (the degu SoC's r5p_soc_memory) — collapsed to a size-1 memory: `s.CFG.BUS.DAT` resolved to ~1.

Three fixes:
- import_hier_path (expression.cpp): for a hier_path with >=3 elements, resolve it via eval_iface_param_field, which walks the nested field chain to a constant. The bare 2-element param handler stops at `CFG` (the whole struct).
- eval_iface_param_field (uhdm2rtlil.cpp): find the interface from the base ref_obj's Actual_group (modport -> parent interface_inst) rather than only the parent's connected port.  The interface copy reachable that way often has empty Param_assigns/Parameters, so search the parent module's Interfaces() for the elaborated instance that carries the parameter; take its value from Param_assigns (override) or the parameter's own default Expr.
- create_memory_from_array (memory_analysis.cpp): wrap the dimension evaluation in force_const_fold so the `-1` and `/(DAT/8)` operations collapse to constants (import_operation otherwise folds all-const ops only in loop/gen/func context).

Test: iface_cfg_mem (a memory whose width comes from `s.CFG.BUS.DAT`) passes formal equivalence + cosim (200 cycles, 0 mismatches).  With this, the SoC's r5p_soc_memory imports at its true width 32 x size 4096 and $readmemh loads the full program.  run_all_tests.sh: 0 true failures.