### PR TITLE
uhdm: register var_select writes in always_ff (2D unpacked array in n…

### DIFF
--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -508,6 +508,25 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
 
                         signals.push_back(sig);
                         log("extract_assigned_signals: Found assignment to bit select of '%s'\n", sig.name.c_str());
+                    } else if (lhs_expr->VpiType() == vpiVarSelect) {
+                        // Multi-index element write on a flattened array
+                        // (`my_array[i][j] <= …` on `logic m [1:0][5:0]`).  Report
+                        // the BASE wire as a PARTIAL write so the always_ff
+                        // lowering allocates one `$0\<base>` temp and a sync
+                        // update, and map_to_temp_wire remaps the per-bit write to
+                        // it.  Without this the multi-index write stayed
+                        // combinational in root_case with an EMPTY sync — the
+                        // register was lost entirely (check_mem/power_of_two).
+                        auto vsel = any_cast<const var_select*>(lhs_expr);
+                        std::string nm = std::string(vsel->VpiName());
+                        // A per-element-wire array (\arr[0]..) isn't covered by a
+                        // single base temp; leave those to the dynamic-write path.
+                        if (!nm.empty() && module->wire(RTLIL::escape_id(nm))) {
+                            sig.name = nm;
+                            sig.is_part_select = true;
+                            signals.push_back(sig);
+                            log("extract_assigned_signals: Found assignment to var select of '%s'\n", nm.c_str());
+                        }
                     } else if (lhs_expr->VpiType() == vpiHierPath) {
                         // Two distinct shapes share this VPI type:
                         //   1. Struct-field write — `internal_bus.field`

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -186,19 +186,14 @@ struct_little_endian_bit_array
 svtypes_struct_array
 
 # --- Yosys v0.67 upstream check_mem / memories additions ---
-# check_mem/init.sv (dynamic read of a 2D unpacked array) and check_mem/non_zero.sv
-#   (registered 1D unpacked array written in a `for (int i=1;i<=3;i++)` always_ff)
-#   were REAL UHDM bugs — both fixed in the frontend, so NOT listed here.
+# check_mem/init.sv (dynamic read of a 2D unpacked array), check_mem/non_zero.sv
+#   (registered 1D unpacked array written in a `for (int i=1;i<=3;i++)` always_ff),
+#   and check_mem/power_of_two.sv (2D unpacked `m[1:0][5:0]` written via a nested
+#   `m[i][j] <= …` var_select) were all REAL UHDM bugs — fixed in the frontend, so
+#   NOT listed here.
 # check_mem/sub_addr — miter proves UHDM == Verilog (equiv_induct incompleteness,
 #   not a real diff).
 check_mem/sub_addr.sv
-# check_mem/power_of_two — remaining genuine UHDM feature gap (TODO): a 2D unpacked
-#   array (`logic m [1:0][5:0]`) written in a NESTED always_ff for-loop via a
-#   two-index var_select (`m[i][j] <= …`).  The memwr-unroll path currently
-#   recognizes a single bit_select `m[<loop_var>]`, not a nested var_select, so the
-#   write is dropped.  Listed until the memwr path handles multi-index unpacked
-#   element writes.
-check_mem/power_of_two.sv
 # memories/wide_all — NOT a UHDM bug: Yosys v0.67's `synth` SEGFAULTS on this
 #   asymmetric wide-port memory for BOTH frontends (read_verilog crashes too).
 memories/wide_all.v


### PR DESCRIPTION
…ested loop)

Fixes check_mem/power_of_two.  A nested always_ff loop writing a flattened 2D unpacked array via a two-index var_select —
`for (i) for (j) my_array[i][j] <= in_data[i][j]` on `logic my_array [1:0][5:0]` — lost its register entirely: the process emitted the writes COMBINATIONALLY into root_case with an EMPTY `sync posedge`, so `my_array` became a plain wire (`my_array = in_data`, 0 $dff vs the Verilog frontend's 12).

Root cause: extract_assigned_signals handled ref_obj / part_select / bit_select / indexed_part_select / hier_path LHS types but NOT vpiVarSelect, so the multi-index element write recorded no assigned signal — no `$0\my_array` temp was created and no sync update was added.

Add a vpiVarSelect case that reports the base wire as a partial write (guarded on the base being a real module wire, leaving per-element-wire arrays to the dynamic path).  The always_ff lowering then allocates `$0\my_array` and emits `update \my_array $0\my_array` on the clock, giving a proper register.

Repro test/run/check_mem/power_of_two (now UHDM == Verilog, SAT-miter verified) — completes the check_mem family (init, non_zero, power_of_two all fixed). Regression clean: 0 true failures, 0 crashes, no new warnings.