### PR TITLE
uhdm: fix SYS_DAT paramod port width from a nested interface struct p…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6276,6 +6276,20 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
             return RTLIL::SigSpec(RTLIL::Const(iv, 32));
         }
     }
+    // `CFG.BUS.DAT` where the base is a struct-typed PARAMETER directly (Surelog
+    // inlines `sub.CFG.BUS.DAT` into a device paramod's port ranges, substituting
+    // the interface's `CFG` parameter for `sub.CFG`).  Resolves without needing
+    // current_instance, so it also fixes port-width evaluation where the width
+    // helper runs with no instance context (degu SoC tcb_dev_gpio sys_wdt/sys_rdt).
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 2) {
+        std::string v = eval_param_struct_field(uhdm_hier);
+        if (!v.empty()) {
+            int iv = atoi(v.c_str());
+            log("    hier_path: %s -> %d via struct parameter field\n",
+                path_name.c_str(), iv);
+            return RTLIL::SigSpec(RTLIL::Const(iv, 32));
+        }
+    }
     // Cross-module reference (XMR) READ: `u_processor.internal_ready` where
     // `u_processor` is a child INSTANCE in this module and `internal_ready` is
     // an INTERNAL signal of it (github #450).  Yosys can't resolve this through

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -574,8 +574,16 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
                     if (!is_packed_multidim) {
                         auto range = (*logic_typespec->Ranges())[0];
                         if (range->Left_expr() && range->Right_expr()) {
+                            // Force constant folding so a range built from a
+                            // resolved struct-parameter field folds to a constant
+                            // (e.g. `[CFG.BUS.DAT-1:0]` -> [31:0] in the degu SoC
+                            // tcb_dev_gpio paramod).  Without this the `-1` becomes
+                            // a $sub cell and the width silently defaults.
+                            bool saved_fcf = force_const_fold;
+                            force_const_fold = true;
                             RTLIL::SigSpec left_spec = import_expression(range->Left_expr());
                             RTLIL::SigSpec right_spec = import_expression(range->Right_expr());
+                            force_const_fold = saved_fcf;
 
                             if (left_spec.is_fully_const() && right_spec.is_fully_const()) {
                                 left = left_spec.as_int();
@@ -982,8 +990,16 @@ void UhdmImporter::import_net(const net* uhdm_net, const UHDM::instance* inst) {
                     if (!is_packed_multidim) {
                         auto range = (*logic_typespec->Ranges())[0];
                         if (range->Left_expr() && range->Right_expr()) {
+                            // Force constant folding so a range built from a
+                            // resolved struct-parameter field folds to a constant
+                            // (e.g. `[CFG.BUS.DAT-1:0]` -> [31:0] in the degu SoC
+                            // tcb_dev_gpio paramod).  Without this the `-1` becomes
+                            // a $sub cell and the width silently defaults.
+                            bool saved_fcf = force_const_fold;
+                            force_const_fold = true;
                             RTLIL::SigSpec left_spec = import_expression(range->Left_expr());
                             RTLIL::SigSpec right_spec = import_expression(range->Right_expr());
+                            force_const_fold = saved_fcf;
 
                             if (left_spec.is_fully_const() && right_spec.is_fully_const()) {
                                 left = left_spec.as_int();
@@ -2212,7 +2228,29 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
             }
             if (auto typespec = port->Typespec()) {
                 log("UHDM: Port has typespec, calling get_width_from_typespec\n");
-                return get_width_from_typespec(typespec, inst);
+                int w = get_width_from_typespec(typespec, inst);
+                // The elaborated port typespec range can carry an UNBOUND reference
+                // that neither the frontend nor Surelog's ExprEval can resolve
+                // (e.g. a stripped `[CFG.BUS.DAT-1:0]` in a specialized device
+                // paramod, degu SoC tcb_dev_gpio sys_wdt/sys_rdt), silently
+                // collapsing to 1.  Retry with the AllModules DEFINITION's port
+                // typespec, whose range refers to the module's OWN parameter
+                // (`[SYS_DAT-1:0]`).  width_from_def_port only trusts that range
+                // when it is driven by a parameter present in the RTLIL module's
+                // parameter_default_values (so it can only RECOVER a lost width via
+                // a resolved parameter, never inflate a genuine scalar).
+                // w == 0/1 only — never the interface sentinel (-1), whose port is
+                // a signal bundle, not a bit-vector.
+                if (w >= 0 && w <= 1 && inst) {
+                    int wd = width_from_def_port(std::string(inst->VpiDefName()),
+                                                 std::string(port->VpiName()), inst);
+                    if (wd > w) {
+                        log("UHDM: Port '%s' width recovered from definition typespec: %d\n",
+                            std::string(port->VpiName()).c_str(), wd);
+                        return wd;
+                    }
+                }
+                return w;
             } else {
                 log("UHDM: Port has no typespec\n");
             }

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -797,6 +797,115 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
     return "";
 }
 
+// Resolve `CFG.BUS.DAT` where the base element (pe[0]) is a struct-typed
+// PARAMETER.  In a specialized device paramod (degu SoC tcb_dev_gpio), Surelog
+// inlines the `.SYS_DAT(sub.CFG.BUS.DAT)` override into the port ranges but
+// substitutes `sub.CFG` with the connected interface's `CFG` parameter directly,
+// so the elaborated range reads `[CFG.BUS.DAT-1:0]`.  Resolves via pe[0]'s own
+// Actual_group (no current_instance needed).  "" on failure.
+std::string UhdmImporter::eval_param_struct_field(const hier_path* hp) {
+    if (!hp || !hp->Path_elems() || hp->Path_elems()->size() < 2) return "";
+    auto& pe = *hp->Path_elems();
+    auto bref = dynamic_cast<const ref_obj*>(pe[0]);
+    if (!bref) return "";
+    auto a = bref->Actual_group();
+    if (!a) return "";
+    const expr* val = nullptr;
+    const typespec* cur_ts = nullptr;
+    // The base's typespec is the struct type (e.g. tcb_lite_cfg_t) — needed for
+    // positional field resolution via struct_member_index.
+    if (auto bts = bref->Typespec()) cur_ts = bts->Actual_typespec();
+    if (a->UhdmType() == uhdmparameter) {
+        auto par = any_cast<const parameter*>(a);
+        val = par->Expr();
+        if (!cur_ts) if (auto rt = par->Typespec()) cur_ts = rt->Actual_typespec();
+        if (!val && par->VpiParent() &&
+            par->VpiParent()->UhdmType() == uhdmparam_assign)
+            val = dynamic_cast<const expr*>(
+                any_cast<const param_assign*>(par->VpiParent())->Rhs());
+    } else if (a->UhdmType() == uhdmoperation || a->UhdmType() == uhdmconstant) {
+        // Surelog often binds `CFG` directly to its assignment-pattern VALUE.
+        val = dynamic_cast<const expr*>(a);
+        if (!cur_ts) if (auto ts = val->Typespec()) cur_ts = ts->Actual_typespec();
+    }
+    if (!val) return "";
+    // Walk pe[1..] as struct field selectors (same as eval_iface_param_field).
+    for (size_t i = 1; i < pe.size() && val; i++) {
+        std::string field = std::string(pe[i]->VpiName());
+        const typespec* next_ts = nullptr;
+        const expr* next = find_tagged_field(val, field);
+        int idx = struct_member_index(cur_ts, field, &next_ts);
+        if (!next && val->UhdmType() == uhdmoperation && idx >= 0) {
+            auto op = any_cast<const operation*>(val);
+            if (op->Operands() && idx < (int)op->Operands()->size())
+                next = dynamic_cast<const expr*>((*op->Operands())[idx]);
+        }
+        val = next;
+        cur_ts = next_ts;
+    }
+    if (auto c = dynamic_cast<const constant*>(val))
+        return std::to_string(parse_vpi_value_to_int(std::string(c->VpiValue())));
+    return "";
+}
+
+// Width of a port from the AllModules DEFINITION's typespec.  The elaborated
+// instance's port range may carry an unbound reference (a stripped
+// `[CFG.BUS.DAT-1:0]`) that collapses to width 1; the definition's range instead
+// refers to the module's own parameter (`[SYS_DAT-1:0]`), which import_expression
+// resolves via the current RTLIL module's parameter_default_values (set from the
+// resolved override).  <=0 on failure.
+int UhdmImporter::width_from_def_port(const std::string& def_name,
+                                      const std::string& port_name,
+                                      const UHDM::scope* inst) {
+    if (!uhdm_design || !uhdm_design->AllModules()) return 0;
+    for (auto m : *uhdm_design->AllModules()) {
+        if (std::string(m->VpiDefName()) != def_name) continue;
+        if (!m->Ports()) return 0;
+        for (auto p : *m->Ports()) {
+            if (std::string(p->VpiName()) != port_name) continue;
+            auto ts = p->Typespec();
+            if (!ts || !ts->Actual_typespec()) return 0;
+            // Only trust the definition width when its range is driven by a
+            // parameter we've actually resolved (present in the module's
+            // parameter_default_values) — otherwise import_expression would fall
+            // back to the definition's DEFAULT and could wrongly inflate a
+            // genuinely narrow port.
+            auto at = ts->Actual_typespec();
+            if (at->UhdmType() != uhdmlogic_typespec) return 0;
+            auto lts = any_cast<const UHDM::logic_typespec*>(at);
+            if (!lts->Ranges() || lts->Ranges()->empty()) return 0;
+            bool param_driven = false;
+            for (auto r : *lts->Ranges()) {
+                if ((r->Left_expr()  && expr_uses_resolved_param(r->Left_expr())) ||
+                    (r->Right_expr() && expr_uses_resolved_param(r->Right_expr())))
+                    { param_driven = true; break; }
+            }
+            if (!param_driven) return 0;
+            return get_width_from_typespec(ts, inst);
+        }
+        return 0;
+    }
+    return 0;
+}
+
+// True if `e` references (possibly nested in an operation) a ref_obj whose name
+// is a parameter present in the current RTLIL module's parameter_default_values.
+bool UhdmImporter::expr_uses_resolved_param(const any* e) {
+    if (!e) return false;
+    if (e->UhdmType() == uhdmref_obj) {
+        std::string n = std::string(any_cast<const ref_obj*>(e)->VpiName());
+        return !n.empty() &&
+               module->parameter_default_values.count(RTLIL::escape_id(n)) > 0;
+    }
+    if (e->UhdmType() == uhdmoperation) {
+        auto op = any_cast<const operation*>(e);
+        if (op->Operands())
+            for (auto o : *op->Operands())
+                if (expr_uses_resolved_param(o)) return true;
+    }
+    return false;
+}
+
 // Recursively import module hierarchy starting from a module instance
 void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool create_instances) {
     if (!uhdm_module) return;
@@ -1773,7 +1882,6 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
     // Set current instance context for expression evaluation
     const module_inst* saved_instance = current_instance;
     current_instance = uhdm_module;
-    
     // For module instances, we want the definition name, not the instance name
     std::string base_modname;
     if (uhdm_module->VpiDefName().data()) {
@@ -1972,9 +2080,28 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                     log("UHDM: Processing parameter assignment for '%s'\n", param_name.c_str());
 
                     // Get the assigned value
-                    RTLIL::SigSpec value_spec = import_expression(any_cast<const expr*>(param_assign->Rhs()));
-                    if (value_spec.is_fully_const()) {
-                        RTLIL::Const param_value = value_spec.as_const();
+                    auto rhs_expr = any_cast<const expr*>(param_assign->Rhs());
+                    RTLIL::SigSpec value_spec = import_expression(rhs_expr);
+                    RTLIL::Const param_value;
+                    bool have_value = false;
+                    // A hier_path override like `.SYS_DAT(sub.CFG.BUS.DAT)` may evaluate
+                    // to X in the paramod-definition context (the interface is not
+                    // reachable here) — resolve it via the interface struct-field
+                    // evaluator, and never clobber the value already resolved by the
+                    // Parameters() pass with an X (degu SoC tcb_dev_gpio SYS_DAT).
+                    if (!value_spec.is_fully_def() && rhs_expr &&
+                        rhs_expr->UhdmType() == uhdmhier_path) {
+                        std::string iv = eval_iface_param_field(
+                            any_cast<const UHDM::hier_path*>(rhs_expr), current_instance);
+                        if (!iv.empty()) {
+                            param_value = RTLIL::Const(std::stoi(iv), 32);
+                            have_value = true;
+                        }
+                    } else if (value_spec.is_fully_const()) {
+                        param_value = value_spec.as_const();
+                        have_value = true;
+                    }
+                    if (have_value) {
                         // Override the parameter value
                         RTLIL::IdString param_id = RTLIL::escape_id(param_name);
                         // Only make non-localparam parameters externally visible
@@ -1986,10 +2113,10 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                             module->avail_parameters(param_id);
                         }
                         module->parameter_default_values[param_id] = param_value;
-                        log("UHDM: Updated parameter '%s' to value %s\n", 
+                        log("UHDM: Updated parameter '%s' to value %s\n",
                             param_name.c_str(), param_value.as_string().c_str());
                     } else {
-                        log_warning("UHDM: Parameter assignment for '%s' has non-constant value\n", 
+                        log_warning("UHDM: Parameter assignment for '%s' has non-constant value\n",
                                    param_name.c_str());
                     }
                 }

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -547,7 +547,21 @@ struct UhdmImporter {
     // child instance's parameter value; "" on failure.  See uhdm2rtlil.cpp.
     std::string eval_iface_param_field(const UHDM::hier_path* hp,
                                        const UHDM::module_inst* child_inst);
-    
+    // Resolve `CFG.BUS.DAT` where the base is a struct-typed PARAMETER (Surelog
+    // substitutes `sub.CFG` -> the interface's `CFG` parameter directly in an
+    // elaborated port range like `[CFG.BUS.DAT-1:0]`); "" on failure.
+    std::string eval_param_struct_field(const UHDM::hier_path* hp);
+    // Width of a port from the AllModules DEFINITION's typespec (whose range
+    // refers to the module's own parameter, resolvable via the RTLIL module's
+    // parameter_default_values); <=0 if not found or not parameter-driven.
+    int width_from_def_port(const std::string& def_name,
+                            const std::string& port_name,
+                            const UHDM::scope* inst);
+    // True if `e` references (possibly nested in an operation) a ref_obj whose
+    // name is a parameter present in the current RTLIL module's
+    // parameter_default_values — i.e. a width we have actually resolved.
+    bool expr_uses_resolved_param(const UHDM::any* e);
+
     // Package support
     void import_package(const UHDM::package* uhdm_package);
     


### PR DESCRIPTION
…arameter

In the degu SoC's specialized tcb_dev_gpio paramod, the SYS_DAT-driven ports (sys_wdt/sys_rdt, declared `[SYS_DAT-1:0]`) collapsed to width 1 and the SYS_DAT parameter to 1'x, because SYS_DAT = `sub.CFG.BUS.DAT` (a nested interface struct parameter passed two levels down) was not resolved and the elaborated port range carried an unbindable reference.  Four layered fixes:

1. import_module Param_assigns pass: a hier_path override that evaluates to X (X is fully_const) was overwriting the value already resolved by the Parameters() pass.  Resolve the hier_path via eval_iface_param_field and never clobber a resolved value with a non-fully_def (X) one.

2. eval_param_struct_field (new): Surelog inlines the override into the port range but substitutes `sub.CFG` with the interface's `CFG` parameter directly, so the range reads `[CFG.BUS.DAT-1:0]` (base = struct-typed parameter, not a modport). Resolve via pe[0]'s Actual_group (a parameter OR its assignment-pattern value) plus the base ref_obj's struct typespec.  Wired into import_hier_path.

3. force_const_fold around the import_port/import_net range evaluation, else `CFG.BUS.DAT-1` becomes a $sub cell instead of a constant and the width silently defaults.

4. width_from_def_port (new): the elaborated port typespec range can carry an unbound reference that neither the frontend nor Surelog ExprEval resolves, collapsing to width 1.  Recover from the AllModules DEFINITION port typespec, whose range refers to the module's own parameter (`[SYS_DAT-1:0]`), resolvable via the RTLIL module's parameter_default_values.  Guarded so it only fires for a genuine bit-vector port (width 0/1, not the -1 interface sentinel) and only when the definition range is driven by a parameter we have actually resolved (expr_uses_resolved_param) — never inflating a real scalar or interface bundle.

Verified on the SoC il: sys_wdt/sys_rdt recover to width 32.  Full regression 0 true failures.