### PR TITLE
uhdm: resolve interface struct-FIELD widths from a nested struct para…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -827,6 +827,14 @@ std::string UhdmImporter::eval_param_struct_field(const hier_path* hp) {
         // Surelog often binds `CFG` directly to its assignment-pattern VALUE.
         val = dynamic_cast<const expr*>(a);
         if (!cur_ts) if (auto ts = val->Typespec()) cur_ts = ts->Actual_typespec();
+        // The value operation carries no typespec of its own; recover the struct
+        // typespec (e.g. cfg_t) from the owning param_assign's parameter so the
+        // positional field walk (struct_member_index) can resolve `.BUS.ADR`.
+        if (!cur_ts && a->VpiParent() &&
+            a->VpiParent()->UhdmType() == uhdmparam_assign)
+            if (auto lhs = dynamic_cast<const parameter*>(
+                    any_cast<const param_assign*>(a->VpiParent())->Lhs()))
+                if (auto rt = lhs->Typespec()) cur_ts = rt->Actual_typespec();
     }
     if (!val) return "";
     // Walk pe[1..] as struct field selectors (same as eval_iface_param_field).

--- a/test/iface_array_internal_assign/dut.sv
+++ b/test/iface_array_internal_assign/dut.sv
@@ -1,0 +1,23 @@
+// Interface ARRAY element's INTERNAL continuous assign (`assign trn = vld & rdy`)
+// must be imported per element.  Mirrors degu SoC tcb_lite_if `assign trn =
+// vld & rdy` on the `tcb_per [2-1:0]` array: for a single interface it is driven,
+// for array elements it was left UNDRIVEN -> sys_wen = wen & X -> no GPIO write.
+interface tif;
+  logic vld, rdy, trn;
+  assign trn = vld & rdy;
+  modport sub (input vld, input rdy, input trn);
+endinterface
+
+module sink (input logic trn, output logic o);
+  assign o = trn;
+endmodule
+
+module iface_array_internal_assign
+  (input logic v0, input logic r0, input logic v1, input logic r1,
+   output logic o0, output logic o1);
+  tif s [2-1:0] ();
+  assign s[0].vld = v0;  assign s[0].rdy = r0;
+  assign s[1].vld = v1;  assign s[1].rdy = r1;
+  sink u0 (.trn(s[0].trn), .o(o0));
+  sink u1 (.trn(s[1].trn), .o(o1));
+endmodule

--- a/test/iface_member_read_assign/dut.sv
+++ b/test/iface_member_read_assign/dut.sv
@@ -1,0 +1,22 @@
+// Reading an interface modport struct MEMBER in a continuous assign:
+// `assign adr = mon.req.adr;`.  Mirrors degu SoC tcb_lite_lib_decoder
+// (`assign adr = mon.req.adr`) whose empty result made the address decode X ->
+// wrong peripheral select -> GPIO never written.
+package p;
+  typedef struct packed { logic [31:0] adr; logic [31:0] dat; } req_t;
+endpackage
+interface tif;
+  p::req_t req;
+  modport mon (input req);
+endinterface
+module dec (tif.mon mon, output logic [31:0] a);
+  logic [31:0] adr;
+  assign adr = mon.req.adr;
+  assign a = adr;
+endmodule
+module iface_member_read_assign (input logic [31:0] din, output logic [31:0] a);
+  tif s();
+  assign s.req.adr = din;
+  assign s.req.dat = '0;
+  dec u (.mon(s.mon), .a(a));
+endmodule

--- a/test/iface_struct_field_param_width/dut.sv
+++ b/test/iface_struct_field_param_width/dut.sv
@@ -1,0 +1,28 @@
+// Interface struct FIELD width from a nested interface struct PARAMETER
+// (`logic [CFG.BUS.ADR-1:0] adr` inside req_t), read via `mon.req.adr`.
+// Mirrors degu SoC tcb_lite_if req_t + tcb_lite_lib_decoder `assign adr =
+// mon.req.adr`, where adr collapsed to 1 bit -> address decode broken.
+package p;
+  typedef struct { int unsigned ADR; int unsigned DAT; } bus_t;
+  typedef struct { bus_t BUS; } cfg_t;
+  localparam cfg_t CFG_PER = '{BUS: '{ADR: 32, DAT: 32}};
+endpackage
+interface tif #(parameter p::cfg_t CFG = p::CFG_PER);
+  typedef struct {
+    logic [CFG.BUS.ADR-1:0] adr;
+    logic [CFG.BUS.DAT-1:0] wdt;
+  } req_t;
+  req_t req;
+  modport mon (input req);
+endinterface
+module dec #(parameter int unsigned ADR = 32) (tif.mon mon, output logic [ADR-1:0] a);
+  logic [ADR-1:0] adr;
+  assign adr = mon.req.adr;
+  assign a = adr;
+endmodule
+module iface_struct_field_param_width (input logic [31:0] din, output logic [31:0] a);
+  tif #(p::CFG_PER) s();
+  assign s.req.adr = din;
+  assign s.req.wdt = '0;
+  dec #(.ADR(32)) u (.mon(s.mon), .a(a));
+endmodule


### PR DESCRIPTION
…meter

An interface signal struct whose field widths come from a nested struct parameter — `logic [CFG.BUS.ADR-1:0] adr` inside req_t, degu SoC tcb_lite_if — collapsed to 1 bit per field (the whole struct shrank to a couple of bits), because eval_param_struct_field could not resolve `CFG.BUS.ADR`: Surelog binds `CFG` directly to its assignment-pattern VALUE (an operation with no typespec of its own), so the positional field walk (struct_member_index) had no struct typespec to index into.

Recover the struct typespec (e.g. cfg_t) from the value operation's owning param_assign's parameter, so `.BUS.ADR` resolves and each field gets its real width.

New test test/iface_struct_field_param_width (mon.req 2-bit -> 64-bit; UHDM-only, Verilator can't build struct-interface-param RTL).  Also adds test/iface_member_read_assign and test/iface_array_internal_assign (interface struct-member read + array-element internal assign — both already worked, added as regression coverage).  Full regression 0 true failures.