### PR TITLE
uhdm: handle zero-width struct-field access (read + no-op write)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6905,6 +6905,17 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                         if (!found) { ok = false; break; }
                         off += moff; field_w = mw; cur_ts = mts;
                     }
+                    // A member resolved to zero width (`sub.req.ctl` with
+                    // CFG.BUS.CTL==0, `sub.rsp.sts` with STS==0) is a legitimate
+                    // empty field — return an empty SigSpec so the enclosing
+                    // no-op assignment (`man.req.ctl = sub.req.ctl`) drops out
+                    // silently instead of falling through to the "Could not
+                    // resolve struct member" warning.
+                    if (ok && field_w == 0 && off <= base_sig.size()) {
+                        log("    hier_path: interface signal struct member %s.* -> zero-width field\n",
+                            wname.c_str());
+                        return RTLIL::SigSpec();
+                    }
                     if (ok && field_w > 0 && off + field_w <= base_sig.size()) {
                         log("    hier_path: interface signal struct member %s.* -> [%d+:%d]\n",
                             wname.c_str(), off, field_w);

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1452,13 +1452,14 @@ void UhdmImporter::import_continuous_assign(const cont_assign* uhdm_assign) {
         log("    RHS constant: %s\n", rhs.as_const().as_string().c_str());
     }
     
-    // Debug: Check for empty signals
+    // A zero-width LHS is a no-op assignment — e.g. `man.req.ctl = sub.req.ctl`
+    // where the struct field has width 0 (CFG.BUS.CTL==0) or `sub.rsp.sts = '0`
+    // with STS==0.  There is nothing to drive; skip it silently instead of
+    // falling through to the connect logic (which throws on the empty vector).
     if (lhs.size() == 0) {
-        log_warning("Empty LHS in continuous assignment (generate scope: %s)\n", current_gen_scope.c_str());
-        if (lhs_expr) {
-            log_warning("  LHS expr type: %s (VpiType=%d)\n", 
-                UHDM::UhdmName(lhs_expr->UhdmType()).c_str(), lhs_expr->VpiType());
-        }
+        if (mode_debug)
+            log("    Zero-width LHS in continuous assignment (no-op) — skipping\n");
+        return;
     }
     if (rhs.size() == 0) {
         log_warning("Empty RHS in continuous assignment (generate scope: %s)\n", current_gen_scope.c_str());
@@ -1466,7 +1467,7 @@ void UhdmImporter::import_continuous_assign(const cont_assign* uhdm_assign) {
             log_warning("  RHS expr type: %s\n", UHDM::UhdmName(rhs_expr->UhdmType()).c_str());
         }
     }
-    
+
     // Handle size mismatch
     if (lhs.size() != rhs.size()) {
         if (rhs.size() == 1) {

--- a/test/iface_zero_width_field/dut.sv
+++ b/test/iface_zero_width_field/dut.sv
@@ -1,0 +1,55 @@
+// Interface struct with a parameter-computed ZERO-WIDTH field (CTL=0, STS=0):
+// `logic [BUS.CTL-1:0] ctl` folds to `[-1:0]` -> width 0.  Passthrough modules
+// copy the whole struct field-by-field, including the empty fields
+// (`man.req.ctl = sub.req.ctl`, `sub.rsp.sts = '0`).  Exercises 0-width struct
+// member access on both sides of a continuous assignment (read + no-op write).
+package p;
+  typedef struct { int unsigned CTL; int unsigned DAT; int unsigned STS; } bus_t;
+  localparam bus_t B = '{CTL:0, DAT:8, STS:0};
+  typedef struct packed {
+    logic              wen;
+    logic [B.CTL-1:0]  ctl;   // ZERO width
+    logic [B.DAT-1:0]  wdt;
+  } req_t;
+  typedef struct packed {
+    logic [B.DAT-1:0]  rdt;
+    logic [B.STS-1:0]  sts;   // ZERO width
+  } rsp_t;
+endpackage
+
+interface my_if import p::*; (input logic clk);
+  req_t req;
+  rsp_t rsp;
+  modport sub (input clk, input  req, output rsp);
+  modport man (input clk, output req, input  rsp);
+endinterface
+
+// Passthrough: copies every field, including the empty ctl/sts.
+module pass import p::*; (my_if.sub sub, my_if.man man);
+  assign man.req.wen = sub.req.wen;
+  assign man.req.ctl = sub.req.ctl;   // 0-width no-op
+  assign man.req.wdt = sub.req.wdt;
+  assign sub.rsp.rdt = man.rsp.rdt;
+  assign sub.rsp.sts = man.rsp.sts;   // 0-width no-op
+endmodule
+
+module top import p::*; (
+  input  logic       clk,
+  input  logic       in_wen,
+  input  logic [7:0] in_wdt,
+  input  logic [7:0] mem_rdt,
+  output logic       out_wen,
+  output logic [7:0] out_wdt,
+  output logic [7:0] out_rdt
+);
+  my_if a (.clk(clk));
+  my_if b (.clk(clk));
+  assign a.req.wen = in_wen;
+  assign a.req.wdt = in_wdt;
+  assign b.rsp.rdt = mem_rdt;
+  pass u (.sub(a), .man(b));
+  // observe the manager-side request and the subordinate-side response
+  assign out_wen = b.req.wen;
+  assign out_wdt = b.req.wdt;
+  assign out_rdt = a.rsp.rdt;
+endmodule


### PR DESCRIPTION
Companion to the zero-width packed-field fix: once `logic [CFG.BUS.CTL-1:0] ctl` (CTL==0) and `logic [CFG.BUS.STS-1:0] sts` (STS==0) correctly collapse to width 0, the interface passthrough/register modules access those empty fields directly — `assign man.req.ctl = sub.req.ctl`, `assign sub.rsp.sts = '0`.

Two gaps surfaced (rp32 Mouse SoC's tcb_lite passthrough/demux/mux/register modules), producing 26 "Could not resolve struct member access" warnings and, after the read side started returning an empty SigSpec, a `vector::reserve` crash on the write side:

- Interface-signal struct-member reader (expression.cpp): the resolver found the member but required `field_w > 0`, so a zero-width field fell through to the failing decodeHierPath + warning.  Return an empty SigSpec for a resolved zero-width member instead.

- Continuous-assignment importer (module.cpp): a zero-width (empty) LHS is a no-op — there is nothing to drive.  Return early instead of falling through to the connect logic, which threw on the empty chunk vector.

rp32 Mouse SoC: unresolved struct-member accesses 39 -> 13 (all `.ctl`/`.sts` gone; residual are the unrelated bare `CFG.HSK.DLY` array-size + `CFG.BUS.STS` param forms), check problems 8 -> 7, no crash.  New test iface_zero_width_field exercises 0-width field read and no-op write with observable passthrough outputs.  No regression in the struct/interface suites.