### PR TITLE
uhdm: resolve a local-var width from a substituted struct-localparam …

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2343,7 +2343,21 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
             log("UHDM: Found net object\n");
             if (auto typespec = variable->Typespec()) {
                 log("UHDM: Net has typespec, calling get_width_from_typespec\n");
-                return get_width_from_typespec(typespec, inst);
+                int w = get_width_from_typespec(typespec, inst);
+                // The elaborated var range may carry a substituted override
+                // hier_path (`[CFG_LSU.BUS.ADR-1:0]`, degu SoC tcb_lite_lib_decoder
+                // `adr`) that references a parent-scope param unresolvable here and
+                // collapses to 1.  Recover from the AllModules DEFINITION var
+                // typespec, whose range refers to the module's own parameter.
+                if (w >= 0 && w <= 1) {
+                    if (auto mi = dynamic_cast<const UHDM::module_inst*>(inst)) {
+                        int wd = width_from_def_var(std::string(mi->VpiDefName()),
+                                                    std::string(variable->VpiName()),
+                                                    inst);
+                        if (wd > w) return wd;
+                    }
+                }
+                return w;
             } else {
                 log("UHDM: Net has no typespec\n");
             }

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -823,6 +823,28 @@ std::string UhdmImporter::eval_param_struct_field(const hier_path* hp) {
             par->VpiParent()->UhdmType() == uhdmparam_assign)
             val = dynamic_cast<const expr*>(
                 any_cast<const param_assign*>(par->VpiParent())->Rhs());
+        // A (local)param declared in a module carries no Expr of its own; its
+        // assignment-pattern value lives in the owning module_inst's
+        // Param_assigns (degu SoC `localparam CFG_LSU = '{...}` referenced from a
+        // child's substituted `[CFG_LSU.BUS.ADR-1:0]` range).  Only accept an
+        // ASSIGNMENT-PATTERN Rhs — a cast like `part_info_t'(16)` is not walkable
+        // by the positional field walk and must fall through to the generic
+        // handler (OutputSizeWithParameterOfInstanceInitializedByStructMember).
+        if (!val && par->VpiParent() &&
+            par->VpiParent()->UhdmType() == uhdmmodule_inst) {
+            auto owner = any_cast<const module_inst*>(par->VpiParent());
+            if (owner->Param_assigns())
+                for (auto pa : *owner->Param_assigns())
+                    if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
+                        if (std::string(l->VpiName()) == std::string(par->VpiName())) {
+                            auto rhs = dynamic_cast<const expr*>(pa->Rhs());
+                            if (rhs && rhs->UhdmType() == uhdmoperation &&
+                                any_cast<const operation*>(rhs)->VpiOpType() ==
+                                    vpiAssignmentPatternOp)
+                                val = rhs;
+                            break;
+                        }
+        }
     } else if (a->UhdmType() == uhdmoperation || a->UhdmType() == uhdmconstant) {
         // Surelog often binds `CFG` directly to its assignment-pattern VALUE.
         val = dynamic_cast<const expr*>(a);
@@ -890,6 +912,41 @@ int UhdmImporter::width_from_def_port(const std::string& def_name,
             }
             if (!param_driven) return 0;
             return get_width_from_typespec(ts, inst);
+        }
+        return 0;
+    }
+    return 0;
+}
+
+// Width of a module-local VARIABLE from the AllModules DEFINITION's typespec.
+// The elaborated instance's var range may carry a substituted override hier_path
+// (`[CFG_LSU.BUS.ADR-1:0]`) whose base is a parent-scope param unresolvable here;
+// the definition's range refers to the module's own parameter (`[ADR-1:0]`),
+// resolvable via parameter_default_values.  <=0 if not found / not param-driven.
+int UhdmImporter::width_from_def_var(const std::string& def_name,
+                                     const std::string& var_name,
+                                     const UHDM::scope* inst) {
+    if (!uhdm_design || !uhdm_design->AllModules()) return 0;
+    for (auto m : *uhdm_design->AllModules()) {
+        if (std::string(m->VpiDefName()) != def_name) continue;
+        if (!m->Variables()) return 0;
+        for (auto v : *m->Variables()) {
+            if (std::string(v->VpiName()) != var_name) continue;
+            auto ts = v->Typespec();
+            if (!ts || !ts->Actual_typespec()) return 0;
+            auto at = ts->Actual_typespec();
+            if (at->UhdmType() != uhdmlogic_typespec) return 0;
+            auto lts = any_cast<const UHDM::logic_typespec*>(at);
+            if (!lts->Ranges() || lts->Ranges()->empty()) return 0;
+            bool param_driven = false;
+            for (auto r : *lts->Ranges()) {
+                if ((r->Left_expr()  && expr_uses_resolved_param(r->Left_expr())) ||
+                    (r->Right_expr() && expr_uses_resolved_param(r->Right_expr())))
+                    { param_driven = true; break; }
+            }
+            if (!param_driven) return 0;
+            int rw = get_width_from_typespec(ts, inst);
+            return rw;
         }
         return 0;
     }

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -557,6 +557,13 @@ struct UhdmImporter {
     int width_from_def_port(const std::string& def_name,
                             const std::string& port_name,
                             const UHDM::scope* inst);
+    // Same, for a module-local VARIABLE (Surelog substitutes an override
+    // hier_path into the elaborated var range, e.g. `[CFG_LSU.BUS.ADR-1:0]`, which
+    // references a parent-scope param that can't resolve here; the definition's
+    // range `[ADR-1:0]` refers to the module's own parameter instead).
+    int width_from_def_var(const std::string& def_name,
+                           const std::string& var_name,
+                           const UHDM::scope* inst);
     // True if `e` references (possibly nested in an operation) a ref_obj whose
     // name is a parameter present in the current RTLIL module's
     // parameter_default_values — i.e. a width we have actually resolved.


### PR DESCRIPTION
…field

The degu SoC tcb_lite_lib_decoder's `logic [ADR-1:0] adr` came out 1 bit, breaking the address decode: its instance gets `.ADR(CFG_LSU.BUS.ADR)` (a module-localparam struct field), and Surelog SUBSTITUTES that override into the elaborated var range -> `[CFG_LSU.BUS.ADR-1:0]` (a hier_path), whose base `CFG_LSU` is a parent-scope localparam unresolvable in the child, so the range never folded.

Two parts:
- eval_param_struct_field: when the base parameter (CFG_LSU) has no Expr and its parent is the owning module_inst, look up its value in that module's Param_assigns.  Accept ONLY an assignment-pattern (vpiAssignmentPatternOp) Rhs — a struct cast like `part_info_t'(16)` is not walkable positionally and must fall through to the generic handler.
- width_from_def_var (new, mirrors width_from_def_port): a general fallback for a local var whose elaborated range carries an unresolvable substituted hier_path — use the AllModules definition var typespec (range refers to the module's own parameter).

Verified on the SoC il: decoder `adr` 1-bit -> 32-bit (`\mon.req[65:34]`).  Full regression 0 true failures.