### PR TITLE
uhdm: don't treat genvar-indexed array writes as dynamic (Ibex id_sta…

### DIFF
--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -1424,7 +1424,22 @@ void UhdmImporter::collect_dynamic_expanded_array_writes(
     if (!stmt || !module) return;
     auto record = [&](const std::string& base, const any* idx) {
         if (base.empty()) return;
-        bool const_idx = idx && idx->VpiType() == vpiConstant;
+        // The write is only *dynamic* if the index does not resolve to a
+        // constant.  A genvar-unrolled write `arr[i] <= …` has `i` as a
+        // ref_obj (VpiType != vpiConstant) that nonetheless resolves to a
+        // constant element via the gen-scope — checking the raw node type
+        // alone wrongly flags it as dynamic and registers the WHOLE array in
+        // every unrolled process, so each element gets conflicting async-reset
+        // values (Ibex ibex_id_stage's `for (genvar i) imd_val_q[i] <= '0`
+        // -> proc_arst "async reset yields non-constant value").
+        bool const_idx = false;
+        if (idx) {
+            if (idx->VpiType() == vpiConstant) const_idx = true;
+            else if (auto e = dynamic_cast<const expr*>(idx)) {
+                RTLIL::SigSpec s = import_expression(e);
+                if (s.is_fully_const()) const_idx = true;
+            }
+        }
         if (const_idx) return;
         // Expanded array, not a real $memory: element wire \base[0] exists.
         if (!module->memories.count(RTLIL::escape_id(base)) &&

--- a/test/genvar_async_reset_array/dut.sv
+++ b/test/genvar_async_reset_array/dut.sv
@@ -1,0 +1,32 @@
+// A genvar loop generating one async-reset always_ff per array element:
+//   for (genvar i) always_ff @(posedge clk or negedge rst_n)
+//     if (!rst_n) q[i] <= '0; else if (we[i]) q[i] <= d[i];
+// The genvar index `q[i]` is a ref_obj (not a literal constant), so the
+// dynamic-expanded-array detector wrongly treated it as a dynamic write and
+// registered EVERY element in EVERY unrolled process — giving each element two
+// conflicting async-reset values (proc_arst "async reset yields non-constant").
+// Mirrors Ibex ibex_id_stage's imd_val_q[2] reset.
+module genvar_async_reset_array (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic [1:0]  we,
+    input  logic [33:0] d0,
+    input  logic [33:0] d1,
+    output logic [33:0] q0,
+    output logic [33:0] q1
+);
+    logic [33:0] q [2];
+
+    for (genvar i = 0; i < 2; i++) begin : gen_reg
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) begin
+                q[i] <= '0;
+            end else if (we[i]) begin
+                q[i] <= (i == 0) ? d0 : d1;
+            end
+        end
+    end
+
+    assign q0 = q[0];
+    assign q1 = q[1];
+endmodule


### PR DESCRIPTION
…ge async reset)

Bringing the whole Ibex core up (all rtl/ + the prim leaf modules, top ibex_top) surfaced a proc failure that the per-module tests missed (they have no read_verilog golden, so they only checked that import succeeds):

  ERROR: Async reset \rst_ni yields non-constant value
         34'mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm for signal \imd_val_q[0].

ibex_id_stage has a genvar loop generating one async-reset flop per element:

  logic [33:0] imd_val_q[2];
  for (genvar i = 0; i < 2; i++) begin : gen_intermediate_val_reg
    always_ff @(posedge clk_i or negedge rst_ni)
      if (!rst_ni) imd_val_q[i] <= '0;
      else if (imd_val_we_ex_i[i]) imd_val_q[i] <= imd_val_d_ex_i[i];
  end

Surelog unrolls this into two processes (i=0, i=1).  Each process correctly resets/writes only its own element, but the sync rules and hold-defaults covered BOTH imd_val_q[0] and imd_val_q[1].  So each element was driven by two async resets: its real `'0` (from its own process) and a hold `\q <= \q` (from the sibling process, which never resets it) — an ambiguous, non-constant reset that proc_arst rejects.

Root cause is in collect_dynamic_expanded_array_writes() (process_helper.cpp): it decides whether an `arr[idx] <= …` write is dynamic (and hence needs every element registered as a flop) by testing `idx->VpiType() == vpiConstant` on the raw UHDM node.  A genvar-unrolled index `imd_val_q[i]` is a ref_obj, not a literal constant, so it was misclassified as dynamic and the WHOLE array got registered in EVERY unrolled process.

Resolve the index through import_expression instead: a genvar / gen-scope index folds to a constant and is correctly treated as a single-element (non-dynamic) write, while a truly dynamic index (a data wire, or a runtime for-loop variable that is not yet bound in loop_values during this pre-unroll scan) stays non-constant and is still registered.  So mem_arst-style dynamic writes (issue326_packed_mem, mem2reg_*) are unaffected.

With this fix the full Ibex core (ibex_top + ibex_core + all submodules) completes read_uhdm; proc; flatten; opt_clean; check with no undriven nets and no proc errors.

Repro test/genvar_async_reset_array: `for (genvar i) always_ff … q[i] <= '0` on a 2-element 34-bit array — imports, synthesizes, and PASSES formal equivalence (previously proc_arst errored "async reset yields non-constant").