### PR TITLE
uhdm: fix $paramod cell-type name for a wide '1 fill-literal default

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1764,19 +1764,12 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
                             has_params = true;
                         }
                     } else if (!val_str.empty()) {
-                        param_string += "\\" + param_name + "=s32'";
-                        // Determine numeric base from type prefix
-                        int base = 10;
-                        if (value_type == "BIN") base = 2;
-                        else if (value_type == "HEX") base = 16;
-                        try {
-                            int val = std::stoi(val_str, nullptr, base);
-                            for (int i = 31; i >= 0; i--) {
-                                param_string += ((val >> i) & 1) ? "1" : "0";
-                            }
-                        } catch (const std::exception& e) {
-                            param_string += "00000000000000000000000000000000";
-                        }
+                        // Use the shared 64-bit-safe, x/z-preserving encoder so a
+                        // `'1` fill default (BIN:111..1 = 2^32-1) matches the
+                        // module-definition name instead of overflowing stoi and
+                        // collapsing to zeros (rp32 gpio SYS_IRQ='1 -> blackbox).
+                        param_string += "\\" + param_name + "=s32'"
+                            + encode_param_bits32(value_type, val_str);
                         has_params = true;
                     }
                 }

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -241,8 +241,8 @@ YOSYS_NAMESPACE_BEGIN
 // x-defaulted params the same, colliding cell type).  Preserve x/z states
 // instead, LSB-aligned and zero-padded, so the name is well-formed and the
 // instance/definition encodings stay consistent.
-static std::string encode_param_bits32(const std::string& value_type,
-                                       const std::string& val_str) {
+std::string UhdmImporter::encode_param_bits32(const std::string& value_type,
+                                              const std::string& val_str) {
     int base = 10;
     if (value_type == "BIN") base = 2;
     else if (value_type == "HEX") base = 16;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -916,6 +916,14 @@ struct UhdmImporter {
                                          std::vector<int>& slice_offsets,
                                          std::vector<int>& slice_widths);
     
+    // Encode a UHDM parameter value (type prefix + digits) as the 32 binary
+    // chars after `s32'` in a $paramod cell-type name.  Uses std::stol (64-bit)
+    // and preserves x/z, so a 32-bit all-ones value (`'1` -> BIN:111..1 = 2^32-1)
+    // and don't-cares survive — std::stoi would overflow/throw and fall back to
+    // zeros, making the instance cell type differ from the module definition.
+    std::string encode_param_bits32(const std::string& value_type,
+                                    const std::string& val_str);
+
     // Width extraction helpers
     int get_width_from_typespec(const UHDM::any* typespec, const UHDM::scope* inst = nullptr);
     bool calculate_struct_member_offset(const UHDM::typespec* ts, const std::string& member_path, 

--- a/test/param_fill_default_paramod/dut.sv
+++ b/test/param_fill_default_paramod/dut.sv
@@ -1,0 +1,24 @@
+// A child instance whose `bit [W-1:0] MASK = '1` parameter (all-ones fill
+// default, width from another parameter) is NOT overridden.  The $paramod cell
+// type must encode MASK the same as the module definition: the elaborated value
+// is 2^W-1 (BIN:111..1), which std::stoi overflows/throws on for W=32 -> the old
+// code fell back to zeros, making the cell type differ from the definition
+// (blackbox / "Target module not found") — the rp32 mouse SoC gpio SYS_IRQ='1
+// case that left gpio_o undriven.
+module child #(
+  parameter int           W    = 8,
+  parameter bit           MIN  = 1'b0,
+  parameter bit [W-1:0]   IEN  = '0,
+  parameter bit [W-1:0]   MASK = '1
+) (input logic [W-1:0] a, output logic [W-1:0] o);
+  assign o = (a & MASK) | IEN;   // MASK all-ones -> o = a
+endmodule
+
+module param_fill_default_paramod #(parameter int W = 32) (
+  input  logic [W-1:0] a,
+  output logic [W-1:0] o
+);
+  generate if (1) begin : gen_c
+    child #(.W(W), .MIN(1'b1)) u (.a(a), .o(o));   // IEN/MASK defaulted
+  end endgenerate
+endmodule


### PR DESCRIPTION
import_instance built the $paramod cell-type name with std::stoi, which overflows/throws on a 32-bit all-ones value: a `bit [W-1:0] P = '1` default with W=32 elaborates to BIN:111..1 = 2^32-1 (> INT_MAX), so the catch fell back to 32 zeros.  The module DEFINITION name (built via the 64-bit encode_param_bits32) kept the correct all-ones, so the cell type (`P=s32'000..0`) no longer matched the definition (`P=s32'111..1`) → "Target module not found" → the module became a blackbox with undriven outputs.

In the rp32 mouse SoC this hit the GPIO device (`SYS_IRQ = '1`, defaulted): the `tcb_lite_dev_gpio` paramod was left unresolved and `gpio_o`/`gpio_e` (64 bits) were undriven (140 check problems).

Promote encode_param_bits32 to a UhdmImporter member (it was a file-static in uhdm2rtlil.cpp) and use it in import_instance's cell-type builder, so the instance and definition encodings are identical and x/z- and 2^32-1-safe.

mouse SoC: 140 -> 7 check problems, gpio_o/gpio_e fully driven, no "Target module not found".  New test param_fill_default_paramod (a defaulted `'1` mask param of width 32 in a generate scope).  No regression.