### PR TITLE
uhdm: treat a `[size-1:0]` packed range with size==0 as a zero-width …

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2714,6 +2714,17 @@ int UhdmImporter::get_width_from_typespec(const UHDM::any* typespec, const UHDM:
                     RTLIL::SigSpec rs = import_expression(r->Right_expr());
                     force_const_fold = saved_fcf;
                     if (ls.is_fully_const() && rs.is_fully_const()) {
+                        // A `[size-1:0]` range with size==0 collapses to `[-1:0]`
+                        // (a negative MSB).  Real packed bit indices are never
+                        // negative, so a negative bound means an intended
+                        // zero-width field (e.g. `logic [CFG.BUS.CTL-1:0] ctl`
+                        // with CTL==0) — elide it instead of the bogus
+                        // abs()-derived width of 2.
+                        if (ls.as_int() < 0 || rs.as_int() < 0) {
+                            log("UHDM: logic_typespec simple range is empty "
+                                "([%d:%d]) -> width 0\n", ls.as_int(), rs.as_int());
+                            return 0;
+                        }
                         int range_size = std::abs(ls.as_int() - rs.as_int()) + 1;
                         log("UHDM: logic_typespec simple range width = %d\n", range_size);
                         return range_size;


### PR DESCRIPTION
…field

`logic [CFG.BUS.CTL-1:0] ctl` with `CFG.BUS.CTL == 0` folds to the range `[-1:0]`.  get_width_from_typespec()'s simple-range case computed the width as `abs(-1 - 0) + 1 == 2`, giving the struct member two phantom bits instead of eliding it.  In the rp32 Mouse SoC this injected two undriven `ctl` bits into every `tcb_lite_if` request struct (`tcb_cpu.req`) and shifted the layout of all fields above it.

Real packed bit indices are never negative — a negative bound can only arise from a `[size-1:0]` dimension collapsing with `size == 0`, which SystemVerilog treats as a zero-width (elided) field.  Return width 0 for that case.

Removes the two phantom `ctl` bits from the SoC (check problems 9 -> 8, the undriven-req-bit set drops the ctl bits, leaving only the genuinely CPU-undriven `lck`/`ndn`/`byt` fields).  No regression in the struct/interface suites.