### PR TITLE
uhdm: treat an empty named port connection (.port()) as unconnected

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1921,7 +1921,20 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
             if (port->High_conn()) {
                 const any* high_conn = port->High_conn();
                 log("    Port %s has High_conn of type %s\n", port_name.c_str(), UhdmName(high_conn->UhdmType()).c_str());
-                
+
+                // An explicitly EMPTY named port connection (`.tcb_xen()`) is
+                // encoded by Surelog as a `vpiNullOp` operation.  It means "leave
+                // this port unconnected" — there is no signal to import, so skip
+                // it (passing the null op to import_expression would warn
+                // "Unsupported operation type: 36").  rp32 SoC: `r5p_mouse`'s
+                // unused `tcb_xen` execute-enable output is tied off this way.
+                if (high_conn->UhdmType() == uhdmoperation &&
+                    any_cast<const operation*>(high_conn)->VpiOpType() == vpiNullOp) {
+                    log("    Port %s has an empty connection (.%s()); leaving unconnected\n",
+                        port_name.c_str(), port_name.c_str());
+                    continue;
+                }
+
                 // Check if this is an interface connection
                 if (high_conn->UhdmType() == uhdmref_obj) {
                     const ref_obj* ref = any_cast<const ref_obj*>(high_conn);

--- a/src/frontends/uhdm/ref_module.cpp
+++ b/src/frontends/uhdm/ref_module.cpp
@@ -119,7 +119,19 @@ void UhdmImporter::import_ref_module(const ref_module* ref_mod) {
                         log("    Skipping interface port connection: %s (hier_path type)\n", port_name.c_str());
                     continue;
                 }
-                
+
+                // An explicitly EMPTY named port connection (`.tcb_xen()`) is a
+                // `vpiNullOp` operation: leave the port unconnected rather than
+                // importing the null op (which warns "Unsupported operation
+                // type: 36").  rp32 SoC r5p_mouse `.tcb_xen()` unused output.
+                if (port->High_conn()->UhdmType() == uhdmoperation &&
+                    any_cast<const UHDM::operation*>(port->High_conn())->VpiOpType() == vpiNullOp) {
+                    if (mode_debug)
+                        log("    Port %s has an empty connection (.%s()); leaving unconnected\n",
+                            port_name.c_str(), port_name.c_str());
+                    continue;
+                }
+
                 RTLIL::SigSpec actual_sig = import_expression(any_cast<const expr*>(port->High_conn()));
                 cell->setPort(RTLIL::escape_id(port_name), actual_sig);
                 

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2148,6 +2148,17 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                     continue;
                                 }
                             }
+                            // An explicitly EMPTY named port connection
+                            // (`.tcb_xen()`) is a `vpiNullOp` operation: leave the
+                            // port unconnected rather than importing the null op
+                            // (which warns "Unsupported operation type: 36").
+                            // rp32 SoC: r5p_mouse's unused `tcb_xen` output.
+                            if (port->High_conn()->UhdmType() == uhdmoperation &&
+                                any_cast<const operation*>(port->High_conn())->VpiOpType() == vpiNullOp) {
+                                log("UHDM: Port %s has an empty connection (.%s()); leaving unconnected\n",
+                                    port_name.c_str(), port_name.c_str());
+                                continue;
+                            }
                             const expr* high_conn = any_cast<const expr*>(port->High_conn());
                             RTLIL::SigSpec conn = import_expression(high_conn);
 

--- a/test/empty_port_connection/dut.sv
+++ b/test/empty_port_connection/dut.sv
@@ -1,0 +1,35 @@
+// Minimal repro for an explicitly EMPTY named port connection: `.unused()`.
+//
+// Surelog encodes an empty named port connection as a `vpiNullOp` operation in
+// the port's vpiHighConn.  The UHDM frontend must treat it as "leave this port
+// unconnected", NOT pass it to import_operation (which warned "Unsupported
+// operation type: 36" and produced no port binding).
+//
+// Reduced from the rp32 mouse SoC, where `r5p_mouse`'s unused `tcb_xen`
+// execute-enable output is tied off as `.tcb_xen()`.
+//
+// Structured for observability: `sub`'s used output `sum` drives the top output
+// `y`, while its second output `carry` is left unconnected via `.carry()`.  The
+// design is fully equivalent between the UHDM and Verilog front ends.
+
+module adder_with_carry (
+  input  logic [7:0] a,
+  input  logic [7:0] b,
+  output logic [7:0] sum,
+  output logic       carry   // deliberately left unconnected by the parent
+);
+  assign {carry, sum} = a + b;
+endmodule
+
+module empty_port_connection (
+  input  logic [7:0] a,
+  input  logic [7:0] b,
+  output logic [7:0] y
+);
+  adder_with_carry u_add (
+    .a     (a),
+    .b     (b),
+    .sum   (y),
+    .carry (      )   // empty named port connection -> vpiNullOp
+  );
+endmodule


### PR DESCRIPTION
An explicitly empty named port connection — `.tcb_xen()` — is encoded by Surelog as a `vpiNullOp` operation in the port's vpiHighConn.  All three port-connection paths passed that null op to import_expression / import_operation, which has no vpiNullOp case, so each emitted "Unsupported operation type: 36" and produced no binding.

Detect a vpiNullOp High_conn and skip it (leave the port unconnected — which is exactly what an empty connection means) in all three sites:
  - uhdm2rtlil.cpp import_module_hierarchy (top-level instances; primary)
  - module.cpp   import_instance
  - ref_module.cpp ref-module port loop

Reduced from the rp32 mouse/degu SoCs, where r5p_mouse's unused `tcb_xen` execute-enable output is tied off as `.tcb_xen()`.

Repro test/empty_port_connection: a submodule whose `carry` output is left unconnected via `.carry()`; UHDM and Verilog frontends both synthesise 38 gates and pass formal equivalence.  The two SoCs lose the "Unsupported operation type: 36" warning (22 -> 18 warnings) with an unchanged netlist / undriven floor.