### PR TITLE
uhdm: resolve a module parameter fed by an interface struct field 2 l…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -726,6 +726,19 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
             if (parent->Interfaces())
                 for (auto ii : *parent->Interfaces())
                     if (has_param(ii)) { iface = ii; break; }
+    // Multi-level (SoC -> wrapper -> device): the elaborated interface copy
+    // reachable from here may lack the parameter, and the connected instance
+    // lives further up the hierarchy (the parent only has a modport PORT, not an
+    // interface instance).  Fall back to the interface DEFINITION in
+    // AllInterfaces, which carries the parameter with its default value.
+    if (iface && !has_param(iface) && uhdm_design && uhdm_design->AllInterfaces()) {
+        std::string dn = std::string(iface->VpiDefName());
+        for (auto ii : *uhdm_design->AllInterfaces())
+            if (std::string(ii->VpiDefName()) == dn && has_param(ii)) {
+                iface = ii;
+                break;
+            }
+    }
     if (!iface) return "";
     const expr* val = nullptr;
     const typespec* cur_ts = nullptr;

--- a/test/iface_param_2level/dut.sv
+++ b/test/iface_param_2level/dut.sv
@@ -1,0 +1,28 @@
+// A parameter passed 2 levels down that references an interface struct field via
+// a modport port: wrapper's `s.CFG.BUS.DAT` -> inner's SYS_DAT.  Mirrors the SoC
+// tcb_lite_dev_gpio (modport port `sub`) -> tcb_dev_gpio `.SYS_DAT(sub.CFG.BUS.DAT)`.
+package p;
+  typedef struct packed { int unsigned DAT; } bus_t;
+  typedef struct packed { bus_t BUS; } cfg_t;
+endpackage
+
+interface tif #(parameter p::cfg_t CFG = '{BUS: '{DAT: 32}});
+  logic [CFG.BUS.DAT-1:0] data;
+  modport sub (input data);
+endinterface
+
+module inner #(parameter int unsigned SYS_DAT = 8)
+              (input logic clk, input logic [SYS_DAT-1:0] wdt, output logic [SYS_DAT-1:0] rdt);
+  logic [SYS_DAT-1:0] reg_data;
+  always_ff @(posedge clk) reg_data <= wdt;
+  assign rdt = reg_data;
+endmodule
+
+module wrapper (input logic clk, tif.sub s, input logic [31:0] wdt, output logic [31:0] rdt);
+  inner #(.SYS_DAT(s.CFG.BUS.DAT)) u_inner (.clk(clk), .wdt(wdt), .rdt(rdt));
+endmodule
+
+module iface_param_2level (input logic clk, input logic [31:0] wdt, output logic [31:0] rdt);
+  tif s();
+  wrapper u (.clk(clk), .s(s.sub), .wdt(wdt), .rdt(rdt));
+endmodule


### PR DESCRIPTION
…evels down

`.SYS_DAT(sub.CFG.BUS.DAT)` where the parameter is passed two hierarchy levels down (top -> wrapper -> device) and `sub` is a modport PORT of the wrapper: eval_iface_param_field found the interface via the base ref_obj's Actual_group, but that elaborated copy has empty Param_assigns/Parameters, and the wrapper has only a modport port -- no interface INSTANCE to search (the connected instance lives a level up). The parameter resolved to X, so the child paramod's port widths collapsed.

Add a fallback: when the reachable interface copy lacks the parameter, look up its DEFINITION in uhdm_design->AllInterfaces() by VpiDefName and use its default parameter value (correct whenever the interface's CFG isn't overridden).

New test test/iface_param_2level (cosim 200/0) reproduces the exact pattern from the degu SoC tcb_lite_dev_gpio -> tcb_dev_gpio instantiation.