### PR TITLE
uhdm: extract full element for a bit-select of an unpacked-array para…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5834,6 +5834,30 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                                             elem_w = total / outer_size;
                                     }
                                 }
+                            } else if (ats->UhdmType() == uhdmarray_typespec) {
+                                // UNPACKED array parameter: `logic [W-1:0] DAM
+                                // [N-1:0]`.  `DAM[i]` selects a whole W-bit
+                                // ELEMENT, not a single bit.  The array_typespec's
+                                // Range is the unpacked dimension (N elements);
+                                // the element width is total/N.  Without this
+                                // elem_w stays 1 and `DAM[i]` returns a single x
+                                // bit — collapsing an x-wildcard address-decode
+                                // mask to all-x so `adr ==? DAM[i]` folds to 1 for
+                                // every address (rp32 tcb_lite_lib_decoder DAM).
+                                auto arr = dynamic_cast<const UHDM::array_typespec*>(ats);
+                                if (arr && arr->Ranges() && !arr->Ranges()->empty()) {
+                                    packed_multidim = true;
+                                    auto r0 = (*arr->Ranges())[0];
+                                    RTLIL::SigSpec ls = import_expression(r0->Left_expr());
+                                    RTLIL::SigSpec rs2 = import_expression(r0->Right_expr());
+                                    if (ls.is_fully_const() && rs2.is_fully_const()) {
+                                        int l = ls.as_int(), r = rs2.as_int();
+                                        int arr_size = std::abs(l - r) + 1;
+                                        outer_low = std::min(l, r);
+                                        if (arr_size > 0 && total % arr_size == 0)
+                                            elem_w = total / arr_size;
+                                    }
+                                }
                             }
                         }
                     }

--- a/test/param_array_wildcard/dut.sv
+++ b/test/param_array_wildcard/dut.sv
@@ -1,0 +1,26 @@
+// A genvar-indexed packed-array PARAMETER whose elements carry x wildcards,
+// used in `adr ==? DAM[i]` (rp32 tcb_lite_lib_decoder). Element extraction
+// DAM[i] must preserve the defined bits of the x-pattern — else ==? sees an
+// all-x mask and folds to constant 1 (every address "matches").
+module decoder #(
+    parameter int              IFN = 2,
+    parameter logic [31:0]     DAM [IFN-1:0] = '{ 32'h0, 32'h0 }
+)(
+    input  logic [31:0] adr,
+    output logic [IFN-1:0] mch
+);
+    for (genvar i=0; i<IFN; i++)
+        assign mch[i] = adr ==? DAM[i];
+endmodule
+
+module param_array_wildcard (
+    input  logic [31:0] adr,
+    output logic [1:0]  mch
+);
+    // DAM[1] (UART) = bit6 must be 1; DAM[0] (GPIO) = bit6 must be 0; rest x.
+    decoder #(
+        .IFN (2),
+        .DAM ({{17'bx, 15'bxx_xxxx_x1xx_xxxx},
+               {17'bx, 15'bxx_xxxx_x0xx_xxxx}})
+    ) u (.adr(adr), .mch(mch));
+endmodule


### PR DESCRIPTION
…meter

`parameter logic [W-1:0] DAM [N-1:0]` indexed as `DAM[i]` returned a single bit instead of the whole W-bit element.  When the element carried x wildcards (an address-decode mask), the 1-bit `x` collapsed the care-mask, so `adr ==? DAM[i]` folded to constant 1 — every address matched, mis-routing peripheral accesses.

The parameter bit-select handler in import_bit_select computed the element width only for a `logic_typespec` (packed multi-dimensional).  An UNPACKED array parameter's typespec is an `array_typespec` whose Range is the unpacked dimension (N elements) and whose Elem_typespec is the packed element — this was unhandled, so `elem_w` stayed 1 and `DAM[i]` extracted `value[i*1 +: 1]`, a single bit.

Fix: add an `array_typespec` branch that takes the first Range as the unpacked size N, sets `outer_low = min(l, r)` and `elem_w = total / N` (mirroring the logic_typespec case), so `DAM[i] = value[(i-outer_low)*elem_w +: elem_w]`.

This was the rp32 SoC peripheral (GPIO/UART) decoder mis-route: with `DAM[i]` all-x, `adr ==? DAM[i]` matched every address.  After the fix the store routes to the correct peripheral (GPIO), sys_wen asserts and the GPIO register is written. Repro: test/param_array_wildcard (eval: `adr ==? DAM[i]` distinguishes the elements' defined bits).