### PR TITLE
Bump Yosys to upstream v0.67; use integrated sv-elab (read_slang)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,17 +69,18 @@ jobs:
         echo "PATH after: /opt/verilator-5.048/bin:$PATH"
         /opt/verilator-5.048/bin/verilator --version
 
-    - name: Setup GCC-11
+    - name: Setup GCC-13
       shell: bash
       run: |
-        # Yosys v0.66 hard-requires C++20: its build passes `-std=c++20`, which
-        # g++-9 rejects ("unrecognized ... did you mean -std=c++2a").  Use g++-11
-        # (the locally-validated toolchain) so Yosys builds; Surelog/antlr4 still
-        # build at C++17 and the uhdm2rtlil plugin at C++20.
-        sudo apt install -y g++-11
-        sudo ln -sf /usr/bin/g++-11 /usr/bin/g++
-        sudo ln -sf /usr/bin/gcc-11 /usr/bin/gcc
-        sudo ln -sf /usr/bin/gcov-11 /usr/bin/gcov
+        # Yosys v0.67 hard-requires C++20, and with YOSYS_ENABLE_SLANG=ON the
+        # build compiles the bundled MikePopoloski/slang library (needs gcc >= 11).
+        # Use the runner's default gcc-13 for the whole build; Surelog/antlr4 still
+        # build at C++17 and the uhdm2rtlil plugin at C++20.  (ubuntu-24.04's apt
+        # cmake is 3.28.x — new enough for slang, old enough for capnproto.)
+        sudo apt install -y g++-13
+        sudo ln -sf /usr/bin/g++-13 /usr/bin/g++
+        sudo ln -sf /usr/bin/gcc-13 /usr/bin/gcc
+        sudo ln -sf /usr/bin/gcov-13 /usr/bin/gcov
     
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/frontend-matrix.yml
+++ b/.github/workflows/frontend-matrix.yml
@@ -88,32 +88,33 @@ jobs:
 
     - name: Build project (Surelog + Yosys + uhdm2rtlil plugin)
       run: |
-        # Yosys v0.66 requires C++20; g++-9 only offers -std=c++2a -> use g++-11.
-        sudo ln -sf /usr/bin/g++-11 /usr/bin/g++
-        sudo ln -sf /usr/bin/gcc-11 /usr/bin/gcc
-        sudo ln -sf /usr/bin/gcov-11 /usr/bin/gcov
+        # Yosys v0.67 requires C++20 and, with YOSYS_ENABLE_SLANG=ON, compiles the
+        # bundled slang library (needs gcc >= 11 and CMake >= 3.28 — both provided
+        # by ubuntu-24.04's default gcc-13 / cmake 3.28).  Use gcc-13 throughout.
+        sudo ln -sf /usr/bin/g++-13 /usr/bin/g++
+        sudo ln -sf /usr/bin/gcc-13 /usr/bin/gcc
+        sudo ln -sf /usr/bin/gcov-13 /usr/bin/gcov
         rm -rf build/CMakeCache.txt build/CMakeFiles/
         make -j4 CC="ccache gcc" CXX="ccache g++" CPU_CORES=4
 
-    - name: Build external frontends (sv2v + yosys-slang)
+    - name: Build external frontends (sv2v)
       # sv2v: prebuilt binary (the runner's GHC rejects gcc with clang-style
-      # flags, so the source build is doomed).  slang: needs gcc >= 11 -> gcc-13.
+      # flags, so the source build is doomed).  slang is now built into the yosys
+      # binary (read_slang / sv-elab), so nothing extra to build here.
       run: |
         cd test
         SV2V_PREBUILT=1 ./build_frontends.sh sv2v
-        CC=gcc-13 CXX=g++-13 ./build_frontends.sh slang
         echo "--- versions ---"; cat ../build/frontends/versions.txt || true
 
     - name: Package runtime
       # Only the run-time bits the harness invokes — statically linked, so this
       # tarball runs on a shard runner with just the system runtime libs (apt).
-      # --dereference so build/slang.so (a symlink) becomes a real file.
+      # slang lives inside out/current/bin/yosys now (read_slang built in).
       run: |
         tar -czhf runtime.tar.gz \
           out/current \
           build/uhdm2rtlil.so \
           build/extract_clocks_resets.so \
