### PR TITLE
Fix nightly Package runtime: create versions.txt on the prebuilt sv2v…

### DIFF
--- a/test/build_frontends.sh
+++ b/test/build_frontends.sh
@@ -97,6 +97,10 @@ build_sv2v() {
         echo "▶ SV2V_PREBUILT=1 — skipping source build, using prebuilt sv2v"
         mkdir -p "$SV2V_DIR"
         sv2v_prebuilt_fallback || return 1
+        # Still record a version line so build/frontends/versions.txt exists (the
+        # matrix's "Package runtime" step tars it).  Previously the now-removed
+        # slang build created this file; the prebuilt sv2v path did not.
+        record_version sv2v "$SV2V_DIR"
         return 0
     fi
     if [ ! -d "$SV2V_DIR/.git" ]; then


### PR DESCRIPTION
… path

After the slang build was removed, `build/frontends/versions.txt` was no longer created on CI: the `SV2V_PREBUILT=1` path (used by the matrix workflow) fetched the prebuilt sv2v and returned without calling record_version — previously the now-gone yosys-slang build wrote that file.  The "Package runtime" step then failed: `tar: build/frontends/versions.txt: Cannot stat: No such file`.

Call record_version on the prebuilt path too so the file always exists.