### PR TITLE
uhdm: resolve whole-struct interface parameter references

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6335,6 +6335,17 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 path_name.c_str(), iv);
             return RTLIL::SigSpec(RTLIL::Const(iv, 32));
         }
+        // WHOLE-STRUCT form (`man.CFG.BUS`, `man.CFG`): the field is a struct,
+        // not a scalar — build a constant SigSpec from its members.  Used by the
+        // interface parameter-consistency assertions
+        // (`assert (man.CFG.BUS == sub.CFG.BUS)` in the TCB register/demux).
+        RTLIL::SigSpec ss = eval_iface_param_struct(uhdm_hier, current_instance);
+        if (ss.size() > 0) {
+            if (mode_debug)
+                log("    hier_path: %s -> %d-bit interface struct parameter\n",
+                    path_name.c_str(), ss.size());
+            return ss;
+        }
     }
     // Bare `CFG.HSK.DLY` — an interface's own struct parameter substituted into a
     // signal width without a modport prefix (tcb_lite_if `[CFG.HSK.DLY-1:0]`).

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -668,10 +668,13 @@ static int struct_member_index(const typespec* ts, const std::string& field,
 // in the elaborated form, POSITIONAL constants in struct-declaration order) ->
 // the named field chain (mapped to operand indices via the struct typespec).
 // Returns the value as a decimal string, or "" on failure.
-std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
-                                          const module_inst* child_inst) {
+bool UhdmImporter::resolve_iface_param(const hier_path* hp,
+                                          const module_inst* child_inst,
+                                          const interface_inst*& iface_out,
+                                          const expr*& val_out,
+                                          const typespec*& ts_out) {
     if (!hp || !hp->Path_elems() || hp->Path_elems()->size() < 2 || !child_inst)
-        return "";
+        return false;
     auto& pe = *hp->Path_elems();
     std::string base  = std::string(pe[0]->VpiName());   // "sub"
     std::string pname = std::string(pe[1]->VpiName());   // "CFG" (or a scalar
@@ -877,7 +880,7 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
             if (param_value(conn)) iface = conn;
             break;
         }
-    if (!iface) return "";
+    if (!iface) return false;
     const expr* val = nullptr;
     const typespec* cur_ts = nullptr;
     // Explicit override (elaborated value) in Param_assigns.
@@ -930,12 +933,25 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
         val = next;
         cur_ts = next_ts;
     }
