### PR TITLE
uhdm: use recorded struct typespec for interface struct-field slices

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -8978,20 +8978,27 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 // its element struct type.
                 RTLIL::Wire* base_wire = nullptr;
                 size_t split = 0;
+                std::string base_prefix;
                 for (size_t k = names.size(); k >= 1; k--) {
                     std::string cand;
                     for (size_t j = 0; j < k; j++) { if (j) cand += "."; cand += names[j]; }
-                    if (name_map.count(cand)) { base_wire = name_map[cand]; split = k; break; }
+                    if (name_map.count(cand)) { base_wire = name_map[cand]; split = k; base_prefix = cand; break; }
                     if (k == 1) break;
                 }
                 if (base_wire) {
                     bool off_ok = true;
                     // Element struct typespec of base_wire (needed for the field
-                    // walk AND the array-element stride).  Prefer wire_map; the
-                    // flattened interface signal is often absent there, so fall
-                    // back to the last consumed segment's own typespec.
+                    // walk AND the array-element stride).  Authoritative source:
+                    // the struct/union typespec recorded for this interface signal
+                    // during modport flattening (module.cpp import_port) — the
+                    // generic fallbacks below can otherwise pick a stale/foreign
+                    // typespec (e.g. a union) for an interface struct signal like
+                    // `tcb_ifu.rsp`.
                     const typespec* ts = nullptr;
+                    if (!base_prefix.empty() && iface_signal_struct_ts_.count(base_prefix))
+                        ts = iface_signal_struct_ts_[base_prefix];
                     for (auto& kv : wire_map) {
+                        if (ts) break;
                         if (kv.second != base_wire) continue;
                         const ref_typespec* rts = nullptr;
                         if (auto ln = dynamic_cast<const UHDM::logic_net*>(kv.first))   rts = ln->Typespec();

--- a/test/iface_struct_field_slice_read/dut.sv
+++ b/test/iface_struct_field_slice_read/dut.sv
@@ -1,0 +1,32 @@
+// Nested struct-field SLICE read on an interface struct signal: `s.rsp.rdt[15:0]`.
+// The struct-field-slice handler must resolve `rsp` to its rsp_t struct typespec
+// (recorded during modport flattening) rather than re-deriving it, which can pick
+// a stale/foreign typespec and leave the read unresolved (X).  Mirrors the degu
+// SoC core reading the fetched instruction: dec32(tcb_ifu.rsp.rdt[32-1:0]).
+package p;
+  typedef struct {
+    logic [31:0] rdt;
+    logic [1:0]  sts;
+    logic        err;
+  } rsp_t;
+endpackage
+
+interface bus_if;
+  import p::*;
+  rsp_t rsp;
+  modport man (input rsp);
+endinterface
+
+module reader (bus_if.man s, output logic [15:0] lo, output logic [15:0] hi);
+  assign lo = s.rsp.rdt[15:0];
+  assign hi = s.rsp.rdt[31:16];
+endmodule
+
+module top (input logic [31:0] d, output logic [15:0] lo, output logic [15:0] hi);
+  import p::*;
+  bus_if bus ();
+  assign bus.rsp.rdt = d;
+  assign bus.rsp.sts = 2'b0;
+  assign bus.rsp.err = 1'b0;
+  reader u (.s(bus), .lo(lo), .hi(hi));
+endmodule


### PR DESCRIPTION
A nested struct-field slice on an interface struct signal (`s.rsp.rdt[hi:lo]`) re-derived the element struct typespec from generic fallbacks (wire_map / the path segment's own typespec / the interface Nets search).  For the degu SoC core reading the fetched instruction — `dec32(ISA, tcb_ifu.rsp.rdt[32-1:0])` — those fallbacks resolved `rsp` to a foreign `union_typespec` (no `rdt` member), so calculate_struct_member_offset failed and the read collapsed to X.

module.cpp import_port already records the correct struct/union typespec of each flattened interface signal in `iface_signal_struct_ts_` (keyed by the flattened name, e.g. `tcb_ifu.rsp`).  Consult that authoritative map first, keyed by the matched base-wire prefix, before the generic fallbacks.

Result: `tcb_ifu.rsp.rdt[31:0]` resolves to `\tcb_ifu.rsp[34:3]` (the rdt field); SoC unresolved struct-member accesses 15 -> 14, req_dly unaffected.

Test iface_struct_field_slice_read: reader slices `s.rsp.rdt[15:0]` / `[31:16]` of an interface struct signal (lo=d[15:0], hi=d[31:16]).