### PR TITLE
uhdm: resolve genvar/parameter base in part-select (i[hi:lo] in gener…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,10 +370,20 @@ the first wire with **no driving cell** — that is where the missing logic is.
 ### 3. Simulate to see WHEN / WHICH register goes X (yosys `sim`)
 
 ```
-read_uhdm ...; hierarchy -top r5p_degu_soc_top; proc; opt
+read_uhdm ...; hierarchy -top r5p_degu_soc_top
+proc; flatten; memory_collect
+delete t:$check t:$print t:$assert; opt_clean
 sim -clock clk -reset rst -rstlen 8 -n 400 -vcd soc_sim.vcd -w soc_sim
 ```
 
+- **Do NOT use `memory -nomap` / `opt_mem` when the design has an initialized
+  ROM** (imem `$readmemh`): `opt_mem` trims a read-only memory to its "used"
+  width (imem 32→27 bits) and MANGLES the `$meminit` (0x800200B7 → 0x400102D),
+  so the fetched instruction reads as garbage/X. Use plain `memory_collect`,
+  which keeps `WIDTH 32` and the correct `INIT`. Verify: the imem `$mem_v2`
+  must show `WIDTH 32` and `INIT` low-32 = `0x800200B7`.
+- **`flatten` is required for `sim` to apply the memory init** to a combinational
+  `$memrd` — without it the read returns 0/X even with a correct `$meminit`.
 - Open `soc_sim.vcd` in gtkwave; sort by first-X transition time. The earliest
   register that latches X (whose D input traces back to an undriven net) is the
   root, not the many downstream signals it poisons.

--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5334,7 +5334,45 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
             base = input_mapping->at(base_signal_name);
             log("      PartSelect: base '%s' from input_mapping (width=%d)\n",
                 base_signal_name.c_str(), base.size());
-        } else {
+        } else if (uhdm_part->Actual_group() &&
+                   uhdm_part->Actual_group()->VpiType() == vpiParameter) {
+            // A part-select whose BASE is a parameter — most importantly a
+            // generate-scope genvar, which the elaborated model represents as a
+            // per-scope `parameter` (e.g. genblk1[0].i).  part_select extends
+            // ref_obj, so it carries Actual_group() -> that parameter, exactly
+            // like the bare ref import_ref_obj resolves.  Without this the base
+            // "i" finds no `\i` wire and collapses to 0, so `sig[expr | i[1:0]]`
+            // silently drops the genvar term.  This is the rp32
+            // tcb_lite_lib_logsize2byteena read-data byte-remux
+            // (man_rdt[(~prefix_or(i[OFF-1:0]) & rsp_off) | i[OFF-1:0]]): every
+            // byte read man_rdt[0] instead of man_rdt[i], so the fetched
+            // instruction never reached the CPU.
+            const parameter* p = any_cast<const parameter*>(uhdm_part->Actual_group());
+            // Prefer the module's ELABORATED parameter value (command-line /
+            // instance override) over the UHDM parameter's raw VpiValue, which
+            // for a parameterized module is the unelaborated default — same rule
+            // as import_ref_obj.  Only fall back to VpiValue for a gen-scope
+            // genvar (not a module parameter, so absent from the map).
+            RTLIL::IdString p_id = RTLIL::escape_id(std::string(p->VpiName()));
+            if (module->parameter_default_values.count(p_id)) {
+                base = RTLIL::SigSpec(module->parameter_default_values.at(p_id));
+                log("      PartSelect: base '%s' from module parameter (width=%d)\n",
+                    base_signal_name.c_str(), base.size());
+            } else {
+                std::string vs = std::string(p->VpiValue());
+                int bw = 32;
+                if (p->Typespec() && p->Typespec()->Actual_typespec()) {
+                    int tw = get_width_from_typespec(p->Typespec()->Actual_typespec(),
+                                                     current_instance);
+                    if (tw > 0) bw = tw;
+                }
+                if (!vs.empty())
+                    base = RTLIL::SigSpec(RTLIL::Const(parse_vpi_value_to_int(vs), bw));
+                log("      PartSelect: base '%s' from genvar/parameter = %s (width=%d)\n",
+                    base_signal_name.c_str(), vs.c_str(), bw);
+            }
+        }
+        if (base.empty()) {
         RTLIL::Wire* wire = find_wire_in_scope(base_signal_name, "part select");
         if (wire) {
             base = RTLIL::SigSpec(wire);

--- a/test/read_remux/dut.sv
+++ b/test/read_remux/dut.sv
@@ -1,0 +1,22 @@
+// Minimal repro of tcb_lite_lib_logsize2byteena read-data byte-remux.
+// With rsp_off==0 the remux must be identity: sub_rdt === man_rdt.
+module read_remux #(
+    parameter int unsigned BYT = 4,
+    parameter int unsigned OFF = 2
+)(
+    input  logic [BYT-1:0][8-1:0] man_rdt,
+    input  logic [OFF-1:0]        rsp_off,
+    output logic [BYT-1:0][8-1:0] sub_rdt
+);
+    // prefix OR (same as the TCB lib helper)
+    function automatic [OFF-1:0] prefix_or (input logic [OFF-1:0] val);
+        prefix_or[OFF-1] = val[OFF-1];
+        for (int unsigned i=OFF-1; i>0; i--) begin
+            prefix_or[i-1] = prefix_or[i] | val[i-1];
+        end
+    endfunction: prefix_or
+
+    for (genvar i=0; i<BYT; i++) begin
+        assign sub_rdt[i] = man_rdt[(~prefix_or(i[OFF-1:0]) & rsp_off) | i[OFF-1:0]];
+    end
+endmodule


### PR DESCRIPTION
…ate for)

A part-select whose base is a generate-scope genvar — e.g. `i[OFF-1:0]` inside `for (genvar i...)` — collapsed to 0. The elaborated model represents the genvar as a per-scope `parameter` (genblk1[0].i); a bare ref `i` resolves via import_ref_obj -> Actual_group() -> parameter, but import_part_select never read Actual_group() (even though part_select extends ref_obj), so the base found no `\i` wire and every `sig[expr | i[hi:lo]]` silently dropped the genvar term.

This was the rp32 SoC instruction-fetch blocker: the TCB tcb_lite_lib_logsize2byteena read-data byte-remux
`man_rdt[(~prefix_or(i[OFF-1:0]) & rsp_off) | i[OFF-1:0]]` read man_rdt[0] for every byte instead of man_rdt[i], so the fetched instruction never byte-aligned back to the CPU's rsp.rdt.

Fix: add an Actual_group()->vpiParameter branch to import_part_select, preferring module->parameter_default_values (the elaborated/override value) and falling back to the UHDM parameter's VpiValue only for gen-scope genvars — same precedence as import_ref_obj, so parameterized-module `PARAM[hi:lo]` overrides stay correct.

Repro: test/read_remux (identity check: rsp_off==0 => sub_rdt===man_rdt). Also documents the SoC-sim opt_mem/flatten meminit trap in CLAUDE.md.