### PR TITLE
uhdm: always_comb partial struct-field write must drive only written …

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -2687,6 +2687,26 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
     // Clear current_comb_values for tracking signal values during processing
     current_comb_values.clear();
 
+    // Which base-wire bits does this comb process actually write?  When several
+    // struct FIELDS of one interface signal are assigned in an always_comb
+    // (rp32 r5p_lsu drives only `tcb.req.wen`/`.ren`) they collapse onto the
+    // base wire, but the STa update must drive ONLY those bits — the other
+    // fields (`tcb.req.lck`/`.ctl`/`.adr`/...) are driven by continuous assigns,
+    // and a full-width update would conflict with them ("Drivers conflicting
+    // with a constant 1'0 driver").
+    std::map<std::string, std::set<int>> comb_written_bits;
+    for (const auto& s : assigned_signals) {
+        if (!s.lhs_expr) continue;
+        RTLIL::SigSpec ls = import_expression(s.lhs_expr);
+        for (const auto& ch : ls.chunks())
+            if (ch.wire) {
+                std::string wn = ch.wire->name.str();
+                if (!wn.empty() && wn[0] == '\\') wn = wn.substr(1);
+                for (int b = 0; b < ch.width; b++)
+                    comb_written_bits[wn].insert(ch.offset + b);
+            }
+    }
+
     // Create sync always rule BEFORE statement import so task/function handlers can add entries
     RTLIL::SyncRule* sync_always = new RTLIL::SyncRule();
     sync_always->type = RTLIL::SyncType::STa;
@@ -2695,10 +2715,33 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
     for (const auto& [sig_name, temp_wire] : signal_temp_wires) {
         if (signal_specs.count(sig_name)) {
             RTLIL::SigSpec lhs_spec = signal_specs[sig_name];
-            sync_always->actions.push_back(
-                RTLIL::SigSig(lhs_spec, RTLIL::SigSpec(temp_wire))
-            );
-            log("    Added update: %s <= %s\n", log_signal(lhs_spec), temp_wire->name.c_str());
+            RTLIL::Wire* base_w = lhs_spec.is_wire() ? lhs_spec.as_wire() : nullptr;
+            auto wb = base_w ? comb_written_bits.find(sig_name)
+                             : comb_written_bits.end();
+            if (base_w && wb != comb_written_bits.end() &&
+                (int)wb->second.size() < base_w->width &&
+                (int)temp_wire->width == base_w->width) {
+                // Partially-written base wire: drive only the written bit runs.
+                RTLIL::SigSpec l, r;
+                int n = base_w->width, i = 0;
+                while (i < n) {
+                    if (!wb->second.count(i)) { i++; continue; }
+                    int j = i;
+                    while (j < n && wb->second.count(j)) j++;
+                    l.append(RTLIL::SigSpec(base_w).extract(i, j - i));
+                    r.append(RTLIL::SigSpec(temp_wire).extract(i, j - i));
+                    i = j;
+                }
+                sync_always->actions.push_back(RTLIL::SigSig(l, r));
+                log("    Added partial update: %s <= %s (%d/%d bits)\n",
+                    sig_name.c_str(), temp_wire->name.c_str(),
+                    (int)wb->second.size(), base_w->width);
+            } else {
+                sync_always->actions.push_back(
+                    RTLIL::SigSig(lhs_spec, RTLIL::SigSpec(temp_wire))
+                );
+                log("    Added update: %s <= %s\n", log_signal(lhs_spec), temp_wire->name.c_str());
+            }
         }
     }
 

--- a/test/comb_partial_struct_write/dut.sv
+++ b/test/comb_partial_struct_write/dut.sv
@@ -1,0 +1,35 @@
+// An always_comb that assigns only SOME fields of a wide interface/struct signal
+// (rp32 r5p_lsu drives only tcb.req.wen/.ren), while the other fields are driven
+// by continuous assigns (tcb.req.lck/.adr).  The comb process must update ONLY
+// the bits it writes; a full-width update collides with the continuous drivers
+// ("Drivers conflicting with a constant 1'0 driver").
+interface bus_if;
+  typedef struct packed { logic wen; logic ren; logic lck; logic [7:0] adr; } req_t;
+  req_t req;
+  modport man (output req);
+endinterface
+
+module drv (bus_if.man tcb, input logic sel, input logic [7:0] a);
+  always_comb begin
+    if (sel) begin tcb.req.wen = 1'b1; tcb.req.ren = 1'b0; end
+    else     begin tcb.req.wen = 1'b0; tcb.req.ren = 1'b1; end
+  end
+  assign tcb.req.lck = 1'b0;
+  assign tcb.req.adr = a;
+endmodule
+
+module comb_partial_struct_write (
+  input  logic       sel,
+  input  logic [7:0] a,
+  output logic       o_wen,   // sel ? 1 : 0
+  output logic       o_ren,   // sel ? 0 : 1
+  output logic       o_lck,   // 0
+  output logic [7:0] o_adr    // a
+);
+  bus_if tb ();
+  drv u (.tcb(tb), .sel(sel), .a(a));
+  assign o_wen = tb.req.wen;
+  assign o_ren = tb.req.ren;
+  assign o_lck = tb.req.lck;
+  assign o_adr = tb.req.adr;
+endmodule


### PR DESCRIPTION
…bits

When an always_comb assigns only SOME fields of a wide struct/interface signal (rp32 r5p_lsu drives `tcb.req.wen`/`.ren` in a comb block) and the other fields are driven by continuous assigns (`tcb.req.lck='0`, `.ctl='0`, `.adr=adr`, `.ndn=1'b0`, ...), import_always_comb collapsed the field writes onto the base wire and emitted a FULL-WIDTH `sync always: update \tcb.req $0\tcb.req`.  That re-drove every bit of the shared wire — including the continuously-assigned fields — producing a multi-driver "Drivers conflicting with a constant 1'0 driver" conflict (degu r5p_lsu; 1 check problem).

Restrict the STa update to the actually-written bits, mirroring the always_ff partial-write path: compute the base-wire bits assigned in the process body (extract_assigned_signals -> chunks) and, when the base wire is only partially written, drive just those contiguous runs (`\tcb.req[10:9] <= $0\tcb.req[10:9]`) instead of the whole wire.  Full-wire writes are unchanged (written == width).

Repro/test comb_partial_struct_write: comb-driven wen/ren coexist with the continuous lck/adr drivers, no conflict, all fields correct.  No regression.