### PR TITLE
uhdm: unique $memwr helper-wire names in the simple-if-else memory path

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -1491,10 +1491,17 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                         RTLIL::IdString mem_id = RTLIL::escape_id(mem_name);
                         RTLIL::Memory* mem = module->memories.at(mem_id);
                         
-                        // Create temp wires for memory write signals
-                        std::string addr_wire_name = stringf("$memwr$\\%s$addr", mem_name.c_str());
-                        std::string data_wire_name = stringf("$memwr$\\%s$data", mem_name.c_str());
-                        std::string en_wire_name = stringf("$memwr$\\%s$en", mem_name.c_str());
+                        // Create temp wires for memory write signals.  The
+                        // unique `$%d` suffix (incr_autoidx, as every other
+                        // memwr-wire site uses) is REQUIRED: the same array can
+                        // be written from several always blocks — ibex_icache's
+                        // `fill_addr_q[fb]` is written by NUM_FB per-feedback-
+                        // buffer always_ff blocks — and without it the second
+                        // block re-adds `$memwr$\fill_addr_q$addr` and aborts
+                        // Module::add (count_id == 0).
+                        std::string addr_wire_name = stringf("$memwr$\\%s$addr$%d", mem_name.c_str(), incr_autoidx());
+                        std::string data_wire_name = stringf("$memwr$\\%s$data$%d", mem_name.c_str(), incr_autoidx());
+                        std::string en_wire_name = stringf("$memwr$\\%s$en$%d", mem_name.c_str(), incr_autoidx());
                         
                         // Calculate address width from memory size
                         int addr_width = 1;

--- a/test/mem_multi_always_write/dut.sv
+++ b/test/mem_multi_always_write/dut.sv
@@ -1,0 +1,26 @@
+// Minimal repro: one unpacked array (memory) written from SEVERAL always_ff
+// blocks (one per element, via a generate for-loop).  The frontend's
+// simple-if-else memory-write path created a fixed-named `$memwr$\mem$addr`
+// helper wire per block; the second block re-added the same name and aborted
+// Module::add (count_id == 0).  Reduced from ibex_icache, where a generate
+// `for (fb)` loop makes NUM_FB always_ff blocks each writing `fill_addr_q[fb]`.
+// mem is zero-initialised so RTL and netlist agree on the never-written entries.
+module mem_multi_always_write #(parameter int N = 4) (
+  input  logic           clk,
+  input  logic [N-1:0]   we,
+  input  logic [N*8-1:0] d,     // packed: element i is d[i*8 +: 8]
+  input  logic [1:0]     radr,
+  output logic [7:0]     q
+);
+  logic [7:0] mem [N];
+  initial for (int k = 0; k < N; k++) mem[k] = '0;
+
+  generate
+    for (genvar i = 0; i < N; i++) begin : g_wr
+      always_ff @(posedge clk)
+        if (we[i]) mem[i] <= d[i*8 +: 8];
+    end
+  endgenerate
+
+  assign q = mem[radr];
+endmodule


### PR DESCRIPTION
ibex_icache aborted UHDM import with
  log_assert(count_id(wire->name) == 0)  (Module::add)
on a duplicate wire `$memwr$\fill_addr_q$addr`.

`fill_addr_q` is an unpacked-array (memory) written by NUM_FB per-feedback- buffer always_ff blocks (`fill_addr_q[fb] <= ...`, one block per element from a generate for-loop).  The simple-if-else memory-write path in import_always created the memwr address/data/enable helper wires with a FIXED name (`$memwr$\<mem>$addr`), with no per-instance suffix, so the second block that writes the same array re-added the identical wire name and aborted.

Give those three wires the same unique `$%d` (incr_autoidx) suffix that every other memwr-wire site already uses.  ibex_icache now imports AND fully synthesises (previously it asserted during import).

Repro test/mem_multi_always_write: one memory written from N generate-loop always_ff blocks (one element each).  Imports cleanly, formal equivalence PASSES, SAT miter EQUIVALENT, Verilator co-sim PASS (0 mismatches).