### PR TITLE
uhdm: register interface struct-field read (sub.rsp.rdt <= mem[adr]),…

### DIFF
--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -578,10 +578,45 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                                 RTLIL::escape_id("is_interface"));
                         bool full_is_wire = !full_name.empty() &&
                             module->wire(RTLIL::escape_id(full_name)) != nullptr;
-                        if (full_is_wire && !base_is_wire)
+                        if (full_is_wire && !base_is_wire) {
                             sig.name = full_name;
-                        else
+                        } else if (base_is_wire) {
                             sig.name = base;
+                        } else {
+                            // Neither the full path (`sub.rsp.rdt`) nor the first
+                            // component (`sub`, an interface-INSTANCE placeholder)
+                            // is a real wire: this is a struct-field write on a
+                            // flattened interface signal, whose wire is an interior
+                            // prefix (`sub.rsp`) with the field a slice of it.  Find
+                            // the longest dotted prefix that IS a real (non-
+                            // interface) wire and mark it a part-select, so the
+                            // always_ff temp-wire + sync-rule setup registers
+                            // `$0\sub.rsp`.  Without this the register is tracked
+                            // under `sub` (no such wire): no `$0\` temp, an EMPTY
+                            // sync rule, and the registered read
+                            // `sub.rsp.rdt <= mem[adr]` collapses to a combinational
+                            // read — breaking DLY=1 pipelines (rp32 SoC
+                            // r5p_soc_memory: the fetched instruction arrived one
+                            // cycle early and never byte-aligned back to the CPU).
+                            std::string chosen, probe = full_name;
+                            while (!probe.empty()) {
+                                RTLIL::Wire* w = module->wire(RTLIL::escape_id(probe));
+                                if (w && !w->attributes.count(
+                                             RTLIL::escape_id("is_interface"))) {
+                                    chosen = probe; break;
+                                }
+                                size_t d = probe.rfind('.');
+                                if (d == std::string::npos) break;
+                                probe = probe.substr(0, d);
+                            }
+                            if (!chosen.empty()) {
+                                if (chosen.size() < full_name.size())
+                                    sig.is_part_select = true;
+                                sig.name = chosen;
+                            } else {
+                                sig.name = base;
+                            }
+                        }
 
                         signals.push_back(sig);
                         log("extract_assigned_signals: Found assignment to hier_path of '%s' (using '%s')\n",

--- a/test/mem_read_reg/dut.sv
+++ b/test/mem_read_reg/dut.sv
@@ -1,0 +1,49 @@
+// Mirror of r5p_soc_memory: registered read into a STRUCT-FIELD of an interface
+// signal (sub.rsp.rdt <= mem[adr]) + byte-enable memory writes. rsp is a packed
+// struct like TCB. Read must stay REGISTERED (1-cycle latency).
+package p;
+    typedef struct packed {
+        logic [31:0] rdt;
+        logic        sts;
+        logic        err;
+        logic        pad;
+    } rsp_t;
+    typedef struct packed {
+        logic        ren;
+        logic        wen;
+        logic [3:0]  byt;
+        logic [3:0]  adr;
+        logic [31:0] wdt;
+    } req_t;
+endpackage
+
+interface mem_if;
+    import p::*;
+    logic clk, trn;
+    req_t req;
+    rsp_t rsp;
+    modport sub (input clk, input trn, input req, output rsp);
+endinterface
+
+module mem_core (mem_if.sub sub);
+    import p::*;
+    logic [31:0] mem [0:15];
+    always_ff @(posedge sub.clk) begin
+        if (sub.trn) begin
+            if (sub.req.ren) sub.rsp.rdt <= mem[sub.req.adr];
+            if (sub.req.byt[0]) mem[sub.req.adr][ 7: 0] <= sub.req.wdt[ 7: 0];
+            if (sub.req.byt[1]) mem[sub.req.adr][15: 8] <= sub.req.wdt[15: 8];
+            if (sub.req.byt[2]) mem[sub.req.adr][23:16] <= sub.req.wdt[23:16];
+            if (sub.req.byt[3]) mem[sub.req.adr][31:24] <= sub.req.wdt[31:24];
+        end
+    end
+endmodule
+
+module mem_read_reg (input logic clk, trn, input logic [41:0] reqbits, output logic [34:0] rspbits);
+    import p::*;
+    mem_if intf();
+    assign intf.clk = clk; assign intf.trn = trn;
+    assign intf.req = reqbits;
+    assign rspbits = intf.rsp;
+    mem_core u (.sub(intf));
+endmodule


### PR DESCRIPTION
… don't drop it

An `always_ff @(posedge clk) ... sub.rsp.rdt <= mem[adr]` writing a struct field of a FLATTENED interface signal produced a COMBINATIONAL read — a direct `assign \sub.rsp[34:3] ...` in the switch plus an EMPTY sync rule (`update { } { }`) — instead of a registered one. The response then appeared in the same cycle as the request (one cycle early), so a DLY=1 pipeline never byte-aligned it.

Root cause: extract_assigned_signals' vpiHierPath LHS case took the base of `sub.rsp.rdt` as the first dotted component `sub` — the interface INSTANCE, which only has a 1-bit is_interface placeholder wire, not real storage. The flattened signal wire is the interior prefix `sub.rsp` (35-bit), with `.rdt` a slice of it. Recording the register under `sub` (no such wire) left it untracked: no `$0\` temp and an empty sync rule, so proc lowered it to a mux, not a $dff. The longest-real-wire-prefix walk already existed but only ran when VpiName carried a trailing `[...]`; a plain struct field has none.

Fix: when neither the full path nor the first component is a usable wire, walk dotted prefixes longest-first to the first real (non-interface) wire, use it as sig.name and mark it a part-select when shorter than the full path. Existing branches (full_is_wire && !base_is_wire -> full; base_is_wire -> base) are preserved, so struct-wire writes (internal_bus.field) are unchanged.

This was the rp32 SoC instruction-fetch blocker (r5p_soc_memory rsp.rdt): after the fix the fetched instruction reaches cpu.tcb_ifu.rsp.rdt registered at the correct cycle and the decoder computes the LUI result. Repro: test/mem_read_reg (interface + registered struct-field read + byte-enable writes) — post-fix netlist has `sync posedge: update \sub.rsp $0\sub.rsp` and proc makes a $dff.