### PR TITLE
Fix extract_clocks_resets build: use installed yosys-config (v0.67)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ target_compile_definitions(uhdm2rtlil PRIVATE
 set_target_properties(uhdm2rtlil PROPERTIES
     PREFIX ""
     SUFFIX ".so"
-    # Yosys v0.66 headers hard-require C++20; scope it to this target only so
+    # Yosys v0.67 headers hard-require C++20; scope it to this target only so
     # the C++17 Surelog/antlr4 subtree keeps building.
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
@@ -173,9 +173,11 @@ install(TARGETS uhdm2rtlil DESTINATION ${INSTALL_DIR}/share/yosys/plugins)
 set(EXTRACT_CR_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/extract_clocks_resets/extract_clocks_resets.cc)
 set(EXTRACT_CR_SO ${CMAKE_CURRENT_BINARY_DIR}/extract_clocks_resets.so)
-# yosys-config lives in the in-tree Yosys checkout (it's a shell script
-# that knows where its own include/lib live) — use that directly.
-set(YOSYS_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/third_party/yosys/yosys-config)
+# v0.67 is CMake-only and no longer generates an in-tree yosys-config; it is
+# installed into the prefix by the yosys build/install.  Use the installed one
+# (it knows where its own include/lib live).  The `yosys` dependency below
+# guarantees the install has run before this command.
+set(YOSYS_CONFIG ${INSTALL_DIR}/bin/yosys-config)
 add_custom_command(
     OUTPUT ${EXTRACT_CR_SO}
     COMMAND ${YOSYS_CONFIG} --build ${EXTRACT_CR_SO} ${EXTRACT_CR_SRC}


### PR DESCRIPTION
After the v0.67 bump the aux plugin build failed with `third_party/yosys/yosys-config: No such file or directory` (Error 127): v0.67 is CMake-only and no longer generates an in-tree yosys-config — it is installed into the prefix by the yosys build/install.  The extract_clocks_resets custom command still pointed YOSYS_CONFIG at the old source-tree path, overriding the installed path set earlier.  Point it at ${INSTALL_DIR}/bin/yosys-config (the `yosys` target dependency guarantees the install ran first).