### PR TITLE
uhdm: memory-write always_ff partial struct-field register drives onl…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -2119,9 +2119,25 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                     std::map<const UHDM::expr*, RTLIL::Wire*> ff_reg_temp_map;
                     std::map<std::string, RTLIL::Wire*> ff_reg_temps;
                     std::map<std::string, RTLIL::SigSpec> ff_reg_specs;
+                    // Base-wire bits each registered signal actually writes.  A
+                    // struct FIELD write (`sub.rsp.rdt <= mem[adr]`) only touches
+                    // a slice; sibling fields (`sub.rsp.sts='0`, `.err`) are
+                    // driven by continuous assigns, so the clocked update must
+                    // drive ONLY the written bits — a full-width `\sub.rsp <=
+                    // $0\sub.rsp` conflicts with those constant drivers
+                    // (rp32 r5p_soc_memory / degu soc: memory-write always_ff).
+                    std::map<std::string, std::set<int>> ff_reg_written;
                     for (const auto& sig : ff_reg_signals) {
                         if (module->memories.count(RTLIL::escape_id(sig.name)))
                             continue;  // memory write — handled above
+                        if (sig.lhs_expr) {
+                            RTLIL::SigSpec ls = import_expression(sig.lhs_expr);
+                            RTLIL::IdString bw = RTLIL::escape_id(sig.name);
+                            for (const auto& ch : ls.chunks())
+                                if (ch.wire && ch.wire->name == bw)
+                                    for (int b = 0; b < ch.width; b++)
+                                        ff_reg_written[sig.name].insert(ch.offset + b);
+                        }
                         if (ff_reg_temps.count(sig.name)) {
                             if (sig.lhs_expr)
                                 ff_reg_temp_map[sig.lhs_expr] = ff_reg_temps[sig.name];
@@ -2192,10 +2208,32 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
 
                     // Latch the registered non-memory signals on the clock
                     // edge: \sig <= $0\sig (mirrors the normal always_ff path).
+                    // Restrict to the actually-written bits so a partial struct-
+                    // field register doesn't re-drive continuously-assigned
+                    // sibling fields of the same wide interface signal.
                     for (const auto& [sig_name, temp_wire] : ff_reg_temps) {
-                        sync->actions.push_back(
-                            RTLIL::SigSig(ff_reg_specs[sig_name], RTLIL::SigSpec(temp_wire)));
-                        log("      Added sync update for registered signal %s\n", sig_name.c_str());
+                        RTLIL::SigSpec lhs = ff_reg_specs[sig_name];
+                        auto wb = ff_reg_written.find(sig_name);
+                        if (lhs.is_wire() && (int)temp_wire->width == lhs.size() &&
+                            wb != ff_reg_written.end() &&
+                            (int)wb->second.size() < lhs.size()) {
+                            RTLIL::SigSpec l, r;
+                            int n = lhs.size(), i = 0;
+                            while (i < n) {
+                                if (!wb->second.count(i)) { i++; continue; }
+                                int j = i;
+                                while (j < n && wb->second.count(j)) j++;
+                                l.append(lhs.extract(i, j - i));
+                                r.append(RTLIL::SigSpec(temp_wire).extract(i, j - i));
+                                i = j;
+                            }
+                            sync->actions.push_back(RTLIL::SigSig(l, r));
+                            log("      Added sync update (written bits only) for %s\n", sig_name.c_str());
+                        } else {
+                            sync->actions.push_back(
+                                RTLIL::SigSig(lhs, RTLIL::SigSpec(temp_wire)));
+                            log("      Added sync update for registered signal %s\n", sig_name.c_str());
+                        }
                     }
 
                     yosys_proc->syncs.push_back(sync);

--- a/test/mem_ff_partial_rsp/dut.sv
+++ b/test/mem_ff_partial_rsp/dut.sv
@@ -1,0 +1,49 @@
+// A memory-write always_ff that also registers ONE field of a wide interface
+// signal (`sub.rsp.rdt <= mem[adr]`), while sibling fields are continuous
+// (`sub.rsp.sts='0`, `sub.rsp.err=1'b0`).  The clocked update must drive only
+// the written bits (rdt); a full-width `\sub.rsp <= $0\sub.rsp` collides with the
+// constant sts/err drivers (rp32 r5p_soc_memory / degu_soc, "Drivers
+// conflicting with a constant 1'0 driver").
+interface bus_if;
+  typedef struct packed { logic [31:0] rdt; logic sts; logic err; } rsp_t;
+  logic clk, trn, ren, wen;
+  logic [3:0]  byt;
+  logic [31:0] wdt;
+  logic [3:0]  adr;
+  rsp_t rsp;
+  modport sub (input clk, input trn, input ren, input wen, input byt,
+               input wdt, input adr, output rsp);
+endinterface
+
+module mem (bus_if.sub sub);
+  logic [31:0] m [0:15];
+  always @(posedge sub.clk)
+  if (sub.trn) begin
+    if (sub.ren) sub.rsp.rdt <= m[sub.adr];
+    if (sub.wen) begin
+      if (sub.byt[0]) m[sub.adr][ 7: 0] <= sub.wdt[ 7: 0];
+      if (sub.byt[1]) m[sub.adr][15: 8] <= sub.wdt[15: 8];
+      if (sub.byt[2]) m[sub.adr][23:16] <= sub.wdt[23:16];
+      if (sub.byt[3]) m[sub.adr][31:24] <= sub.wdt[31:24];
+    end
+  end
+  assign sub.rsp.sts = '0;
+  assign sub.rsp.err = 1'b0;
+endmodule
+
+module mem_ff_partial_rsp (
+  input  logic        clk, trn, ren, wen,
+  input  logic [3:0]  byt, adr,
+  input  logic [31:0] wdt,
+  output logic [31:0] o_rdt,   // registered read data
+  output logic        o_sts,   // 0
+  output logic        o_err    // 0
+);
+  bus_if b ();
+  assign b.clk=clk; assign b.trn=trn; assign b.ren=ren; assign b.wen=wen;
+  assign b.byt=byt; assign b.adr=adr; assign b.wdt=wdt;
+  mem u (.sub(b));
+  assign o_rdt = b.rsp.rdt;
+  assign o_sts = b.rsp.sts;
+  assign o_err = b.rsp.err;
+endmodule


### PR DESCRIPTION
…y written bits

A clocked block that both writes a memory AND registers ONE field of a wide interface signal (`always @(posedge clk) if (trn) begin if (ren) sub.rsp.rdt <= mem[adr]; if (wen) mem[adr][..]<=wdt; end` in rp32's r5p_soc_memory) is routed to the byte-enable memory-write path.  That path latched the registered non-memory signals with a FULL-WIDTH `\sub.rsp <= $0\sub.rsp`, re-driving the sibling fields (`sub.rsp.sts='0`, `sub.rsp.err=1'b0`, driven by continuous assigns) — a multi-driver "Drivers conflicting with a constant 1'0 driver" conflict on the shared wire (mouse_soc / degu_soc).

The other always_ff paths already restrict the sync to the written bits; do the same here.  Track, per base wire, which bits each registered field write touches (extract_assigned_signals -> import_expression chunks), and when the wire is only partially written drive just those contiguous runs (`\sub.rsp[33:2] <= $0\sub.rsp[33:2]`) instead of the whole wire.

mouse_soc 7 -> 6, degu_soc 5 -> 4 check problems (the conflict cleared; the residual are the known CPU-undriven tcb.req control/byte fields).  New test mem_ff_partial_rsp.  No regression.