### PR TITLE
uhdm: keep explicit default clause of a unique/priority case (don't X…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10246,6 +10246,27 @@ void UhdmImporter::emit_full_case_default(const case_stmt* uhdm_case, RTLIL::Swi
                 collect_blocking_assigned_names(case_item->Stmt(), blocking_names);
     }
 
+    // Signals that an EXPLICIT `default:` clause already assigns must NOT be
+    // X-defaulted — doing so would append `sig = 'x` after the user's value and
+    // override it (RTLIL applies later actions last).  The full_case X-default
+    // is only for the IMPLICIT default of a `unique`/`priority` case with NO
+    // default clause.  A case_item with no match expressions IS the default
+    // clause.  Without this, `unique case (opc) ... default: ifu_pcn = ifu_pcs`
+    // (rp32 r5p_degu next-PC) drove ifu_pcn to X for every unlisted opcode
+    // (e.g. LUI) — the PC collapsed and the CPU never advanced.
+    std::set<std::string> default_assigned;
+    if (auto case_items = uhdm_case->Case_items()) {
+        for (auto case_item : *case_items) {
+            if (case_item->VpiExprs() && !case_item->VpiExprs()->empty())
+                continue;  // a matched item, not the default
+            if (auto s = case_item->Stmt()) {
+                std::vector<AssignedSignal> ds;
+                extract_assigned_signals(s, ds);
+                for (auto& d : ds) default_assigned.insert(d.name);
+            }
+        }
+    }
+
     std::vector<AssignedSignal> body_signals;
     if (auto case_items = uhdm_case->Case_items()) {
         for (auto case_item : *case_items)
@@ -10255,6 +10276,8 @@ void UhdmImporter::emit_full_case_default(const case_stmt* uhdm_case, RTLIL::Swi
     std::set<std::string> seen_keys;
     for (const auto& sig : body_signals) {
         if (!sig.lhs_expr) continue;
+        // Keep the user's explicit default value for this signal.
+        if (default_assigned.count(sig.name)) continue;
         // FF (non-blocking) signals hold; only blocking temps get X'd.
         if (in_always_ff_context && !blocking_names.count(sig.name)) continue;
         RTLIL::SigSpec lhs = import_expression(sig.lhs_expr);

--- a/test/unique_case_default/dut.sv
+++ b/test/unique_case_default/dut.sv
@@ -1,0 +1,14 @@
+// A `unique case` with an EXPLICIT default clause: unlisted selects must take
+// the default expression (c), NOT x. (rp32 r5p_degu ifu_pcn next-PC case.)
+module unique_case_default (
+    input  logic [1:0] sel,
+    input  logic [7:0] a, b, c,
+    output logic [7:0] y
+);
+    always_comb
+        unique case (sel)
+            2'b00:   y = a;
+            2'b01:   y = b;
+            default: y = c;
+        endcase
+endmodule


### PR DESCRIPTION
…-override it)

`unique case (sel) 0:..; 1:..; default: y = c; endcase` drove `y = 'x` for every unlisted select instead of `c`. Plain `case` was unaffected — only `unique` and `priority` cases.

Root cause: for a unique/priority case the frontend sets `full_case` and calls emit_full_case_default to assign `sig = 'x` (the don't-care value for the IMPLICIT default of a full_case with no default clause) to the default CaseRule for every signal assigned in the case. When an EXPLICIT `default:` clause exists, its body was imported into that same default CaseRule (empty compare), and emit_full_case_default then APPENDED `sig = 'x` after the user's `sig = c`. RTLIL applies later actions last, so X won.

Fix: in emit_full_case_default, first collect the signals the explicit default clause assigns (the case_item whose VpiExprs() is empty is the default; run extract_assigned_signals on its Stmt()), then skip those in the X-default loop. Signals a partial default doesn't cover still get the full_case X. Shared by the comb and always_ff sync call sites.

This was the rp32 SoC next-PC blocker: r5p_degu
`unique case (idu_dec.opc) ... default: ifu_pcn = ifu_pcs` drove ifu_pcn to X for LUI and every other non-JAL/JALR/BRANCH opcode, so the program counter collapsed and the CPU never advanced past the first instruction. After the fix the PC advances through the whole program. Repro: test/unique_case_default (eval: an unlisted select yields the default value, not x).