### PR TITLE
uhdm: implement wildcard equality ==? / !=? (vpiWildEqOp/vpiWildNeqOp)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3210,6 +3210,7 @@ int UhdmImporter::self_determined_width(const UHDM::any* node) {
             }
             // Comparisons, logical, reductions: 1 bit.
             case vpiEqOp: case vpiNeqOp: case vpiLtOp: case vpiLeOp:
+            case vpiWildEqOp: case vpiWildNeqOp:
             case vpiGtOp: case vpiGeOp: case vpiLogAndOp: case vpiLogOrOp:
             case vpiNotOp: case vpiUnaryAndOp: case vpiUnaryNandOp:
             case vpiUnaryOrOp: case vpiUnaryNorOp: case vpiUnaryXorOp:
@@ -3576,6 +3577,7 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
         if (ctx_unsigned_entry || !is_expr_signed(uhdm_op))
             expression_context_unsigned = true;
     } else if (op_type == vpiEqOp || op_type == vpiNeqOp ||
+               op_type == vpiWildEqOp || op_type == vpiWildNeqOp ||
                op_type == vpiLtOp || op_type == vpiLeOp ||
                op_type == vpiGtOp || op_type == vpiGeOp) {
         // A comparison's RESULT is unsigned 1-bit, but its operands are sized
@@ -4356,6 +4358,40 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                     xz_value_extend_pair(a, b);
                     std::string cell_name = generate_cell_name(uhdm_op, "nex");
                     return module->Nex(RTLIL::escape_id(cell_name), a, b);
+                }
+            break;
+        case vpiWildEqOp:
+        case vpiWildNeqOp:
+            // Wildcard equality `==?` / `!=?`: bits where the RHS pattern is x/z
+            // are DON'T-CARE (unlike `===`/$eqx, which require an exact x match).
+            // The pattern is normally a constant literal (rp32
+            // tcb_lite_lib_decoder `adr ==? DAM[i]`, DAM carries x wildcards).
+            // Build a care-mask from the constant RHS (1 where it is 0/1) and
+            // compare only those bits: (a & mask) == (b_with_x_as_0).  Without
+            // this the op was unsupported → 0, so no address ever matched and
+            // every peripheral store was misrouted to data memory.
+            if (operands.size() == 2)
+                {
+                    RTLIL::SigSpec a = operands[0], b = operands[1];
+                    xz_value_extend_pair(a, b);
+                    RTLIL::SigSpec res;
+                    if (b.is_fully_const()) {
+                        std::vector<RTLIL::State> mask, bdef;
+                        for (auto bit : b.as_const().to_bits()) {
+                            bool care = (bit == RTLIL::State::S0 ||
+                                         bit == RTLIL::State::S1);
+                            mask.push_back(care ? RTLIL::State::S1 : RTLIL::State::S0);
+                            bdef.push_back(care ? bit : RTLIL::State::S0);
+                        }
+                        RTLIL::SigSpec am = module->And(NEW_ID, a, RTLIL::Const(mask));
+                        res = module->Eq(NEW_ID, am, RTLIL::Const(bdef));
+                    } else {
+                        // Non-constant pattern: no compile-time wildcards.
+                        res = module->Eq(NEW_ID, a, b);
+                    }
+                    if (op_type == vpiWildNeqOp)
+                        res = module->Not(NEW_ID, res);
+                    return res;
                 }
             break;
         case vpiNeqOp:

--- a/test/wildcard_eq/dut.sv
+++ b/test/wildcard_eq/dut.sv
@@ -1,0 +1,12 @@
+// Wildcard equality `==?`: bits where the RHS pattern is x/z are don't-care.
+// (rp32 tcb_lite_lib_decoder address match `adr ==? DAM[i]`, DAM has x wildcards.)
+module wildcard_eq (
+    input  logic [31:0] adr,
+    output logic        mch_per,   // peripheral match (0x8002_0000 region)
+    output logic        mch_mem    // data-memory match (0x8000_0000 region)
+);
+    localparam logic [31:0] DAM_PER = {12'h800, 4'b001x, 16'bxxxx_xxxx_xxxx_xxxx};
+    localparam logic [31:0] DAM_MEM = {12'h800, 4'b000x, 16'bxxxx_xxxx_xxxx_xxxx};
+    assign mch_per = adr ==? DAM_PER;
+    assign mch_mem = adr ==? DAM_MEM;
+endmodule


### PR DESCRIPTION
`adr ==? MASK` always evaluated to 0 — the operators were unhandled and fell through to "Unsupported operation type". `==?` (vpiWildEqOp) and `!=?` (vpiWildNeqOp) are NOT the same as `===`/`!==` (vpiCaseEqOp → $eqx): in a wildcard compare the bits where the RHS PATTERN is x/z are DON'T-CARE, not an exact x match.

Fix: handle both in import_operation. When the RHS is fully constant (the normal case — a literal mask), build a care-mask (1 where the pattern bit is 0/1, 0 where it is x/z) and a defined pattern (x/z → 0), then compare only the cared bits: (a & care_mask) == pattern_defined; invert the result for !=?. A non-constant pattern has no compile-time wildcards, so it falls back to plain equality. Also add the two ops to the result-width table (1 bit) and to the comparison operand width/signedness equalization list next to vpiEqOp.

This was the rp32 SoC store-to-GPIO blocker: tcb_lite_lib_decoder computes `mch[i] = adr ==? DAM[i]` where DAM carries x wildcards for the address map; with ==? returning 0 no address ever matched, so tcb_lsu_sel stayed 0 and every peripheral store (0x8002_0000) was misrouted to data memory. After the fix the decoder routes correctly (0x8002_0000 → peripherals, 0x8000/0x8001_xxxx → data memory). Repro: test/wildcard_eq.