### PR TITLE
uhdm: honor unpacked-array declaration initializer (mem [..] = '{defa…

### DIFF
--- a/src/frontends/uhdm/memory_analysis.cpp
+++ b/src/frontends/uhdm/memory_analysis.cpp
@@ -717,6 +717,60 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
     // Add memory to module
     module->memories[mem_id] = memory;
 
+    // Declaration initializer `mem [..] = '{default: '0}` — emit a $meminit_v2
+    // so every word starts at the default value.  Without it the memory is X at
+    // reset: rp32's r5p_gpr register file relies on this to keep x0 (never
+    // written) reading 0, else the whole datapath goes X.  Handles the common
+    // all-words-equal `'{default: V}` form (a per-word list would need
+    // per-element evaluation).
+    if (auto init_expr = uhdm_array->Expr()) {
+        if (init_expr->UhdmType() == uhdmoperation) {
+            auto op = any_cast<const UHDM::operation*>(init_expr);
+            if (op && op->VpiOpType() == vpiAssignmentPatternOp && op->Operands()) {
+                const UHDM::expr* defpat = nullptr;
+                for (auto operand : *op->Operands()) {
+                    if (operand->UhdmType() != uhdmtagged_pattern) continue;
+                    auto tp = any_cast<const UHDM::tagged_pattern*>(operand);
+                    if (!tp || !tp->Typespec()) continue;
+                    std::string tn = std::string(tp->Typespec()->VpiName());
+                    if (auto a = tp->Typespec()->Actual_typespec())
+                        if (tn.empty()) tn = std::string(a->VpiName());
+                    if (tn == "default" && tp->Pattern()) {
+                        defpat = any_cast<const UHDM::expr*>(tp->Pattern());
+                        break;
+                    }
+                }
+                if (defpat) {
+                    int saved_ctx = expression_context_width;
+                    expression_context_width = width;
+                    RTLIL::SigSpec dv = import_expression(defpat);
+                    expression_context_width = saved_ctx;
+                    if (dv.is_fully_const() && width > 0 && size > 0) {
+                        std::vector<RTLIL::State> word = dv.as_const().to_bits();
+                        word.resize(width, RTLIL::State::S0);
+                        std::vector<RTLIL::State> data;
+                        data.reserve((size_t)size * width);
+                        for (int i = 0; i < size; i++)
+                            data.insert(data.end(), word.begin(), word.end());
+                        RTLIL::Cell* cell = module->addCell(
+                            stringf("$meminit$\\%s$0", array_name.c_str()),
+                            ID($meminit_v2));
+                        cell->setParam(ID::MEMID, RTLIL::Const(mem_id.str()));
+                        cell->setParam(ID::ABITS, RTLIL::Const(32));
+                        cell->setParam(ID::WIDTH, RTLIL::Const(width));
+                        cell->setParam(ID::WORDS, RTLIL::Const(size));
+                        cell->setParam(ID::PRIORITY, RTLIL::Const(0));
+                        cell->setPort(ID::ADDR, RTLIL::Const(start_offset, 32));
+                        cell->setPort(ID::DATA, RTLIL::Const(data));
+                        cell->setPort(ID::EN, RTLIL::Const(RTLIL::State::S1, width));
+                        log("    Added $meminit for %s: %d words = default\n",
+                            array_name.c_str(), size);
+                    }
+                }
+            }
+        }
+    }
+
     if (mode_debug)
         log("    Created RTLIL memory %s: width=%d, size=%d, start_offset=%d\n",
             array_name.c_str(), width, size, start_offset);

--- a/test/array_default_init/dut.sv
+++ b/test/array_default_init/dut.sv
@@ -1,0 +1,17 @@
+// An unpacked-array (memory) declaration initializer `= '{default: '0}` must
+// initialize every word to 0 (rp32 r5p_gpr register file — else x0 reads X and
+// the whole datapath goes X). Reading an un-written word must give 0, not X.
+module array_default_init #(
+    parameter int unsigned AW = 5,
+    parameter int unsigned DW = 32
+)(
+    input  logic          clk,
+    input  logic          we,
+    input  logic [AW-1:0] wa, ra,
+    input  logic [DW-1:0] wd,
+    output logic [DW-1:0] rd
+);
+    logic [DW-1:0] mem [0:(1<<AW)-1] = '{default: '0};
+    always_ff @(posedge clk) if (we) mem[wa] <= wd;
+    assign rd = mem[ra];
+endmodule


### PR DESCRIPTION
…ult: '0})

A memory declaration initializer — `logic [W-1:0] mem [0:N] = '{default: '0}` — was ignored: create_memory_from_array built the RTLIL memory but never looked at the initializer, so the memory started X at reset. Reading a never-written word returned X.

rp32's r5p_gpr register file relies on exactly this to keep x0 (whose writes are disabled — a_rd==0) reading 0. Without the init x0 read X, so `addi x2, x0, -1` computed X and the whole datapath collapsed to X.

Fix: in create_memory_from_array(const array_var*), after building the memory, inspect array_var->Expr() (inherited from `variables`). When it is a vpiAssignmentPatternOp with a `default:` tagged_pattern, import the default value (with expression_context_width set to the word width), replicate it across all `size` words, and emit one $meminit_v2. Only the all-words-equal `'{default: V}` form is handled; a per-word list would need per-element evaluation. array_net has no Expr() (nets don't carry a declaration initializer), so only the array_var overload is changed.

After the fix the SoC's registers all initialize/compute correctly: x0=0, x1=0x80020000, x2=0xFFFFFFFF (addi now works), x3=0xDEADB000. Repro: test/array_default_init.