### PR TITLE
uhdm: resolve bare interface struct-parameter field (CFG.HSK.DLY)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6335,6 +6335,18 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
             return RTLIL::SigSpec(RTLIL::Const(iv, 32));
         }
     }
+    // Bare `CFG.HSK.DLY` — an interface's own struct parameter substituted into a
+    // signal width without a modport prefix (tcb_lite_if `[CFG.HSK.DLY-1:0]`).
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 2 &&
+        current_instance) {
+        std::string v = eval_bare_iface_param_field(uhdm_hier, current_instance);
+        if (!v.empty()) {
+            int iv = atoi(v.c_str());
+            log("    hier_path: %s -> %d via bare interface struct parameter\n",
+                path_name.c_str(), iv);
+            return RTLIL::SigSpec(RTLIL::Const(iv, 32));
+        }
+    }
     // `CFG.BUS.DAT` where the base is a struct-typed PARAMETER directly (Surelog
     // inlines `sub.CFG.BUS.DAT` into a device paramod's port ranges, substituting
     // the interface's `CFG` parameter for `sub.CFG`).  Resolves without needing

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -851,6 +851,109 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
     return "";
 }
 
+// BARE `CFG.HSK.DLY` — see header.  Surelog substitutes an interface's own struct
+// parameter into a signal width (`logic [CFG.HSK.DLY-1:0] ...` in tcb_lite_if)
+// WITHOUT a modport prefix, and leaves pe[0]=`CFG`'s Actual_group null.  Find the
+// interface via any of child_inst's interface ports and walk the field chain.
+std::string UhdmImporter::eval_bare_iface_param_field(const hier_path* hp,
+                                          const module_inst* child_inst) {
+    if (!hp || !hp->Path_elems() || hp->Path_elems()->size() < 2 || !child_inst)
+        return "";
+    auto& pe = *hp->Path_elems();
+    std::string pname = std::string(pe[0]->VpiName());   // "CFG"
+    // pe[0] must NOT be one of child_inst's ports — otherwise this is the modport
+    // form (`sub.CFG.BUS.DAT`) handled by eval_iface_param_field.
+    if (child_inst->Ports())
+        for (auto p : *child_inst->Ports())
+            if (std::string(p->VpiName()) == pname) return "";
+    auto has_param = [&](const interface_inst* ii) -> bool {
+        if (!ii) return false;
+        if (ii->Param_assigns())
+            for (auto pa : *ii->Param_assigns())
+                if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
+                    if (std::string(l->VpiName()) == pname) return true;
+        if (ii->Parameters())
+            for (auto p : *ii->Parameters())
+                if (std::string(p->VpiName()) == pname) return true;
+        return false;
+    };
+    auto iface_of_port = [&](const port* p) -> const interface_inst* {
+        const any* lc = p->Low_conn();
+        if (lc && lc->UhdmType() == uhdmref_obj)
+            if (auto a = any_cast<const ref_obj*>(lc)->Actual_group()) lc = a;
+        if (lc && lc->UhdmType() == uhdmmodport) {
+            auto mp = any_cast<const modport*>(lc);
+            if (mp && mp->VpiParent() &&
+                mp->VpiParent()->UhdmType() == uhdminterface_inst)
+                return any_cast<const interface_inst*>(mp->VpiParent());
+        }
+        if (lc && lc->UhdmType() == uhdminterface_inst)
+            return any_cast<const interface_inst*>(lc);
+        return nullptr;
+    };
+    const interface_inst* iface = nullptr;
+    if (child_inst->Ports())
+        for (auto p : *child_inst->Ports()) {
+            auto ii = iface_of_port(p);
+            if (has_param(ii)) { iface = ii; break; }
+        }
+    if (!iface)
+        if (auto parent = dynamic_cast<const module_inst*>(child_inst->VpiParent())) {
+            if (parent->Interfaces())
+                for (auto ii : *parent->Interfaces())
+                    if (has_param(ii)) { iface = ii; break; }
+        }
+    // Elaborated interface copy may lack the parameter; fall back to the
+    // definition in AllInterfaces.
+    if (iface && !has_param(iface) && uhdm_design && uhdm_design->AllInterfaces()) {
+        std::string dn = std::string(iface->VpiDefName());
+        for (auto ii : *uhdm_design->AllInterfaces())
+            if (std::string(ii->VpiDefName()) == dn && has_param(ii)) { iface = ii; break; }
+    }
+    if (!iface) return "";
+    const expr* val = nullptr;
+    const typespec* cur_ts = nullptr;
+    if (iface->Param_assigns())
+        for (auto pa : *iface->Param_assigns()) {
+            auto l = dynamic_cast<const parameter*>(pa->Lhs());
+            if (!l || std::string(l->VpiName()) != pname) continue;
+            val = dynamic_cast<const expr*>(pa->Rhs());
+            if (auto rt = l->Typespec()) cur_ts = rt->Actual_typespec();
+            break;
+        }
+    if (!val && iface->Parameters())
+        for (auto p : *iface->Parameters()) {
+            if (std::string(p->VpiName()) != pname) continue;
+            if (auto par = dynamic_cast<const parameter*>(p)) {
+                val = par->Expr();
+                if (auto rt = par->Typespec()) cur_ts = rt->Actual_typespec();
+            }
+            break;
+        }
+    if (!val) return "";
+    // Walk the field path pe[1..] (HSK.DLY).
+    for (size_t i = 1; i < pe.size() && val; i++) {
+        std::string field = std::string(pe[i]->VpiName());
+        const typespec* next_ts = nullptr;
+        const expr* next = find_tagged_field(val, field);
+        int idx = struct_member_index(cur_ts, field, &next_ts);
+        if (!next && val->UhdmType() == uhdmoperation && idx >= 0) {
+            auto op = any_cast<const operation*>(val);
+            if (op->Operands() && idx < (int)op->Operands()->size())
+                next = dynamic_cast<const expr*>((*op->Operands())[idx]);
+        }
+        val = next;
+        cur_ts = next_ts;
+    }
+    if (val && val->UhdmType() != uhdmconstant) {
+        long out;
+        if (eval_iface_local_const(iface, val, out)) return std::to_string(out);
+    }
+    if (auto c = dynamic_cast<const constant*>(val))
+        return std::to_string(parse_vpi_value_to_int(std::string(c->VpiValue())));
+    return "";
+}
+
 // Recursively fold a scalar interface-localparam value expression (see header).
 bool UhdmImporter::eval_iface_local_const(const interface_inst* iface,
                                           const UHDM::any* ve, long& out) {

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -547,6 +547,12 @@ struct UhdmImporter {
     // child instance's parameter value; "" on failure.  See uhdm2rtlil.cpp.
     std::string eval_iface_param_field(const UHDM::hier_path* hp,
                                        const UHDM::module_inst* child_inst);
+    // BARE form `CFG.HSK.DLY` — an interface's own struct parameter substituted
+    // into a signal width WITHOUT a modport prefix (pe[0] IS the parameter, not a
+    // port).  Finds the interface via any of child_inst's interface ports; ""
+    // on failure.  See uhdm2rtlil.cpp.
+    std::string eval_bare_iface_param_field(const UHDM::hier_path* hp,
+                                            const UHDM::module_inst* child_inst);
     // Recursively fold a scalar interface-localparam value expression to an int
     // in the interface-instance scope.  Handles the TCB-Lite localparam chain
     // (`BYT = CFG.BUS.DAT/8`, `OFF = $clog2(BYT)`): constants, refs to other

--- a/test/iface_nested_param_field/dut.sv
+++ b/test/iface_nested_param_field/dut.sv
@@ -1,0 +1,19 @@
+// Nested interface struct-PARAM field access `CFG.HSK.DLY` used inside the
+// interface (tcb_lite_if: `req_dly [0:CFG.HSK.DLY]`).  3-level: CFG->HSK->DLY.
+package p;
+  typedef struct { int unsigned DLY; } hsk_t;
+  typedef struct { hsk_t HSK; int unsigned W; } cfg_t;
+  localparam cfg_t CFG_DEF = '{HSK: '{DLY: 3}, W: 8};
+endpackage
+interface tif #(parameter p::cfg_t CFG = p::CFG_DEF);
+  logic [CFG.HSK.DLY-1:0] dly_reg;    // width uses CFG.HSK.DLY = 3 -> [2:0]
+  modport sub (input dly_reg);
+endinterface
+module mem (tif.sub sub, output logic [2:0] o);
+  assign o = sub.dly_reg;
+endmodule
+module iface_nested_param_field (input logic [2:0] d, output logic [2:0] o);
+  tif s();
+  assign s.dly_reg = d;
+  mem u (.sub(s.sub), .o(o));
+endmodule


### PR DESCRIPTION
An interface's own struct parameter used in a signal width (`logic [CFG.HSK.DLY-1:0] req_dly` in tcb_lite_if) is substituted by Surelog WITHOUT a modport prefix and with pe[0]=`CFG`'s Actual_group left null, so neither eval_iface_param_field (needs a modport base) nor eval_param_struct_field (needs pe[0]'s Actual_group) could resolve it -> the width collapsed to 1 bit.

New eval_bare_iface_param_field: when pe[0] is not one of child_inst's ports, treat it as an interface parameter name, find the interface via any of the instance's interface ports (Low_conn modport -> parent interface_inst) — falling back to the parent's Interfaces() and the AllInterfaces definition — then walk the field chain pe[1..] (HSK.DLY) with the existing struct-field resolver.  Dispatched from import_hier_path right after eval_iface_param_field.

Repro test/iface_nested_param_field: SAT-verified 3-bit width from a nested `CFG.HSK.DLY` (=3).  Degu SoC CFG.HSK.DLY unresolved-access warnings 28 -> 12, total 86 -> 70.  Full regression: 0 true failures, 0 crashes.