### PR TITLE
uhdm: size struct-field assignment-pattern RHS to the field width ins…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -527,7 +527,45 @@ void UhdmImporter::process_stmt_to_case(const any* stmt, RTLIL::CaseRule* case_r
                 }
             }
             RTLIL::SigSpec lhs_sig;
-            RTLIL::SigSpec rhs_sig = import_expression(any_cast<const expr*>(assign->Rhs()), &input_mapping);
+            RTLIL::SigSpec rhs_sig;
+            // Size the RHS to the LHS *field* width for a struct-field write
+            // (`decode.gpr = '{...}`).  Otherwise the surrounding function-call
+            // context (the WHOLE return struct — e.g. rp32's 306-bit dec_t)
+            // leaks in as the target width, and an assignment-pattern RHS
+            // (`'{'1,'0,'0}`) sizes each unsized fill literal to
+            // context/field_count bits instead of one field, so every field
+            // collapses to the same value (dec.gpr became 000/111 not 100/011,
+            // breaking the GPR write-enable so no register was ever written).
+            {
+                int fw = 0;
+                if (assign->Lhs()->UhdmType() == uhdmhier_path) {
+                    auto hp = any_cast<const hier_path*>(assign->Lhs());
+                    auto pe = hp ? hp->Path_elems() : nullptr;
+                    if (pe && pe->size() == 2) {
+                        std::string bn = std::string((*pe)[0]->VpiName());
+                        std::string fn = std::string((*pe)[1]->VpiName());
+                        const UHDM::struct_typespec* st = nullptr;
+                        if (bn == func_name)
+                            st = current_func_return_struct_ts;
+                        if (!st)
+                            if (auto bref = dynamic_cast<const UHDM::ref_obj*>((*pe)[0]))
+                                if (auto bts = bref->Typespec())
+                                    if (auto a = bts->Actual_typespec())
+                                        if (a->UhdmType() == uhdmstruct_typespec)
+                                            st = any_cast<const UHDM::struct_typespec*>(a);
+                        if (st && st->Members())
+                            for (auto m : *st->Members())
+                                if (std::string(m->VpiName()) == fn)
+                                    if (auto mts = m->Typespec())
+                                        if (auto a = mts->Actual_typespec())
+                                            fw = get_width_from_typespec(a, current_instance);
+                    }
+                }
+                int saved_ctx = expression_context_width;
+                if (fw > 0) expression_context_width = fw;
+                rhs_sig = import_expression(any_cast<const expr*>(assign->Rhs()), &input_mapping);
+                expression_context_width = saved_ctx;
+            }
 
             // For accumulative assignments in loops, we need special handling
             // The issue is that result = result + expr creates conflicting assignments

--- a/test/struct_pat_fill/dut.sv
+++ b/test/struct_pat_fill/dut.sv
@@ -1,0 +1,26 @@
+// Struct assignment pattern with fill literals INSIDE A FUNCTION returning a
+// struct. `dec.gpr = '{'1,'0,'0}` must assign each field (100), not replicate a
+// fill across all fields. The return struct is deliberately wide AND its width
+// is a multiple of the field count (idx[5:0]+gpr[2:0] = 9, 9%3==0) to exercise
+// the same path as rp32's 306-bit dec_t (306%3==0). (rp32 dec32 gpr enable.)
+module struct_pat_fill (
+    input  logic [1:0] sel,
+    output logic [2:0] out
+);
+    typedef struct packed { logic rd; logic rs1; logic rs2; } ena_t;
+    typedef struct packed { logic [5:0] idx; ena_t gpr; } dec_t;
+
+    function automatic dec_t decode (input logic [1:0] s);
+        decode.idx = 6'd0;
+        unique case (s)
+            2'd0:    decode.gpr = '{'1, '0, '0};   // 100
+            2'd1:    decode.gpr = '{'0, '1, '1};   // 011
+            2'd2:    decode.gpr = '{'1, '1, '0};   // 110
+            default: decode.gpr = '{'0, '0, '0};   // 000
+        endcase
+    endfunction
+
+    dec_t d;
+    assign d = decode(sel);
+    assign out = d.gpr;
+endmodule


### PR DESCRIPTION
…ide functions

A struct-field write of an assignment pattern inside a struct-returning function — `function dec_t decode(...); ... decode.gpr = '{'1,'0,'0}` where gpr is a 3x1-bit packed struct — produced 000 instead of 100: every field collapsed to the last fill literal. Module-level `e = '{'1,'0,'0}` was correct; only the function path broke.

Root cause: the surrounding call context (`d = decode(sel)` sets expression_context_width to d's width = the WHOLE return struct) leaked into every inner statement. process_stmt_to_case imported the pattern RHS with that full width (306 for rp32's dec_t). The vpiAssignmentPatternOp handler sizes each element to context/element_count = 306/3 = 102, so each unsized fill literal ('0/'1) expanded to 102 bits; the 306-bit concat was then truncated back to the 3-bit field, keeping only the last operand.

Fix: in process_stmt_to_case's assignment case, when the LHS is a 2-element hier_path struct field, look up the field width from the base struct typespec (current_func_return_struct_ts for `func.field`, else the base ref's typespec) and import the RHS with expression_context_width set to that field width (restored afterwards). Module-level and non-struct assignments are unaffected.

This was the rp32 SoC GPR-write blocker: dec32's GPR read/write-enable field (`dec.gpr = '{...}`) decoded to all-0/all-1, so the writeback enable was wrong and no register was ever written. After the fix the LUI destinations write correctly (x1=0x80020000, x3=0xDEADB000). Repro: test/struct_pat_fill (function returns a struct whose width is a multiple of the field count, like the SoC; eval sel 0/1/2 => 100/011/110).