-          build/slang.so \
           build/frontends/sv2v/bin/sv2v \
           build/third_party/Surelog/bin/surelog \
           build/frontends/versions.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/chipsalliance/Surelog.git
 [submodule "third_party/yosys"]
 	path = third_party/yosys
-	url = https://github.com/alainmarcel/yosys.git
+	url = https://github.com/YosysHQ/yosys.git
 	# Tracking a fork branch (v0.66 + one local patch) until upstream
 	# Yosys merges the `write_verilog` signedness fix (still not upstream as of
 	# v0.66 — the backend's dump_wire does not emit `signed`; the related

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Yosys frontend that converts SystemVerilog to RTLIL (Register Transfer Level Intermediate Language) via UHDM (Universal Hardware Data Model). The workflow is: SystemVerilog → Surelog → UHDM → UHDM Frontend → RTLIL → Yosys synthesis.
 
-The Yosys submodule is pinned at **v0.66** (`third_party/yosys`, on the fork's
-`v0.66-write-verilog-signed-port` branch = v0.66 + one local write_verilog
-signedness patch). v0.66 requires **C++20** (kernel/yosys_common.h hard-errors
-otherwise), so the plugin's `CMAKE_CXX_STANDARD` is 20. yosys-slang officially
-lists support only up to v0.65, but it builds and runs fine against v0.66 in
-practice (verified: the 4-frontend matrix's slang column synthesizes).
+The Yosys submodule is pinned at **upstream YosysHQ tag v0.67**
+(`third_party/yosys`; the old `write_verilog signed` fork patch is now upstream,
+so no fork is needed). v0.67 requires **C++20** (kernel/yosys_common.h
+hard-errors otherwise), so the plugin's `CMAKE_CXX_STANDARD` is 20.
+
+**v0.67 is CMake-only** — the top-level Makefile is gone.  Our CMakeLists builds
+Yosys via `cmake -B third_party/yosys/build … && cmake --build … && cmake
+--install` (was `make CONFIG=gcc PREFIX=… install`), installing the yosys binary
++ yosys-config into `out/current/`.  The build passes
+`-DYOSYS_ENABLE_SLANG=ON` (toggle: `-DUHDM2RTLIL_ENABLE_SLANG=OFF`) so the
+vendored **sv-elab** SystemVerilog frontend is compiled into the yosys binary as
+the built-in `read_slang` command — this replaces the standalone
+povik/yosys-slang plugin as the 4-frontend matrix's `slang` column.  Building
+slang compiles the bundled MikePopoloski/slang library, which needs **gcc ≥ 11**
+and **CMake in the [3.28, 3.31] range**: ≥ 3.28 is required by slang, but CMake
+**4.x cannot be used** because Surelog/UHDM's bundled capnproto still declares
+`cmake_minimum_required(VERSION < 3.5)`, which CMake 4 rejects.  ubuntu-24.04's
+default cmake 3.28 satisfies both; on ubuntu-22.04 (cmake 3.22) install a 3.28–
+3.31 build (e.g. `pip install 'cmake==3.31.6'`, which lands in `~/.local/bin` on
+PATH) or build with `-DUHDM2RTLIL_ENABLE_SLANG=OFF`.  NOTE the top-level project
+must be *configured* with that cmake, because the vendored-Yosys build reuses the
+same `CMAKE_COMMAND` for its nested `cmake -B third_party/yosys/build`.  The
+matrix's default / golden frontend remains Yosys-native `read_verilog`.
 
 ## Build Commands
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,15 +45,39 @@ else()
         OFF
         CACHE INTERNAL "")
     set(YOSYS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/third_party/yosys)
