### PR TITLE
uhdm: handle typed named assignment patterns T'{field: value, ...}

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3610,6 +3610,63 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
         return result;
     }
 
+    // A TYPED named assignment pattern `T'{field: val, ...}` is emitted by
+    // Surelog as a cast (vpiCastOp) wrapping a CONCAT whose operands alternate
+    // (member-name ref_obj, value): the field-name keys leak in as unresolved
+    // refs — producing undriven phantom wires + "unknown signal" warnings — and
+    // the values are otherwise dropped (rp32 hamster/degu NOP = `op32_i_t'{...}`
+    // collapses to 0).  Detect this shape (each odd operand is a ref_obj naming
+    // a member of the cast's struct type) and build the struct value from the
+    // VALUE operands in member order, matching the non-cast `'{...}` path.
+    if (op_type == vpiCastOp && uhdm_op->Operands() &&
+        uhdm_op->Operands()->size() == 1) {
+        const struct_typespec* sts = nullptr;
+        if (auto rt = uhdm_op->Typespec())
+            if (auto at = rt->Actual_typespec())
+                if (at->UhdmType() == uhdmstruct_typespec)
+                    sts = any_cast<const struct_typespec*>(at);
+        auto inner = dynamic_cast<const UHDM::operation*>((*uhdm_op->Operands())[0]);
+        if (sts && sts->Members() && inner &&
+            inner->VpiOpType() == vpiConcatOp && inner->Operands() &&
+            inner->Operands()->size() == sts->Members()->size() * 2) {
+            auto& iops = *inner->Operands();
+            auto& mems = *sts->Members();
+            std::map<std::string, const UHDM::expr*> field_val;
+            bool tagged = true;
+            for (size_t i = 0; i < iops.size() && tagged; i += 2) {
+                auto key = dynamic_cast<const ref_obj*>(iops[i]);
+                auto val = dynamic_cast<const UHDM::expr*>(iops[i + 1]);
+                if (!key || !val) { tagged = false; break; }
+                std::string kn = std::string(key->VpiName());
+                bool is_member = false;
+                for (auto m : mems)
+                    if (std::string(m->VpiName()) == kn) { is_member = true; break; }
+                if (!is_member) { tagged = false; break; }
+                field_val[kn] = val;
+            }
+            if (tagged && field_val.size() == mems.size()) {
+                // Concat the per-field values in member order (first member =
+                // MSB), each sized to its member width.
+                RTLIL::SigSpec result;
+                for (int i = (int)mems.size() - 1; i >= 0; i--) {
+                    std::string mn = std::string(mems[i]->VpiName());
+                    int mw = 0;
+                    if (auto mt = mems[i]->Typespec())
+                        if (auto ma = mt->Actual_typespec())
+                            mw = get_width_from_typespec(
+                                const_cast<UHDM::typespec*>(ma), inst);
+                    RTLIL::SigSpec v = import_expression(field_val[mn], input_mapping);
+                    if (mw > 0) {
+                        if (v.size() < mw) v.extend_u0(mw);
+                        else if (v.size() > mw) v = v.extract(0, mw);
+                    }
+                    result.append(v);
+                }
+                return result;
+            }
+        }
+    }
+
     // Try to reduce it first (for non-side-effect operations). We skip
     // `vpiCastOp` here: Surelog's reduceExpr folds `8'(4'(signed'(...)))`
     // into a single constant but applies plain zero-extension at the

--- a/test/typed_named_pattern/dut.sv
+++ b/test/typed_named_pattern/dut.sv
@@ -1,0 +1,26 @@
+// A TYPED named assignment pattern `T'{field: value, ...}` (RISC-V NOP encoding
+// `op32_i_t'{imm_11_0: .., rs1: .., ...}` from rp32 hamster/degu).  Surelog
+// emits this as a cast wrapping a concat whose operands alternate
+// (member-name ref, value); the field-name keys previously leaked in as
+// undriven phantom wires and the whole value collapsed to 0.  The result must
+// equal the same pattern written without the type prefix.
+package q;
+  typedef struct packed { logic opc; logic [1:0] c11; } opcode_t;
+  typedef struct packed {
+    logic [11:0] imm_11_0;
+    logic [4:0]  rs1;
+    logic [2:0]  funct3;
+    logic [4:0]  rd;
+    opcode_t     opcode;
+  } op32_i_t;
+endpackage
+
+module typed_named_pattern import q::*; (
+  output logic [26:0] o_cast,   // typed   T'{...}
+  output logic [26:0] o_plain   // untyped   '{...}
+);
+  localparam op32_i_t NOP_CAST  = op32_i_t'{imm_11_0: 12'h123, rs1: 5'd5, funct3: 3'd2, rd: 5'd9, opcode: '{opc: 1'b1, c11: 2'b11}};
+  localparam op32_i_t NOP_PLAIN =           '{imm_11_0: 12'h123, rs1: 5'd5, funct3: 3'd2, rd: 5'd9, opcode: '{opc: 1'b1, c11: 2'b11}};
+  assign o_cast  = NOP_CAST;
+  assign o_plain = NOP_PLAIN;
+endmodule


### PR DESCRIPTION
Surelog emits a typed named assignment pattern (`op32_i_t'{imm_11_0: .., rs1: .., ...}` — the RISC-V NOP encoding in rp32 hamster/degu) as a cast (vpiCastOp) wrapping a CONCAT whose operands alternate (member-name ref_obj, value).  The front-end imported the concat literally: the field-name keys resolved to nothing, so each was created as an undriven phantom wire ("Reference to unknown signal: imm_11_0/rs1/funct3/rd/opcode") and the pattern value collapsed to 0 — breaking the hamster decoder (5 undriven top-level wires / 5 check problems). The equivalent untyped `'{...}` form (vpiAssignmentPatternOp) was already handled correctly.

Detect the shape in import_operation: a vpiCastOp to a struct type whose single operand is a concat with exactly 2×(member count) operands where every odd operand is a ref_obj naming a member of the struct.  Build the struct value from the VALUE operands, keyed by field name and concatenated in member order (first member = MSB), each sized to its member width — identical to the untyped path.

rp32 hamster: 5 undriven decode-field wires / 5 check problems -> 0.  New test typed_named_pattern verifies the typed `T'{...}` result is bit-identical to the untyped `'{...}` form.  No regression in the struct/pattern/union suites.