### PR TITLE
uhdm: force-fold computed part-select bounds in the struct-field slic…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -9003,6 +9003,11 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                     // prefix (`sub.req_dly[DLY]`).  Stride = the element struct
                     // width; for the collapsed 1-element interface array this is
                     // the whole base wire and any index resolves to offset 0.
+                    // Index and bound sub-expressions may be computed
+                    // (`$clog2(sub.CFG_BUS_BYT)-1`); force constant folding so the
+                    // arithmetic reduces to a literal instead of emitting cells.
+                    bool saved_fcf = force_const_fold;
+                    force_const_fold = true;
                     int elem_off = 0;
                     int elem_w = ts ? get_width_from_typespec(const_cast<typespec*>(ts), inst) : 0;
                     if (elem_w <= 0) elem_w = base_wire->width;
@@ -9038,6 +9043,7 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                             bounds_ok = true;
                         }
                     }
+                    force_const_fold = saved_fcf;
                     if (off_ok && bounds_ok && len > 0) {
                         int abs_start = elem_off + field_offset + lsb;
                         if (abs_start >= 0 && abs_start + len <= base_wire->width) {


### PR DESCRIPTION
…e handler

The nested struct-field part-select handler imported the select bounds and array index with plain import_expression, which only constant-folds arithmetic in a loop/generate/function/force_const_fold context.  A bound like `sub.req_dly[DLY].adr[$clog2(sub.CFG_BUS_BYT)-1:0]` (tcb_lite_lib_logsize2byteena) folded $clog2(sub.CFG_BUS_BYT) to 2 but then left the outer `- 1` as a live $sub cell, so the bound was non-constant and the slice fell through to the "could not resolve" fallback (X).

Wrap the index/bound imports in force_const_fold so the surrounding arithmetic reduces to a literal.  Drops the degu SoC's
`sub.req_dly[N].adr[$clog2()-1:0]` unresolved-access warnings from 2 to 0. Full regression: 0 true failures, 0 crashes.