-    set(YOSYS_CONFIG ${PROJECT_SOURCE_DIR}/third_party/yosys/yosys-config)
-    # Build Vendored Yosys if not provided by upper cmake
+    # yosys-config is installed into the prefix by the CMake build/install.
+    set(YOSYS_CONFIG ${INSTALL_DIR}/bin/yosys-config)
+    set(YOSYS_SRC_DIR ${PROJECT_SOURCE_DIR}/third_party/yosys)
+    set(YOSYS_BUILD_DIR ${YOSYS_SRC_DIR}/build)
+    include(ProcessorCount)
+    ProcessorCount(YOSYS_NPROC)
+    if(YOSYS_NPROC EQUAL 0)
+      set(YOSYS_NPROC 4)
+    endif()
+    # Build Vendored Yosys if not provided by upper cmake.
+    #
+    # Yosys v0.67 is CMake-only — the old top-level Makefile we used to invoke
+    # (`make CONFIG=gcc PREFIX=… install`) was removed.  v0.67 also vendors the
+    # sv-elab SystemVerilog frontend under frontends/slang; building it in
+    # (YOSYS_ENABLE_SLANG=ON) makes `read_slang` part of the yosys binary so the
+    # 4-frontend matrix's slang column uses the integrated frontend instead of a
+    # standalone povik/yosys-slang plugin.  Slang compiles the bundled
+    # MikePopoloski/slang library, which needs CMake >= 3.28 and gcc >= 11 — turn
+    # it OFF (-DUHDM2RTLIL_ENABLE_SLANG=OFF) on hosts with an older toolchain.
+    option(UHDM2RTLIL_ENABLE_SLANG
+           "Build the sv-elab (read_slang) frontend into the vendored Yosys" ON)
     add_custom_target(yosys DEPENDS ${INSTALL_DIR}/bin/yosys)
     add_custom_command(
       OUTPUT ${INSTALL_DIR}/bin/yosys
-      COMMAND echo "       Compiling Yosys"
-      COMMAND make CONFIG=gcc PREFIX=${INSTALL_DIR} ENABLE_DEBUG=1 install -j4
-      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/yosys"
-      DEPENDS ${PROJECT_SOURCE_DIR}/third_party/yosys/kernel/yosys.cc)
+      COMMAND ${CMAKE_COMMAND} -E echo "Compiling Yosys v0.67 via CMake, slang=${UHDM2RTLIL_ENABLE_SLANG}"
+      COMMAND ${CMAKE_COMMAND} -B ${YOSYS_BUILD_DIR} -S ${YOSYS_SRC_DIR}
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+              -DYOSYS_ENABLE_SLANG=${UHDM2RTLIL_ENABLE_SLANG}
+      COMMAND ${CMAKE_COMMAND} --build ${YOSYS_BUILD_DIR} --parallel ${YOSYS_NPROC}
+      COMMAND ${CMAKE_COMMAND} --install ${YOSYS_BUILD_DIR}
+      WORKING_DIRECTORY "${YOSYS_SRC_DIR}"
+      DEPENDS ${YOSYS_SRC_DIR}/kernel/yosys.cc)
   endif()
 endif()
 
@@ -85,14 +109,18 @@ add_dependencies(uhdm2rtlil surelog yosys)
 # Link against Surelog library only
 target_link_libraries(uhdm2rtlil surelog)
 
