### PR TITLE
uhdm: expand comb-only arrays written in gen-scope/named-block loops …

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -9365,10 +9365,23 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
             RTLIL::IdString mem_id_check = RTLIL::escape_id(bs_name);
             RTLIL::Wire* first_elem = !module->memories.count(mem_id_check)
                 ? module->wire(RTLIL::escape_id(bs_name + "[0]")) : nullptr;
-            if (first_elem && bs->VpiIndex() && bs->VpiIndex()->VpiType() != vpiConstant) {
+            // The index is only *truly* dynamic if it does not resolve to a
+            // constant.  Inside an unrolled for-loop the index is a `ref_obj`
+            // (VpiType != vpiConstant) but resolves to a constant via
+            // loop_values — checking the raw node type alone would wrongly take
+            // the per-element mux path and emit `\arr[i] = mux(\arr[i], rhs,
+            // addr==i)`, a self-referential combinational loop (Ibex
+            // gen_mhpmevent's `for(i) mhpmevent[i]='0`).  Resolve the index and
+            // only treat it as dynamic when it is not fully constant.
+            RTLIL::SigSpec resolved_idx;
+            bool idx_is_dynamic = false;
+            if (first_elem && bs->VpiIndex()) {
+                resolved_idx = import_expression(bs->VpiIndex(), comb_read_map());
+                idx_is_dynamic = !resolved_idx.is_fully_const();
+            }
+            if (first_elem && bs->VpiIndex() && idx_is_dynamic) {
                 // Dynamic write to expanded array
-                RTLIL::SigSpec dyn_addr = import_expression(bs->VpiIndex(),
-                    comb_read_map());
+                RTLIL::SigSpec dyn_addr = resolved_idx;
 
                 RTLIL::SigSpec dyn_rhs;
                 if (auto rhs_any = uhdm_assign->Rhs()) {

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2799,7 +2799,7 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
     // Such arrays must NOT be created as $memory objects; instead they get individual
     // element wires so that write-then-read semantics work correctly in the same block.
     comb_only_arrays.clear();
-    if (uhdm_module->Process()) {
+    {
         // Collect which array names are touched by clocked vs combinational always blocks.
         std::set<std::string> clocked_access;
         std::set<std::string> any_access;
@@ -2816,12 +2816,40 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                 if (bs) collect_array_accesses(bs->VpiIndex(), out);
                 return;
             }
+            if (stmt->VpiType() == vpiVarSelect) {
+                auto vs = any_cast<const var_select*>(stmt);
+                if (vs && !vs->VpiName().empty())
+                    out.insert(std::string(vs->VpiName()));
+                if (vs && vs->Exprs())
+                    for (auto e : *vs->Exprs()) collect_array_accesses(e, out);
+                return;
+            }
             // Recurse into child nodes that may contain statements/expressions
             auto recurse = [&](const any* n) { collect_array_accesses(n, out); };
             switch (stmt->VpiType()) {
-                case vpiBegin: case vpiNamedBegin: {
+                case vpiBegin: {
+                    // named_begin is NOT a subclass of begin (both derive from
+                    // scope), so vpiBegin and vpiNamedBegin need distinct casts.
                     auto b = any_cast<const begin*>(stmt);
                     if (b && b->Stmts()) for (auto s : *b->Stmts()) recurse(s);
+                    break;
+                }
+                case vpiNamedBegin: {
+                    auto b = any_cast<const named_begin*>(stmt);
+                    if (b && b->Stmts()) for (auto s : *b->Stmts()) recurse(s);
+                    break;
+                }
+                case vpiCase: {
+                    auto cs = any_cast<const case_stmt*>(stmt);
+                    if (cs) {
+                        recurse(cs->VpiCondition());
+                        if (cs->Case_items())
+                            for (auto it : *cs->Case_items()) {
+                                if (it->VpiExprs())
+                                    for (auto e : *it->VpiExprs()) recurse(e);
+                                recurse(it->Stmt());
+                            }
+                    }
                     break;
                 }
                 case vpiAssignment: case vpiAssignStmt: {
@@ -2844,6 +2872,11 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                     if (ec) recurse(ec->Stmt());
                     break;
                 }
+                case vpiFor: {
+                    auto fs = any_cast<const for_stmt*>(stmt);
+                    if (fs) recurse(fs->VpiStmt());
+                    break;
+                }
                 case vpiOperation: {
                     auto op = any_cast<const operation*>(stmt);
                     if (op && op->Operands()) for (auto o : *op->Operands()) recurse(o);
@@ -2853,7 +2886,36 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
             }
         };
 
-        for (auto proc : *uhdm_module->Process()) {
+        // Gather all always blocks: module-level Process() PLUS every always
+        // block nested inside generate scopes (gen_scope_array -> gen_scope ->
+        // Process(), recursively).  Ibex's gen_mhpmevent writes `mhpmevent`
+        // from a combinational always INSIDE a generate for-loop, so scanning
+        // only module->Process() would miss it and the array would wrongly be
+        // inferred as a $mem.
+        std::vector<const process_stmt*> all_procs;
+        std::function<void(const module_inst*)> collect_procs_mod;
+        std::function<void(const gen_scope*)> collect_procs_gs;
+        collect_procs_gs = [&](const gen_scope* gs) {
+            if (!gs) return;
+            if (gs->Process())
+                for (auto p : *gs->Process()) all_procs.push_back(p);
+            if (gs->Gen_scope_arrays())
+                for (auto gsa : *gs->Gen_scope_arrays())
+                    if (gsa->Gen_scopes())
+                        for (auto inner : *gsa->Gen_scopes()) collect_procs_gs(inner);
+        };
+        collect_procs_mod = [&](const module_inst* m) {
+            if (!m) return;
+            if (m->Process())
+                for (auto p : *m->Process()) all_procs.push_back(p);
+            if (m->Gen_scope_arrays())
+                for (auto gsa : *m->Gen_scope_arrays())
+                    if (gsa->Gen_scopes())
+                        for (auto gs : *gsa->Gen_scopes()) collect_procs_gs(gs);
+        };
+        collect_procs_mod(uhdm_module);
+
+        for (auto proc : all_procs) {
             if (proc->VpiType() != vpiAlways) continue;
             auto always_obj = any_cast<const always*>(proc);
             if (!always_obj) continue;
@@ -3039,21 +3101,23 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                         // Get the first unpacked dimension (array size)
                         auto first_range = (*ranges)[0];
                         int array_size = 4;  // Default
-                        if (first_range->Left_expr() && first_range->Right_expr()) {
-                            // Get constants from expressions
-                            if (first_range->Left_expr()->VpiType() == vpiConstant &&
-                                first_range->Right_expr()->VpiType() == vpiConstant) {
-                                const constant* left_const = any_cast<const constant*>(first_range->Left_expr());
-                                const constant* right_const = any_cast<const constant*>(first_range->Right_expr());
-                                // Get the integer values using helper function
-                                std::string left_str(left_const->VpiValue());
-                                std::string right_str(right_const->VpiValue());
-                                RTLIL::Const left_const_val = extract_const_from_value(left_str);
-                                RTLIL::Const right_const_val = extract_const_from_value(right_str);
-                                int left = left_const_val.size() > 0 ? left_const_val.as_int() : 3;
-                                int right = right_const_val.size() > 0 ? right_const_val.as_int() : 0;
-                                array_size = std::abs(left - right) + 1;
+                        // Range bounds may be a literal `vpiConstant` OR an
+                        // expression (e.g. `[0 : 32-1]` where the right bound is
+                        // a `vpiOperation` 32-1).  Fold either through
+                        // import_expression so `logic [..] a [32]` is sized 32,
+                        // not the fallback 4 (Ibex mhpmevent[32]).
+                        auto eval_bound = [&](const any* node, int dflt) -> int {
+                            if (!node) return dflt;
+                            if (auto e = dynamic_cast<const expr*>(node)) {
+                                RTLIL::SigSpec s = import_expression(e);
+                                if (s.is_fully_const()) return s.as_const().as_int();
                             }
+                            return dflt;
+                        };
+                        if (first_range->Left_expr() && first_range->Right_expr()) {
+                            int left = eval_bound(first_range->Left_expr(), 3);
+                            int right = eval_bound(first_range->Right_expr(), 0);
+                            array_size = std::abs(left - right) + 1;
                         }
                         
                         // Get the packed width from the underlying variable
@@ -4031,21 +4095,20 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                     int array_size = 4; // Default for cases like M[3:0]
                     if (array->Ranges() && !array->Ranges()->empty()) {
                         auto first_range = (*array->Ranges())[0];
-                        if (first_range->Left_expr() && first_range->Right_expr()) {
-                            // Get constants from expressions
-                            if (first_range->Left_expr()->VpiType() == vpiConstant &&
-                                first_range->Right_expr()->VpiType() == vpiConstant) {
-                                const constant* left_const = any_cast<const constant*>(first_range->Left_expr());
-                                const constant* right_const = any_cast<const constant*>(first_range->Right_expr());
-                                // Get the integer values using helper function
-                                std::string left_str(left_const->VpiValue());
-                                std::string right_str(right_const->VpiValue());
-                                RTLIL::Const left_const_val = extract_const_from_value(left_str);
-                                RTLIL::Const right_const_val = extract_const_from_value(right_str);
-                                int left = left_const_val.size() > 0 ? left_const_val.as_int() : 3;
-                                int right = right_const_val.size() > 0 ? right_const_val.as_int() : 0;
-                                array_size = std::abs(left - right) + 1;
+                        // Bounds may be literal constants or expressions
+                        // (e.g. `[0 : N-1]`); fold either via import_expression.
+                        auto eval_bound = [&](const any* node, int dflt) -> int {
+                            if (!node) return dflt;
+                            if (auto e = dynamic_cast<const expr*>(node)) {
+                                RTLIL::SigSpec s = import_expression(e);
+                                if (s.is_fully_const()) return s.as_const().as_int();
                             }
+                            return dflt;
+                        };
+                        if (first_range->Left_expr() && first_range->Right_expr()) {
+                            int left = eval_bound(first_range->Left_expr(), 3);
+                            int right = eval_bound(first_range->Right_expr(), 0);
+                            array_size = std::abs(left - right) + 1;
                         }
                     }
                     

--- a/test/comb_2d_bitsel/dut.sv
+++ b/test/comb_2d_bitsel/dut.sv
@@ -1,0 +1,27 @@
+// Combinational LUT built in a named always_comb with an unrolled for-loop,
+// writing a per-element bit-select, plus a dynamic-index read.
+// Mirrors Ibex ibex_cs_registers gen_mhpmevent:
+//   * comb array written only in a combinational block (must NOT become $mem)
+//   * array size given by an expression bound `[0 : N-1]`
+//   * `for(i) arr[i]='0; if(i>=B) arr[i][i-B]=1'` — loop-unrolled constant index
+//   * dynamic read `arr[sel]`
+module comb_2d_bitsel #(
+    parameter int N = 8,
+    parameter int B = 3
+) (
+    input  logic [$clog2(N)-1:0] sel,
+    output logic [N-1:0]         y
+);
+    logic [N-1:0] lut [0:N-1];
+
+    always_comb begin : gen_lut
+        for (int i = 0; i < N; i++) begin
+            lut[i] = '0;
+            if (i >= B) begin
+                lut[i][i - B] = 1'b1;
+            end
+        end
+    end
+
+    assign y = lut[sel];
+endmodule


### PR DESCRIPTION
…(Ibex cs_registers)

ibex_cs_registers aborted UHDM import with
  log_assert(offset + length <= size())  (SigSpec::extract)
on the gen_mhpmevent combinational LUT
  logic [31:0] mhpmevent [32];
  always_comb begin : gen_mhpmevent
    for (int i = 0; i < 32; i++) begin
      mhpmevent[i] = '0;
      if (i >= MHPMCOUNTER_BASE) mhpmevent[i][i - MHPMCOUNTER_BASE] = 1'b1;
    end
  end
  ...
  csr_rdata_int = mhpmevent[mhpmcounter_idx];   // dynamic read

The array is written only combinationally, so (per the slang criterion: any combinational/blocking write disqualifies an unpacked array from being a $mem) it must be flattened to per-element wires, not inferred as a $memory.  Three distinct frontend bugs prevented that:

1. comb-only detection never saw the write.  collect_array_accesses() only scanned module->Process() and mis-cast named blocks: named_begin is `final : public scope` and is NOT a subclass of begin, so any_cast<const begin*>() on the gen_mhpmevent named_begin returned null and the whole subtree was skipped.  Now it (a) gathers always blocks from generate scopes too (module + gen_scope_array -> gen_scope, recursively), (b) casts vpiBegin and vpiNamedBegin distinctly, and (c) also recurses into vpiFor and vpiCase (the dynamic read lives inside a case).

2. array element-wire expansion sized the array to the fallback 4.  The unpacked range of `mhpmevent [32]` is `[0 : 32-1]`, whose right bound is a vpiOperation, not a literal vpiConstant — the old code required both bounds to be vpiConstant.  Both the array_var and array_net comb-only paths now fold the bounds through import_expression, so all 32 element wires are created (the dynamic read no longer hits "element not found").

3. loop-unrolled writes took the dynamic-index path and built a comb loop. `for(i) mhpmevent[i]='0` unrolls with i in loop_values, but the write path keyed off the raw UHDM node type (ref_obj != vpiConstant) and emitted a per-element mux `\mhpmevent[i] = mux(\mhpmevent[i], rhs, addr==i)` — a self-referential combinational loop that sent proc_dlatch's find_mux_feedback into unbounded recursion (stack overflow).  The index is now resolved and the dynamic path is taken only when it is not fully constant.

ibex_cs_registers now imports and runs proc; opt -full; synth cleanly (was: assert during import, then a proc_dlatch stack overflow once import completed).

Repro test/comb_2d_bitsel: a comb LUT in a named always_comb with an unrolled for-loop, per-element bit-select write, and a dynamic-index read.  Formal SAT equivalence PASSES; UHDM, read_verilog and read_slang all agree with the expected 1<<(i-B) values across every input.