### PR TITLE
uhdm: emit $meminit for `initial for(int k) mem[k]=<const>` power-up …

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -3587,6 +3587,91 @@ bool UhdmImporter::emit_initial_meminit_writes(const any* stmt) {
                 words.emplace_back(mem, is.as_const().as_int(), v);
                 return true;
             }
+            case vpiFor: {
+                // `initial for (int k = 0; k < N; k++) mem[k] = <const>;` — a
+                // power-up memory initializer written as a loop (Ibex
+                // ibex_register_file_fpga: `mem[k] = WordZeroVal`).  The inline
+                // `int k` declaration routes the block to the interpreter path,
+                // which does not emit $meminit, so the memory powers up X while
+                // the Verilog frontend initializes it (32 $meminit words).
+                // Unroll here — every iteration must fold to a constant — and
+                // let the caller emit one $meminit_v2 per word.
+                const for_stmt* fl = any_cast<const for_stmt*>(s);
+                if (!fl || !fl->VpiForInitStmts() ||
+                    fl->VpiForInitStmts()->size() != 1)
+                    return false;
+                const assignment* ia =
+                    any_cast<const assignment*>((*fl->VpiForInitStmts())[0]);
+                if (!ia || !ia->Lhs() || !ia->Rhs()) return false;
+                std::string lv = std::string(ia->Lhs()->VpiName());
+                const expr* starte = dynamic_cast<const expr*>(ia->Rhs());
+                const expr* conde = dynamic_cast<const expr*>(fl->VpiCondition());
+                const any* inc = (fl->VpiForIncStmts() &&
+                                  !fl->VpiForIncStmts()->empty())
+                                     ? (*fl->VpiForIncStmts())[0] : nullptr;
+                if (lv.empty() || !starte || !conde || !inc) return false;
+                // Increment amount: `k++` (vpiPostIncOp) or `k = k + N`.
+                int64_t inc_amt = 0;
+                if (inc->VpiType() == vpiOperation) {
+                    auto io = any_cast<const operation*>(inc);
+                    if (io && io->VpiOpType() == vpiPostIncOp) inc_amt = 1;
+                    else return false;
+                } else if (inc->VpiType() == vpiAssignment) {
+                    auto ina = any_cast<const assignment*>(inc);
+                    auto re = ina && ina->Rhs()
+                                  ? dynamic_cast<const expr*>(ina->Rhs()) : nullptr;
+                    if (!re) return false;
+                    loop_values[lv] = 0;
+                    RTLIL::SigSpec z = import_expression(re);
+                    loop_values[lv] = 1;
+                    RTLIL::SigSpec o = import_expression(re);
+                    loop_values.erase(lv);
+                    if (!z.is_fully_const() || !o.is_fully_const()) return false;
+                    inc_amt = o.as_const().as_int() - z.as_const().as_int();
+                } else return false;
+                if (inc_amt == 0) return false;
+                // Body must be a single `mem[k] = <expr>` assignment.
+                const any* body = fl->VpiStmt();
+                if (body && (body->VpiType() == vpiBegin ||
+                             body->VpiType() == vpiNamedBegin))
+                    if (auto st = begin_block_stmts(body))
+                        if (st->size() == 1) body = (*st)[0];
+                const assignment* ba =
+                    body ? any_cast<const assignment*>(body) : nullptr;
+                if (!ba || !ba->Lhs() ||
+                    ba->Lhs()->VpiType() != vpiBitSelect || !ba->Rhs())
+                    return false;
+                const bit_select* bs = any_cast<const bit_select*>(ba->Lhs());
+                std::string mem = std::string(bs->VpiName());
+                RTLIL::IdString mid = RTLIL::escape_id(mem);
+                if (!module->memories.count(mid)) return false;
+                int w = module->memories.at(mid)->width;
+                const expr* idxe = dynamic_cast<const expr*>(bs->VpiIndex());
+                const expr* rhse = dynamic_cast<const expr*>(ba->Rhs());
+                if (!idxe || !rhse) return false;
+                auto saved_lv = loop_values;
+                RTLIL::SigSpec sv = import_expression(starte);
+                if (!sv.is_fully_const()) { loop_values = saved_lv; return false; }
+                int64_t k = sv.as_const().as_int();
+                bool ok = true;
+                for (int guard = 0; guard < (1 << 20); guard++) {
+                    loop_values[lv] = (int)k;
+                    RTLIL::SigSpec cc = import_expression(conde);
+                    if (!cc.is_fully_const()) { ok = false; break; }
+                    if (cc.as_const().as_int() == 0) break;  // condition false
+                    RTLIL::SigSpec is = import_expression(idxe);
+                    RTLIL::SigSpec rs = import_expression(rhse);
+                    if (!is.is_fully_const() || !rs.is_fully_const()) {
+                        ok = false; break;
+                    }
+                    RTLIL::Const v = rs.as_const();
+                    if (v.size() != w) v = v.extract(0, w, RTLIL::State::S0);
+                    words.emplace_back(mem, is.as_const().as_int(), v);
+                    k += inc_amt;
+                }
+                loop_values = saved_lv;
+                return ok;
+            }
             default:
                 return false;
         }