-# Include directories
-target_include_directories(uhdm2rtlil PRIVATE 
+# Include directories.
+#
+# Use the INSTALLED Yosys headers (out/current/share/yosys/include), not the
+# source tree: v0.67's CMake build generates kernel/yosys_config.h (included by
+# kernel/yosys_common.h) into its build dir, and `cmake --install` lays the full
+# header set — generated + static — under share/yosys/include with the usual
+# kernel/ … prefixes.  The source tree alone is missing yosys_config.h.  The
+# `yosys` target (an add_dependencies below) installs these before this compiles.
+target_include_directories(uhdm2rtlil PRIVATE
     src/frontends/uhdm
     third_party/Surelog/include
-    third_party/yosys/kernel
-    third_party/yosys/frontends
-    third_party/yosys/backends
-    third_party/yosys
+    ${INSTALL_DIR}/share/yosys/include
 )
 
 # Add compiler warning flags - treat all warnings as errors
@@ -110,16 +138,15 @@ target_compile_options(uhdm2rtlil PRIVATE
     -Wno-maybe-uninitialized
 )
 
-# Add required Yosys defines
+# Add required Yosys defines.
+#
+# Only `_YOSYS_` here.  v0.67's generated kernel/yosys_config.h (pulled in via
+# kernel/yosys.h) now defines the YOSYS_ENABLE_* feature macros itself — valueless
+# `#define YOSYS_ENABLE_PLUGINS` etc. reflecting how the yosys binary was actually
+# built — so defining them again here as `=1` triggers -Werror macro-redefinition.
+# Matches what `yosys-config --cxxflags` passes for an external plugin.
 target_compile_definitions(uhdm2rtlil PRIVATE
     _YOSYS_
-    YOSYS_ENABLE_TCL=1
-    YOSYS_ENABLE_ABC=1
-    YOSYS_ENABLE_GLOB=1
-    YOSYS_ENABLE_PLUGINS=1
-    YOSYS_ENABLE_READLINE=1
-    YOSYS_ENABLE_COVER=1
-    YOSYS_ENABLE_ZLIB=1
 )
 
 # Set plugin properties

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ test-yosys: all preprocess-yosys-tests
 	@echo "Running Yosys tests..."
 	@cd test && ./run_all_tests.sh --yosys
 
-# Build the two external frontends (sv2v, yosys-slang) for the 4-frontend
-# matrix.  Requires a completed `make` first (needs out/current yosys-config)
-# and Haskell Stack on PATH for sv2v.
+# Build the external frontend(s) for the 4-frontend matrix.  Only sv2v is
+# external now — slang (read_slang / sv-elab) is built into the yosys binary
+# via YOSYS_ENABLE_SLANG=ON.  Requires Haskell Stack on PATH for sv2v.
 frontends: all
-	@echo "Building external frontends (sv2v, yosys-slang)..."
+	@echo "Building external frontends (sv2v)..."
 	@cd test && ./build_frontends.sh
 
 # Run the 4-frontend regression matrix over the internal tests.
@@ -88,19 +88,15 @@ build-debug/Makefile:
 
 # Clean build artifacts.
 #
-# IMPORTANT: Yosys (and its bundled abc) build IN-TREE under third_party/yosys,
-# and the install lives in out/.  Both survive `rm -rf build`, so the old clean
-# left stale Yosys *.o behind — after a Yosys-submodule bump those link against
-# freshly-built v0.65 objects and crash at runtime (ABI mismatch, e.g.
-# `std::out_of_range: Cell::getParam()`).  A proper clean must remove them too.
+# IMPORTANT: Yosys v0.67 builds out-of-tree under third_party/yosys/build/ (its
+# own CMake build dir) and installs into out/.  Both survive `rm -rf build`, so
+# a proper clean must remove the Yosys CMake build dir too — otherwise a stale
+# build links against objects from a previous submodule pin and crashes at
+# runtime (ABI mismatch, e.g. `std::out_of_range: Cell::getParam()`).
 clean:
-	@echo "Cleaning build artifacts (build dirs, out/, in-tree Yosys + abc)..."
+	@echo "Cleaning build artifacts (build dirs, out/, Yosys CMake build)..."
 	rm -rf build build-debug out
-	-$(MAKE) -C third_party/yosys clean >/dev/null 2>&1 || true
-	@find third_party/yosys \( -name '*.o' -o -name '*.d' -o -name '*.a' \) -delete 2>/dev/null || true
-	rm -f third_party/yosys/yosys third_party/yosys/yosys-* \
-	      third_party/yosys/libyosys.so* third_party/yosys/abc/abc \
-	      third_party/yosys/kernel/version_*.cc
+	rm -rf third_party/yosys/build
 	@echo "Clean complete. (Re-running 'make' will rebuild Yosys from scratch.)"
 
 # Install target
@@ -123,7 +119,7 @@ help:
 	@echo "  test       - Run internal tests only (includes test-read-sv)"
 	@echo "  test-all   - Run all tests (internal + Yosys)"
 	@echo "  test-yosys - Run Yosys tests only"
-	@echo "  frontends  - Build sv2v + yosys-slang for the 4-frontend matrix"
+	@echo "  frontends  - Build sv2v for the 4-frontend matrix (slang is built into yosys)"
 	@echo "  test-matrix - Run the 4-frontend regression matrix (internal tests)"
 	@echo "  clean      - Remove ALL build artifacts (build dirs, out/, in-tree Yosys/abc objects)"
 	@echo "  install    - Install the plugin"

--- a/test/build_frontends.sh
+++ b/test/build_frontends.sh
@@ -1,25 +1,24 @@
 #!/usr/bin/env bash
 #
-# build_frontends.sh — clone + build the two external SystemVerilog frontends
+# build_frontends.sh — clone + build the external SystemVerilog frontend(s)
 # used by the 4-frontend regression matrix (run_frontend_matrix.py):
 #
-#   * sv2v        (https://github.com/zachjs/sv2v)        — SV → Verilog transpiler
-#   * yosys-slang (https://github.com/povik/yosys-slang)  — slang-based Yosys plugin
+#   * sv2v (https://github.com/zachjs/sv2v)  — SV → Verilog transpiler
 #
-# Both are cloned and built under build/frontends/.  The script is idempotent:
-# an already-built tool is skipped unless --force is given.  yosys-slang is
-# built against THIS repo's Yosys (out/current/bin/yosys-config), so a normal
-# `make` must have completed first.
+# The matrix's `slang` column no longer needs building here: Yosys v0.67 vendors
+# the sv-elab frontend (`read_slang`) directly in the binary, built via
+# YOSYS_ENABLE_SLANG=ON in the top-level CMake build.  `slang`/`all` are accepted
+# for backward compatibility but only build sv2v.
+#
+# sv2v is cloned and built under build/frontends/.  The script is idempotent:
+# an already-built tool is skipped unless --force is given.
 #
 # Outputs:
-#   build/frontends/sv2v/bin/sv2v                     — sv2v binary
-#   build/frontends/yosys-slang/build/slang.so        — slang plugin
-#   build/slang.so                                    — stable symlink to the above
-#   build/frontends/versions.txt                      — cloned commit of each tool
+#   build/frontends/sv2v/bin/sv2v    — sv2v binary
+#   build/frontends/versions.txt     — cloned commit of each tool
 #
 # Host prerequisites:
-#   sv2v        : Haskell Stack   (https://get.haskellstack.org/)
-#   yosys-slang : gcc >= 11 or clang >= 17, cmake
+#   sv2v : Haskell Stack   (https://get.haskellstack.org/)
 #
 # Usage: test/build_frontends.sh [--force] [sv2v|slang|all]
 
@@ -32,12 +31,8 @@ YOSYS_CONFIG="$PROJECT_ROOT/out/current/bin/yosys-config"
 VERSIONS_FILE="$FRONTENDS_DIR/versions.txt"
 
 SV2V_REPO="https://github.com/zachjs/sv2v"
-SLANG_REPO="https://github.com/povik/yosys-slang"
 SV2V_DIR="$FRONTENDS_DIR/sv2v"
-SLANG_DIR="$FRONTENDS_DIR/yosys-slang"
 SV2V_BIN="$SV2V_DIR/bin/sv2v"
-SLANG_SO="$SLANG_DIR/build/slang.so"
-SLANG_LINK="$PROJECT_ROOT/build/slang.so"
 
 FORCE=0
 WHAT="all"
@@ -125,46 +120,12 @@ build_sv2v() {
     record_version sv2v "$SV2V_DIR"
 }
 
+# The slang frontend is now built into the yosys binary (YOSYS_ENABLE_SLANG=ON
+# in the top-level CMake build), so there is nothing to build here.  Kept as a
+# no-op so `build_frontends.sh slang` / `all` still succeed.
 build_slang() {
-    if [ "$FORCE" -eq 0 ] && [ -f "$SLANG_SO" ]; then
-        echo "✓ yosys-slang already built: $SLANG_SO (use --force to rebuild)"
-        ln -sf "$SLANG_SO" "$SLANG_LINK"
-        return 0
-    fi
-    if [ ! -x "$YOSYS_CONFIG" ]; then
-        echo "❌ yosys-config not found at $YOSYS_CONFIG" >&2
-        echo "   Run the normal repo build first:  make -j$NPROC" >&2
-        return 1
-    fi
-    if [ ! -d "$SLANG_DIR/.git" ]; then
-        echo "▶ Cloning yosys-slang (recursive: pulls slang submodule) → $SLANG_DIR"
-        rm -rf "$SLANG_DIR"
-        git clone --recursive "$SLANG_REPO" "$SLANG_DIR" || return 1
-    else
-        # Make sure the slang submodule is present on a reused checkout.
-        git -C "$SLANG_DIR" submodule update --init --recursive || true
-    fi
-    # Upstream (now "sv-elab") retired the Makefile wrapper — its `make` target
-    # is empty in current master, so `make YOSYS_PREFIX=…` dies with
-    # "make: *** No targets.  Stop.".  Drive CMake directly instead (the old
-    # Makefile only wrapped these two commands anyway, so this works for both the
-    # old and new checkouts).  -DYOSYS_CONFIG must point at OUR pinned Yosys's
-    # yosys-config; without it CMake picks up a stray system yosys-config
-    # (e.g. /usr/local v0.38) and the build fails against the older RTLIL API.
-    # Wipe any stale cmake cache from a previous mis-detected configure first.
-    local yosys_bindir; yosys_bindir="$(dirname "$YOSYS_CONFIG")/"
-    echo "▶ Building yosys-slang against ${yosys_bindir}yosys-config …"
-    rm -rf "$SLANG_DIR/build"
-    ( cd "$SLANG_DIR" \
-        && cmake -B build -DYOSYS_CONFIG="${yosys_bindir}yosys-config" . \
-        && make -C build -j"$NPROC" ) \
-        || { echo "❌ yosys-slang build failed" >&2; return 1; }
-    if [ ! -f "$SLANG_SO" ]; then
-        echo "❌ slang.so not produced at $SLANG_SO" >&2; return 1
-    fi
-    ln -sf "$SLANG_SO" "$SLANG_LINK"
-    record_version yosys-slang "$SLANG_DIR"
-    echo "✓ yosys-slang built: $SLANG_SO  (linked → $SLANG_LINK)"
+    echo "✓ slang: built into yosys (read_slang, sv-elab) — nothing to build here"
+    return 0
 }
 
 RC=0

--- a/test/frontend_matrix_workflow.sh
+++ b/test/frontend_matrix_workflow.sh
@@ -6,7 +6,7 @@
 #   verilog : Yosys native      read_verilog            (also the golden ref)
 #   uhdm    : this plugin        Surelog -> read_uhdm
 #   sv2v    : zachjs/sv2v        sv2v src... -> read_verilog
-#   slang   : povik/yosys-slang  read_slang src...
+#   slang   : built-in read_slang (sv-elab, YOSYS_ENABLE_SLANG)  read_slang src...
 #
 # Only the *read* step differs between frontends; the synthesis tail
 #   hierarchy -check -auto-top; proc; opt; synth -auto-top; write_verilog -noexpr
@@ -54,7 +54,6 @@ MODULE_NAME=$(basename "$(pwd)")
 SURELOG_BIN="$PROJECT_ROOT/build/third_party/Surelog/bin/surelog"
 YOSYS_BIN="$PROJECT_ROOT/out/current/bin/yosys"
 UHDM_PLUGIN="$PROJECT_ROOT/build/uhdm2rtlil.so"
-SLANG_PLUGIN="$PROJECT_ROOT/build/slang.so"
 SV2V_BIN="$PROJECT_ROOT/build/frontends/sv2v/bin/sv2v"
 
 # Resolve the file list / language flags the same way every other harness does.
@@ -186,16 +185,19 @@ else
 fi
 
 # ------------------------------------------------------------------ slang ----
-echo "[4/4] slang (yosys-slang read_slang)"
-if [ ! -f "$SLANG_PLUGIN" ]; then
+# Yosys v0.67 vendors the sv-elab SystemVerilog frontend directly in the binary
+# (built with YOSYS_ENABLE_SLANG=ON), so `read_slang` is a built-in command —
+# no external plugin is loaded (replaces the old standalone povik/yosys-slang).
+echo "[4/4] slang (built-in read_slang / sv-elab)"
+if ! "$YOSYS_BIN" -p "help read_slang" 2>&1 | grep -q "read_slang"; then
     echo "slang TOOL_MISSING 0" >> "$STATUS_FILE"
-    echo "   → slang: TOOL_MISSING (run build_frontends.sh)"
+    echo "   → slang: TOOL_MISSING (yosys built without YOSYS_ENABLE_SLANG)"
 else
     {
         echo "read_slang $PROJECT_SRCS"
         emit_tail slang
     } > slang_read.ys
-    run_capped "$YOSYS_BIN" -m "$SLANG_PLUGIN" -s slang_read.ys > slang_path.log 2>&1
+    run_capped "$YOSYS_BIN" -s slang_read.ys > slang_path.log 2>&1
     record_status slang $?
 fi
 

--- a/test/test_sim_equivalence.py
+++ b/test/test_sim_equivalence.py
@@ -56,7 +56,9 @@ def find_paths(project_root: Path) -> dict[str, Path]:
             sys.exit(f"❌ missing {k}: {p}")
     # Optional frontend tools — only needed for --frontend sv2v / slang.  Don't
     # fail here if absent; frontend_read_setup() reports a clear error instead.
-    paths["slang_plugin"] = project_root / "build/slang.so"
+    # slang (read_slang / sv-elab) is built into the yosys binary now, so there
+    # is no separate plugin path.
+    paths["yosys_bin"]    = project_root / "out/current/bin/yosys"
     paths["sv2v_bin"]     = project_root / "build/frontends/sv2v/bin/sv2v"
     return paths
 
@@ -73,10 +75,8 @@ def frontend_read_setup(frontend: str, paths: dict, uhdm: Path,
     if frontend == "verilog":
         return f"read_verilog {lang} {srcs}\n", []
     if frontend == "slang":
-        if not paths["slang_plugin"].exists():
-            sys.exit(f"❌ slang plugin not built: {paths['slang_plugin']} "
-                     f"(run test/build_frontends.sh)")
-        return f"read_slang {srcs}\n", ["-m", str(paths["slang_plugin"])]
+        # read_slang is built into yosys (YOSYS_ENABLE_SLANG=ON); no plugin.
+        return f"read_slang {srcs}\n", []
     if frontend == "sv2v":
         if not paths["sv2v_bin"].exists():
             sys.exit(f"❌ sv2v not built: {paths['sv2v_bin']} "


### PR DESCRIPTION
Move the vendored Yosys from the v0.66 fork to upstream YosysHQ tag v0.67 and switch the 4-frontend matrix's slang column from the standalone povik/yosys-slang plugin to Yosys's built-in sv-elab frontend.

Yosys:
- third_party/yosys -> YosysHQ v0.67 (2d1509d1b).  Our write_verilog "preserve signed" patch is upstream in v0.67, so the fork is dropped (.gitmodules URL now points at YosysHQ).  New sub-submodules (libs/slang, frontends/slang/lib = sv-elab, libs/fmt/cxxopts/tomlplusplus/boost_regex) come in via recursive checkout.

Build (v0.67 is CMake-only — the top-level Makefile was removed):
- CMakeLists.txt builds Yosys with `cmake -B third_party/yosys/build … && cmake --build … && cmake --install` (was `make CONFIG=gcc PREFIX=… install`), passing -DYOSYS_ENABLE_SLANG=${UHDM2RTLIL_ENABLE_SLANG} (new option, default ON) so `read_slang` is compiled into the yosys binary.
- Plugin now includes the INSTALLED yosys headers (out/current/share/yosys/include) so the generated kernel/yosys_config.h is found, and drops the manual YOSYS_ENABLE_* defines that v0.67's yosys_config.h now owns (they collided under -Werror).  YOSYS_CONFIG points at the installed yosys-config.
- Top Makefile: `clean` removes third_party/yosys/build; `frontends` builds only sv2v.

Frontend matrix / harness:
- slang column uses the built-in `read_slang` (no `-m slang.so`); verilog stays the golden/default frontend.  build_frontends.sh no longer builds yosys-slang (sv2v stays external).  test_sim_equivalence.py drops the slang plugin path.

CI: recursive submodule checkout already in place; gcc-13 for both jobs (slang needs gcc >= 11); external-frontends step builds only sv2v; runtime package drops build/slang.so.

Note: building slang needs CMake in [3.28, 3.31] — >= 3.28 for slang, < 4.0 because Surelog/capnproto's old cmake_minimum_required is rejected by CMake 4. ubuntu-24.04's apt cmake 3.28 satisfies both.