### PR TITLE
uhdm: resolve interface struct params through array-element connections

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -783,6 +783,59 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
                 break;
             }
     }
+    // The interface copy reached above may declare `pname` but carry no VALUE
+    // (its Param_assigns is empty and the Parameter has no Expr) — this happens
+    // for an interface-ARRAY-element connection (`.sub(tcb_lsd[0])`), whose port
+    // copy is a value-less stub.  The actual valued instance is the connected
+    // array element, reachable via the child port's bit_select High_conn.
+    auto param_value = [&](const interface_inst* ii) -> const expr* {
+        if (!ii) return nullptr;
+        if (ii->Param_assigns())
+            for (auto pa : *ii->Param_assigns())
+                if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
+                    if (std::string(l->VpiName()) == pname)
+                        if (auto r = dynamic_cast<const expr*>(pa->Rhs())) return r;
+        if (ii->Parameters())
+            for (auto p : *ii->Parameters())
+                if (std::string(p->VpiName()) == pname)
+                    if (auto par = dynamic_cast<const parameter*>(p)) {
+                        if (par->Expr()) return par->Expr();
+                        if (par->VpiParent() &&
+                            par->VpiParent()->UhdmType() == uhdmparam_assign)
+                            return dynamic_cast<const expr*>(
+                                any_cast<const param_assign*>(par->VpiParent())->Rhs());
+                    }
+        return nullptr;
+    };
+    if (child_inst->Ports())
+        for (auto p : *child_inst->Ports()) {
+            if (std::string(p->VpiName()) != base) continue;
+            const any* hc = p->High_conn();
+            bool is_arr_elem = hc && hc->UhdmType() == uhdmbit_select;
+            // For an interface-ARRAY-ELEMENT connection (`.sub(arr[0])`) the
+            // pe[0] modport-parent port copy is a value-less / DEFAULT stub, so
+            // the bit_select High_conn (the actual connected element) is
+            // authoritative and preferred even if the stub carries a (wrong)
+            // default.  For a plain connection only re-resolve when we found no
+            // value at all.
+            if (!is_arr_elem && param_value(iface)) break;
+            const any* a = nullptr;
+            if (is_arr_elem)
+                a = any_cast<const bit_select*>(hc)->Actual_group();
+            else if (hc && hc->UhdmType() == uhdmref_obj)
+                a = any_cast<const ref_obj*>(hc)->Actual_group();
+            const interface_inst* conn = nullptr;
+            if (a && a->UhdmType() == uhdminterface_inst)
+                conn = any_cast<const interface_inst*>(a);
+            else if (a && a->UhdmType() == uhdmmodport) {
+                auto mp2 = any_cast<const modport*>(a);
+                if (mp2 && mp2->VpiParent() &&
+                    mp2->VpiParent()->UhdmType() == uhdminterface_inst)
+                    conn = any_cast<const interface_inst*>(mp2->VpiParent());
+            }
+            if (param_value(conn)) iface = conn;
+            break;
+        }
     if (!iface) return "";
     const expr* val = nullptr;
     const typespec* cur_ts = nullptr;

--- a/test/iface_array_elem_cfg_param/dut.sv
+++ b/test/iface_array_elem_cfg_param/dut.sv
@@ -1,0 +1,26 @@
+// Interface-ARRAY-ELEMENT struct-parameter resolution: a child connects its
+// interface port to an array element `.s(arr[0])` (a bit_select).  Reading a
+// struct parameter field of that interface (`s.CFG.DAT`) must follow the
+// bit_select High_conn to the valued array-element instance; the port-copy
+// interface is a value-less / default stub, so without that the read resolves
+// to the wrong (default) value.  Mirrors the degu SoC converters connected to
+// tcb_lsd[i] / tcb_per[i].  The reader is parameterized so it is elaborated
+// per-instance (with instance context), matching those paramod converters.
+package p;
+  typedef struct packed { int unsigned DAT; } cfg_t;
+endpackage
+
+interface bus_if #(parameter p::cfg_t CFG = '{DAT: 8});
+  logic [CFG.DAT-1:0] data;
+  modport mp (input data);
+endinterface
+
+module reader #(parameter int ID = 0) (bus_if.mp s, output logic [31:0] w);
+  assign w = 32'(s.CFG.DAT) + ID;   // struct-param field of an array-element iface
+endmodule
+
+module top (output logic [31:0] w);
+  localparam p::cfg_t C16 = '{DAT: 16};
+  bus_if #(C16) arr [2-1:0] ();
+  reader #(.ID(0)) u (.s(arr[0]), .w(w));   // connect to array ELEMENT (bit_select)
+endmodule


### PR DESCRIPTION
eval_iface_param_field resolved an interface struct parameter (`s.CFG.BUS.DAT`) via the base ref_obj's modport-parent, which for an interface-ARRAY-ELEMENT connection (`.sub(tcb_lsd[0])` / `.sub(tcb_per[i])`) is a value-less / DEFAULT port-copy stub: its Param_assigns is empty and the CFG parameter carries no Expr, so the field read stayed unresolved (X) — or picked the interface's DEFAULT instead of the array element's override.

Follow the child port's `bit_select` High_conn to the actual connected array-element interface_inst (the authoritative valued instance) and use it when it carries a value for the parameter.  For an array-element connection this is preferred even over a wrong default on the stub; for a plain connection it only kicks in when no value was found at all.

Degu SoC: unresolved interface struct-member accesses 14 -> 10 (the LSU-path tcb_lsm converter reading `sub.CFG.BUS.*` via tcb_lsd[0] now resolves).

Test iface_array_elem_cfg_param: a parameterized reader connected to `arr[0]` reads `s.CFG.DAT` = 16 (the array-element override), not the default 8.