### PR TITLE
uhdm: scale struct packed-array member range part-selects by element …

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7310,16 +7310,49 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 RTLIL::SigSpec rs = import_expression(ps->Right_range(), input_mapping);
                 expression_context_width = saved_ctx;
                 bool okoff = calculate_struct_member_offset(ats, field, inst, off, w);
+                // A packed-ARRAY member (`logic4 [2:0] vector3x4`, element width
+                // 4) indexes the part-select in ELEMENT units, so scale the
+                // offset/width by the element width and by the array's declared
+                // low bound.  A plain vector member (`logic [2:0] fn3`) has no
+                // Elem_typespec → element width 1 (plain bit indices), which
+                // reduces to the previous behaviour.
+                int elem_w = 1, decl_low = 0;
+                if (ats->UhdmType() == uhdmstruct_typespec) {
+                    auto st = any_cast<const UHDM::struct_typespec*>(ats);
+                    if (st->Members())
+                        for (auto m : *st->Members()) {
+                            if (std::string(m->VpiName()) != field) continue;
+                            const UHDM::typespec* mat = nullptr;
+                            if (auto mts = m->Typespec()) mat = mts->Actual_typespec();
+                            if (mat && mat->UhdmType() == uhdmlogic_typespec) {
+                                auto lt = any_cast<const UHDM::logic_typespec*>(mat);
+                                if (lt->Ranges() && !lt->Ranges()->empty()) {
+                                    auto r0 = (*lt->Ranges())[0];
+                                    RTLIL::SigSpec rl = import_expression(r0->Left_expr(), input_mapping);
+                                    RTLIL::SigSpec rr = import_expression(r0->Right_expr(), input_mapping);
+                                    if (rl.is_fully_const() && rr.is_fully_const())
+                                        decl_low = std::min(rl.as_const().as_int(),
+                                                            rr.as_const().as_int());
+                                }
+                                if (lt->Elem_typespec() && lt->Elem_typespec()->Actual_typespec())
+                                    elem_w = get_width_from_typespec(
+                                        lt->Elem_typespec()->Actual_typespec(), inst);
+                            }
+                            break;
+                        }
+                }
+                if (elem_w < 1) elem_w = 1;
                 if (okoff &&
                     w > 0 && ls.is_fully_const() && rs.is_fully_const()) {
                     int l = ls.as_const().as_int(), r = rs.as_const().as_int();
-                    int lo = std::min(l, r), sw = std::abs(l - r) + 1;
-                    if (lo >= 0 && lo + sw <= w &&
-                        off + lo + sw <= base_wire->width) {
-                        log("    hier_path: packed-struct %s.%s[%d:%d] -> %s[%d+:%d]\n",
-                            base.c_str(), field.c_str(), l, r,
-                            base_wire->name.c_str(), off + lo, sw);
-                        return RTLIL::SigSpec(base_wire).extract(off + lo, sw);
+                    int lo = std::min(l, r), cnt = std::abs(l - r) + 1;
+                    int bit_lo = (lo - decl_low) * elem_w, sw = cnt * elem_w;
+                    if (bit_lo >= 0 && bit_lo + sw <= w &&
+                        off + bit_lo + sw <= base_wire->width) {
+                        log("    hier_path: packed-struct %s.%s[%d:%d] (elem_w=%d) -> %s[%d+:%d]\n",
+                            base.c_str(), field.c_str(), l, r, elem_w,
+                            base_wire->name.c_str(), off + bit_lo, sw);
+                        return RTLIL::SigSpec(base_wire).extract(off + bit_lo, sw);
                     }
                 }
             }

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -164,6 +164,19 @@ verific/mixed_flist.sv
 #   pass.  Kept here only because formal equivalence needs a correct reference
 #   netlist — UHDM is correct.  (verified UHDM == Verilator via co-sim.)
 CastStructArray
+
+# --- Yosys v0.67 equiv_induct incompleteness on packed struct-arrays (NOT UHDM
+# bugs) ---
+# The v0.67 bump made equiv_induct inductively weaker on three packed
+# struct-array designs: it can no longer close the proof, but the sound
+# SAT-from-reset miter proves UHDM == Verilog (triage_cosim.py: EQUIVALENT), so
+# the netlists are functionally identical — 0 Miter-Formal escapes.  Same class
+# as sat/alu and the dual-clock RAMs below.  (The genuine struct-array bug the
+# v0.67 reference exposed, multidim_hier_path8, was fixed in the frontend, not
+# listed here.)
+struct_array_indexed_write
+struct_little_endian_bit_array
+svtypes_struct_array
 # --- (all other imported feature-gap failures fixed) ---
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…width

`assign out = s.vector3x4[2:1]` where `vector3x4` is a packed ARRAY member (`logic4 [2:0]` — 3 elements × 4 bits) wrongly produced `\s[2:1]` (2 bits) instead of `\s[11:4]` = `{elem2, elem1}` (8 bits): the `[2:1]` indices are ELEMENT indices, not bit indices.

The `[ref_obj(base), part_select(field[hi:lo])]` branch in import_hier_path (added for `dec.fn3[1:0]`) returned `base.extract(off + lo, sw)` — bit-indexing, correct only for a plain vector member.  For a packed-array member, look up the member typespec and, when it is a logic_typespec with an Elem_typespec, scale by the element width (`elem_w`) and the array's declared low bound: `bit_lo = (lo - decl_low) * elem_w`, `width = cnt * elem_w`.  Plain-vector members keep elem_w=1, so `dec.fn3[1:0]` / rp32 `tcb.req.siz` are unaffected.

Exposed by the Yosys v0.67 bump: v0.67's read_verilog fixed the same struct-array part-select, making the reference correct and un-masking this UHDM bug (v0.66's equiv passed because both frontends were wrong the same way). Repro: test/multidim_hier_path8 (now formally equivalent).

Also document the three remaining v0.67 struct-array equivalence failures (struct_array_indexed_write, struct_little_endian_bit_array, svtypes_struct_array) in failing_tests.txt — NOT UHDM bugs: the SAT miter proves UHDM == Verilog, only equiv_induct is inductively incomplete on them under v0.67.