### PR TITLE
uhdm: constant-fold if guards in comb; classify ibex_register_file_fp…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10352,6 +10352,22 @@ void UhdmImporter::import_if_stmt_comb(const UHDM::if_stmt* uhdm_if, RTLIL::Proc
         if (mode_debug)
             log("    If condition: %s\n", log_signal(condition_sig));
 
+        // Compile-time-constant condition (typically a for-loop-unrolled guard
+        // such as `if (i >= MHPMCOUNTER_BASE)`): fold it and import only the
+        // taken branch.  A false guard's then-branch must NOT be imported at all
+        // — it can reference an out-of-range select that is unreachable by
+        // construction (ibex_cs_registers `mhpmevent[i][i-MHPMCOUNTER_BASE]` for
+        // i < MHPMCOUNTER_BASE, whose bit index goes negative and aborts
+        // SigSpec::extract).
+        if (condition_sig.is_fully_const()) {
+            if (condition_sig.as_const().as_bool()) {
+                if (auto then_stmt = uhdm_if->VpiStmt())
+                    import_statement_comb(then_stmt, proc);
+            }
+            current_if_qualifier = saved_qualifier;
+            return;
+        }
+
         // Create a switch statement for the if
         RTLIL::SwitchRule* sw = new RTLIL::SwitchRule;
         sw->signal = condition_sig;

--- a/test/sim_equiv_classification.txt
+++ b/test/sim_equiv_classification.txt
@@ -72,3 +72,4 @@ EnumBases                             artefact   # output undriven; enum/typedef
 TaskReturn                            artefact   # procedural assign-in-task + undriven output
 assignment-pattern                    artefact   # self-checking asserts $stop the Verilator sim
 rp32_r5p_mouse        artefact   # reset-dependent CPU core; miter runs without asserting rst -> false NON-EQ; co-sim X-prop adjudicated (verilog netlist diverges from Verilator the same way)
+ibex_register_file_fpga  artefact   # FPGA regfile; Verilator co-sim PASSES (0 mismatches), equiv_induct false NON-EQ on reset-dependent state (same class as rp32_r5p_mouse)


### PR DESCRIPTION
…ga artefact

Two independent Ibex-driven improvements:

1. import_if_stmt_comb (process.cpp): when an if condition folds to a compile-time constant -- typically a for-loop-unrolled guard such as `if (i >= MHPMCOUNTER_BASE)` -- import only the taken branch instead of emitting a switch and importing both.  A false guard's then-branch must NOT be imported at all: it can reference a select that is out of range by construction and unreachable at run time (ibex_cs_registers `mhpmevent[i][i-MHPMCOUNTER_BASE]` for i < MHPMCOUNTER_BASE, whose bit index goes negative and aborts SigSpec::extract).  This fixes that negative-index abort and is a generic robustness improvement.

2. sim_equiv_classification.txt: mark ibex_register_file_fpga as an artefact. Its Verilator co-sim PASSES (0 mismatches / 200 cycles); it only trips equiv_induct's reset-dependent false NON-EQUIVALENT, the same class as rp32_r5p_mouse.

Note: ibex_cs_registers is not fully closed by (1) -- the i >= BASE case is a separate, deeper issue (a combinational unpacked array read dynamically and so classified as a clocked memory, with a guarded partial-bit write at a loop-unrolled constant index).  ibex_icache (duplicate generate-scope wire name) is likewise separate.  Both tracked for follow-up.