### PR TITLE
uhdm: unroll function for-loops with locally-declared counters + comp…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -823,6 +823,39 @@ void UhdmImporter::process_stmt_to_case(const any* stmt, RTLIL::CaseRule* case_r
                 }
             }
 
+            // Compound assignment (`x |= y`, `x += y`, ...): UHDM encodes the
+            // operator on the assignment's VpiOpType (a binary op, not the plain
+            // vpiAssignmentOp) and stores only `y` as the RHS.  Combine with the
+            // LHS's current value so that unrolled-loop accumulation
+            // (`encode |= v[i] ? ... : '0`) chains across iterations instead of
+            // each iteration overwriting the previous one.
+            if (lhs_sig.size() > 0 && !skip_assignment) {
+                // The accumulator's current value is the most recent action
+                // targeting this exact LHS (the pre-loop initializer or the
+                // previous iteration's result); fall back to the wire itself.
+                RTLIL::SigSpec acc = lhs_sig;
+                for (const auto& act : case_rule->actions)
+                    if (act.first == lhs_sig) acc = act.second;
+                if (acc.size() < rhs_sig.size()) acc.extend_u0(rhs_sig.size());
+                else if (acc.size() > rhs_sig.size()) rhs_sig.extend_u0(acc.size());
+                RTLIL::SigSpec c;
+                bool did = true;
+                switch (assign->VpiOpType()) {
+                case vpiBitOrOp:  c = module->Or (NEW_ID, acc, rhs_sig); break;
+                case vpiBitAndOp: c = module->And(NEW_ID, acc, rhs_sig); break;
+                case vpiBitXorOp: c = module->Xor(NEW_ID, acc, rhs_sig); break;
+                case vpiAddOp:    c = module->Add(NEW_ID, acc, rhs_sig); break;
+                case vpiSubOp:    c = module->Sub(NEW_ID, acc, rhs_sig); break;
+                case vpiMultOp:   c = module->Mul(NEW_ID, acc, rhs_sig); break;
+                case vpiDivOp:    c = module->Div(NEW_ID, acc, rhs_sig); break;
+                case vpiModOp:    c = module->Mod(NEW_ID, acc, rhs_sig); break;
+                case vpiLShiftOp: c = module->Shl(NEW_ID, acc, rhs_sig); break;
+                case vpiRShiftOp: c = module->Shr(NEW_ID, acc, rhs_sig); break;
+                default: did = false;
+                }
+                if (did) rhs_sig = c;
+            }
+
             // Add the assignment action
             if (lhs_sig.size() > 0) {
                 // Truncate or extend RHS to match LHS width
@@ -894,14 +927,11 @@ void UhdmImporter::process_stmt_to_case(const any* stmt, RTLIL::CaseRule* case_r
                 if (init_stmt->UhdmType() == uhdmassignment) {
                     const assignment* init_assign = any_cast<const assignment*>(init_stmt);
                     if (init_assign->Lhs()) {
-                        // Handle both ref_obj and ref_var (integer variables use ref_var)
-                        if (init_assign->Lhs()->UhdmType() == uhdmref_obj) {
-                            const ref_obj* ref = any_cast<const ref_obj*>(init_assign->Lhs());
-                            loop_var_name = ref->VpiName();
-                        } else if (init_assign->Lhs()->UhdmType() == uhdmref_var) {
-                            const ref_var* ref = any_cast<const ref_var*>(init_assign->Lhs());
-                            loop_var_name = ref->VpiName();
-                        }
+                        // A locally-declared loop var (`for (int i=0; ...)`) has
+                        // the variable DECLARATION itself as the init Lhs (an
+                        // int_var/integer_var/logic_var), not a ref_obj/ref_var.
+                        // Any of these carries the name via VpiName().
+                        loop_var_name = init_assign->Lhs()->VpiName();
                         
                         if (!loop_var_name.empty() && init_assign->Rhs() && init_assign->Rhs()->UhdmType() == uhdmconstant) {
                             const constant* const_val = any_cast<const constant*>(init_assign->Rhs());

--- a/test/func_forloop_onehot/dut.sv
+++ b/test/func_forloop_onehot/dut.sv
@@ -1,0 +1,19 @@
+// Minimal repro of tcb_lite_lib_decoder's `encode` one-hot->binary function:
+// a for loop inside a function whose bound is a parameter, with a bit-select
+// of the loop variable (i[IFL-1:0]) and of the argument (val[i]).
+module func_forloop_onehot #(
+    parameter int unsigned IFN = 4,          // number of interfaces (one-hot width)
+    parameter int unsigned IFL = 2           // log2(IFN) (binary width)
+) (
+    input  logic [IFN-1:0] val,
+    output logic [IFL-1:0] sel
+);
+    function logic [IFL-1:0] encode (logic [IFN-1:0] v);
+        encode = '0;
+        for (int i=0; i<IFN; i++) begin
+            encode |= v[i] ? i[IFL-1:0] : '0;
+        end
+    endfunction
+
+    assign sel = encode(val);
+endmodule


### PR DESCRIPTION
…ound assign

Two bugs prevented the tcb_lite_lib_decoder `encode` one-hot->binary function (`for (int i=0; i<IFN; i++) encode |= v[i] ? i[IFL-1:0] : '0`) from synthesising, which aborted the whole degu SoC read with `ERROR: Could not find wire 'PRI' for bit select`.

1. Locally-declared loop counter: `for (int i=0; ...)` puts the variable DECLARATION (an int_var) as the init assignment's Lhs, not a ref_obj/ref_var, so loop_var_name stayed empty and the loop never unrolled (each iteration's `i[IFL-1:0]` collapsed).  Take the name from the Lhs's VpiName() directly, which works for int_var/integer_var/logic_var alike.

2. Compound assignment in the loop body: UHDM encodes `encode |= y` as an assignment whose VpiOpType is the binary op (vpiBitOrOp) with only `y` as the RHS.  process_stmt_to_case ignored the op, so each unrolled iteration OVERWROTE the accumulator (last-wins) instead of OR-ing.  Combine the RHS with the accumulator's current value (the most recent action targeting the LHS) for the compound binary ops (|= &= ^= += -= *= /= %= <<= >>=).

Repro test/func_forloop_onehot: SAT-verified one-hot->binary for all 4 inputs; formal-equivalent to the Verilog frontend.  Unblocks the degu SoC read (memory `adr` now a correct 12-bit address).  Full regression: 0 true failures.