--- a/test/mem_init_for_param/dut.sv
+++ b/test/mem_init_for_param/dut.sv
@@ -1,0 +1,30 @@
+// Power-up memory initializer written as `initial for (int k...) mem[k] = P;`
+// where the RHS is a *parameter* (not a literal).  The inline `int k`
+// declaration routes the initial block to the interpreter path, which used to
+// drop the $meminit — leaving the RAM X at power-up while the Verilog frontend
+// initialized it.  Mirrors Ibex ibex_register_file_fpga's mem[k]=WordZeroVal.
+module mem_init_for_param #(
+    parameter int              Depth   = 8,
+    parameter logic [31:0]     InitVal = 32'hDEAD_BEEF
+) (
+    input  logic        clk,
+    input  logic        we,
+    input  logic [2:0]  waddr,
+    input  logic [31:0] wdata,
+    input  logic [2:0]  raddr,
+    output logic [31:0] rdata
+);
+    logic [31:0] mem [Depth];
+
+    always @(posedge clk) begin
+        if (we) mem[waddr] <= wdata;
+    end
+
+    assign rdata = mem[raddr];
+
+    initial begin
+        for (int k = 0; k < Depth; k++) begin
+            mem[k] = InitVal;
+        end
+    end
+endmodule


### PR DESCRIPTION
…init (Ibex regfile_fpga)

ibex_register_file_fpga read cleanly but failed formal equivalence: equiv_induct reported the two netlists non-equivalent while Verilator co-sim passed.  Root cause: the UHDM frontend left the register-file RAM uninitialized (power-up X) where the Verilog frontend initialized it to all-zeros.

The RTL initializes the RAM with
  logic [DataWidth-1:0] mem[NUM_WORDS];
  initial begin
    for (int k = 0; k < NUM_WORDS; k++) mem[k] = WordZeroVal;   // WordZeroVal = '0
  end

The Verilog frontend emits one $meminit per word (INIT = 1024'b0); the UHDM frontend emitted none, so memory_collect produced INIT = 1024'x.  The read is combinational, so the uninitialized words fed straight to rdata and the miter diverged from reset.

emit_initial_meminit_writes() only matched *unrolled* `mem[const] = const` assignments, not a `vpiFor` loop.  The inline `int k` declaration also makes import_initial route the block to the interpreter path (has_for_decl), which does not emit $meminit at all — so neither path initialized the memory.

Add a vpiFor case to emit_initial_meminit_writes() (which runs *before* the sync/comb/interpreter routing and short-circuits on success): unroll the loop, evaluate the index and RHS each iteration via import_expression with the loop variable bound in loop_values, and require every word to fold to a constant. The RHS may be a parameter (WordZeroVal / InitVal), which import_expression resolves — the whole point the old const-only assignment matcher missed. Handles `k++` and `k = k + N` increments; bails (falls back to the existing behaviour) on any non-constant iteration.

ibex_register_file_fpga now emits 32 $meminit words (INIT = 1024'b0, identical to the Verilog frontend) and PASSES formal equivalence.

Repro test/mem_init_for_param: `initial for(int k) mem[k] = InitVal` with a parameter RHS (DEADBEEF).  UHDM and read_verilog both initialize all words to the parameter value; formal equivalence PASSES.