### PR TITLE
uhdm: route a continuous-assign connect to the module owning its LHS …

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1322,6 +1322,20 @@ void UhdmImporter::import_net(const net* uhdm_net, const UHDM::instance* inst) {
 }
 
 // Import a continuous assignment
+// A continuous assignment's connect must land in the module that OWNS the LHS
+// wire.  Returns that module when all LHS wire chunks share a single owner that
+// differs from `fallback` (this->module); otherwise returns `fallback`.
+static RTLIL::Module* connect_target_module(RTLIL::Module* fallback,
+                                            const RTLIL::SigSpec& lhs) {
+    RTLIL::Module* owner = nullptr;
+    for (auto &ch : lhs.chunks()) {
+        if (!ch.wire) continue;
+        if (owner == nullptr) owner = ch.wire->module;
+        else if (owner != ch.wire->module) return fallback;  // mixed owners → don't redirect
+    }
+    return (owner && owner != fallback) ? owner : fallback;
+}
+
 void UhdmImporter::import_continuous_assign(const cont_assign* uhdm_assign) {
     if (mode_debug)
         log("  Importing continuous assignment\n");
@@ -1564,8 +1578,20 @@ void UhdmImporter::import_continuous_assign(const cont_assign* uhdm_assign) {
                 log("  Created continuous assignment for net declaration with non-constant expression\n");
         }
     } else {
-        // Regular continuous assignment
-        module->connect(lhs, rhs);
+        // Regular continuous assignment.
+        //
+        // A continuous assignment must drive a wire in ITS OWN module.  Surelog's
+        // elaborated model can attach a parent module's `assign` to a deeply
+        // nested child instance's Cont_assigns() (rp32 SoC: the SoC top's
+        // `assign tcb_cpu.req.lck/ndn = 1'b0` tie-offs surface in the
+        // tcb_dev_uart_des `rx_des` instance).  The LHS then resolves — via the
+        // global name_map — to the parent's wire (`\tcb_cpu.req`, owned by
+        // r5p_mouse_soc_top), and connecting it into the child module produces a
+        // cross-module SigChunk that aborts write_rtlil ("chunk_.wire->module ==
+        // mod") and leaves the parent's bits undriven.  Route the connect to the
+        // module that actually owns the LHS wire.
+        RTLIL::Module* tgt = connect_target_module(module, lhs);
+        tgt->connect(lhs, rhs);
     }
 }
 

--- a/test/skipped_tests.txt
+++ b/test/skipped_tests.txt
@@ -29,11 +29,3 @@ various/shregmap.v        # `module $__SHREG_DFF_P_` and `module $__XILINX_SHREG
 # via test/rand_const/dut.sv.
 various/rand_const.sv     # `rand` modifier at module scope (non-LRM)
 
-# Full Mouse SoC — the UHDM frontend reads and FUNCTIONALLY simulates it (boots
-# the boot program and drives GPIO correctly; see soc_functional_sim.sh), but
-# the standard `synth -auto-top` path asserts `chunk_.wire->module == mod`
-# (kernel/rtlil.cc) on a cross-module wire reference specific to this top.  That
-# is a separate, still-open synth-path bug; skipped from the standard equivalence
-# suite so it doesn't crash the run, while remaining available for functional
-# simulation (./soc_functional_sim.sh rp32_r5p_mouse_soc_top).
-rp32_r5p_mouse_soc_top    # functional-sim only; synth -auto-top asserts (open bug)


### PR DESCRIPTION
…wire

The full rp32 mouse_soc_top crashed `write_rtlil` / `synth` with `Assert chunk_.wire->module == mod` (kernel/rtlil.cc): a SigChunk in module `\tcb_dev_uart_des` referenced wire `\tcb_cpu.req`, which is owned by `\r5p_mouse_soc_top`.

Root cause: Surelog's elaborated model attaches the SoC top's tie-off assignments `assign tcb_cpu.req.lck/ndn = 1'b0` to the `Cont_assigns()` of a deeply-nested child instance (`tcb_dev_uart_des` inst `rx_des`), even though the UHDM tree places the cont_assign correctly under r5p_mouse_soc_top. `import_module(rx_des)` then iterates that foreign assign; its LHS `tcb_cpu.req` resolves — via the global name_map — to the parent's wire, and the connect is added to the child module, producing a cross-module chunk.  This also left the parent's `req.lck/ndn` (and the cascaded `req.byt`) bits undriven — the long-standing "benign undriven req[70]/[73]/[32-35]" was this bug.

Fix (import_continuous_assign): a continuous assignment must drive a wire in its own module.  `connect_target_module()` returns the module that owns the LHS wire when all LHS chunks share a single owner that differs from `this->module`, and the connect is emitted there.  The normal case (LHS wire in the current module) is unchanged.

Result: mouse_soc / degu_soc undriven wires 6 -> 0 (fully clean); write_rtlil and `synth -auto-top` no longer abort; rp32_r5p_mouse_soc_top now passes the standard workflow, so it is un-skipped from test/skipped_tests.txt.  Full regression: 0 crashes, no new failures (the 4 remaining unexpected failures — ibex_core/cs_registers/icache/register_file_fpga — all pre-date this change).