+    iface_out = iface;
+    val_out = val;
+    ts_out = cur_ts;
+    return val != nullptr;
+}
+
+// Scalar int value of an interface struct-parameter field ("" on failure).
+std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
+                                          const module_inst* child_inst) {
+    const interface_inst* iface = nullptr;
+    const expr* val = nullptr;
+    const typespec* cur_ts = nullptr;
+    if (!resolve_iface_param(hp, child_inst, iface, val, cur_ts)) return "";
     // A COMPUTED scalar interface localparam (`sub.OFF` where
     // OFF = $clog2(CFG.BUS.DAT/8)) leaves `val` as a non-constant expression;
     // Surelog stores neither its value nor BYT's in the elaborated model, so
     // ExprEval can't fold it.  Recursively evaluate the localparam chain in the
     // interface scope (degu SoC r5p_soc_memory `sub.CFG_BUS_OFF`).
-    if (val && val->UhdmType() != uhdmconstant && pe.size() == 2) {
+    if (val && val->UhdmType() != uhdmconstant && hp->Path_elems()->size() == 2) {
         long out;
         if (eval_iface_local_const(iface, val, out))
             return std::to_string(out);
@@ -943,6 +959,55 @@ std::string UhdmImporter::eval_iface_param_field(const hier_path* hp,
     if (auto c = dynamic_cast<const constant*>(val))
         return std::to_string(parse_vpi_value_to_int(std::string(c->VpiValue())));
     return "";
+}
+
+// Recursively flatten a struct-parameter value expr (an assignment pattern) to
+// a constant SigSpec using its typespec.  Packed layout: the first struct
+// member is the MSB.  Empty SigSpec if any member cannot be resolved.
+RTLIL::SigSpec UhdmImporter::struct_param_to_sig(const expr* val,
+                                                 const typespec* ts) {
+    if (!val || !ts) return RTLIL::SigSpec();
+    if (ts->UhdmType() == uhdmstruct_typespec) {
+        auto st = any_cast<const struct_typespec*>(ts);
+        if (!st->Members()) return RTLIL::SigSpec();
+        RTLIL::SigSpec sig;  // accumulated (earlier/higher members) at the MSB
+        for (auto m : *st->Members()) {
+            std::string mname = std::string(m->VpiName());
+            const typespec* mts = (m->Typespec() && m->Typespec()->Actual_typespec())
+                                      ? m->Typespec()->Actual_typespec() : nullptr;
+            const expr* mval = find_tagged_field(val, mname);
+            if (!mval && val->UhdmType() == uhdmoperation) {
+                int idx = struct_member_index(ts, mname, nullptr);
+                auto op = any_cast<const operation*>(val);
+                if (idx >= 0 && op->Operands() && idx < (int)op->Operands()->size())
+                    mval = dynamic_cast<const expr*>((*op->Operands())[idx]);
+            }
+            RTLIL::SigSpec msig = struct_param_to_sig(mval, mts);
+            if (msig.empty()) return RTLIL::SigSpec();
+            sig = {sig, msig};
+        }
+        return sig;
+    }
+    // Scalar member: the constant value sized to the member width.
+    int w = get_width_from_typespec(const_cast<typespec*>(ts), current_instance);
+    if (w <= 0) w = 32;
+    if (auto c = dynamic_cast<const constant*>(val))
+        return RTLIL::SigSpec(
+            RTLIL::Const(parse_vpi_value_to_int(std::string(c->VpiValue())), w));
+    return RTLIL::SigSpec();
+}
+
+// Whole-struct interface parameter field (`man.CFG.BUS`, `man.CFG`): a constant
+// SigSpec built from the struct's field values.  Used by the interface
+// parameter-consistency assertions (`assert (man.CFG.BUS == sub.CFG.BUS)`).
+RTLIL::SigSpec UhdmImporter::eval_iface_param_struct(const hier_path* hp,
+                                          const module_inst* child_inst) {
+    const interface_inst* iface = nullptr;
+    const expr* val = nullptr;
+    const typespec* cur_ts = nullptr;
+    if (!resolve_iface_param(hp, child_inst, iface, val, cur_ts)) return RTLIL::SigSpec();
+    if (!cur_ts || cur_ts->UhdmType() != uhdmstruct_typespec) return RTLIL::SigSpec();
+    return struct_param_to_sig(val, cur_ts);
 }
 
 // BARE `CFG.HSK.DLY` — see header.  Surelog substitutes an interface's own struct

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -547,6 +547,23 @@ struct UhdmImporter {
     // child instance's parameter value; "" on failure.  See uhdm2rtlil.cpp.
     std::string eval_iface_param_field(const UHDM::hier_path* hp,
                                        const UHDM::module_inst* child_inst);
+    // Shared core of the above: resolve the interface + walk the CFG field path,
+    // returning the resolved interface, the field value expr and its typespec.
+    bool resolve_iface_param(const UHDM::hier_path* hp,
+                             const UHDM::module_inst* child_inst,
+                             const UHDM::interface_inst*& iface_out,
+                             const UHDM::expr*& val_out,
+                             const UHDM::typespec*& ts_out);
+    // WHOLE-STRUCT interface parameter field (`man.CFG.BUS`, `man.CFG`): build a
+    // constant SigSpec from the struct's field values (used by the interface
+    // parameter-consistency assertions).  Empty SigSpec if not a resolvable
+    // struct.
+    RTLIL::SigSpec eval_iface_param_struct(const UHDM::hier_path* hp,
+                                           const UHDM::module_inst* child_inst);
+    // Recursively flatten a struct-parameter value expr (an assignment pattern)
+    // to a constant SigSpec using its typespec (first member at MSB).
+    RTLIL::SigSpec struct_param_to_sig(const UHDM::expr* val,
+                                       const UHDM::typespec* ts);
     // BARE form `CFG.HSK.DLY` — an interface's own struct parameter substituted
     // into a signal width WITHOUT a modport prefix (pe[0] IS the parameter, not a
     // port).  Finds the interface via any of child_inst's interface ports; ""

--- a/test/iface_wholestruct_param/dut.sv
+++ b/test/iface_wholestruct_param/dut.sv
@@ -1,0 +1,23 @@
+// Reading a WHOLE interface struct parameter (`s.CFG`) as a value.  Packed
+// struct layout: first member at MSB.  The frontend flattens the struct
+// assignment-pattern parameter into a constant SigSpec.  Mirrors the degu SoC
+// TCB register/demux parameter-consistency assertions `man.CFG == sub.CFG`.
+package p;
+  typedef struct packed { logic [7:0] A; logic [7:0] B; } bus_t;   // A msb, B lsb
+  typedef struct packed { logic [3:0] X; bus_t BUS; } cfg_t;       // X msb, BUS lsb
+endpackage
+
+interface bus_if #(parameter p::cfg_t CFG = '{X: 4'h1, BUS: '{A: 8'h02, B: 8'h03}});
+  logic dummy;
+  modport mp (input dummy);
+endinterface
+
+module reader #(parameter int ID = 0) (bus_if.mp s, output logic [19:0] w);
+  assign w = s.CFG;   // {X(4), A(8), B(8)} = 20 bits
+endmodule
+
+module top (output logic [19:0] w);
+  localparam p::cfg_t C = '{X: 4'h5, BUS: '{A: 8'h0A, B: 8'h14}};   // 5, 10, 20
+  bus_if #(C) bus ();
+  reader #(.ID(0)) u (.s(bus), .w(w));   // expect w = 0x5_0A_14 = 0x50A14
+endmodule


### PR DESCRIPTION
An interface parameter-consistency assertion compares whole CFG structs (`assert (man.CFG.BUS == sub.CFG.BUS)` / `man[i].CFG == sub.CFG` in the TCB register/demux).  eval_iface_param_field only ever returned a scalar integer, so a whole-struct field (`man.CFG.BUS`, wider than 64 bits) could not be resolved and the read collapsed to X, emitting a spurious "could not resolve".

Refactor the interface + field-path resolution out of eval_iface_param_field into resolve_iface_param (returns the interface, the field value expr and its typespec).  Add struct_param_to_sig, which recursively flattens a struct-typed value (an assignment pattern) into a constant SigSpec using its typespec (packed: first member at MSB), and eval_iface_param_struct which uses it. import_hier_path now falls back to the whole-struct builder when the scalar form doesn't apply.

Degu SoC unresolved interface struct-member accesses 6 -> 3 (the register/demux parameter assertions resolve).  The residual 3 are cosmetic (bare CFG.HSK.DLY def-pass, an untaken generate-branch error device, a redundant inner-device param re-eval where the interface is out of scope).

Test iface_wholestruct_param: reading a whole interface struct parameter `s.CFG` yields the correctly packed constant 20'h50A14 (X=5, A=0x0A, B=0x14).