### PR TITLE
uhdm: register the resolved element for genvar-indexed array FF write…

### DIFF
--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -483,7 +483,23 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                         // Skip it here so we don't create a temp wire for the whole array.
                         if (!sig.name.empty()) {
                             auto idx = bit_sel->VpiIndex();
-                            bool is_const_idx = idx && idx->VpiType() == vpiConstant;
+                            // Resolve the index rather than testing the raw node
+                            // type: a genvar / gen-scope index (`arr[i]` in a
+                            // genvar-unrolled always_ff) is a ref_obj, not a
+                            // vpiConstant, yet folds to a constant element.
+                            // Treating it as a dynamic write would skip the
+                            // element entirely, so the FF is never created and
+                            // the register collapses to combinational logic
+                            // (Ibex ibex_id_stage `for (genvar i) imd_val_q[i]
+                            // <= '0` — imd_val_q lost its flop).
+                            RTLIL::SigSpec is;
+                            bool is_const_idx = false;
+                            if (idx) {
+                                if (auto e = dynamic_cast<const expr*>(idx)) {
+                                    is = import_expression(e);
+                                    is_const_idx = is.is_fully_const();
+                                }
+                            }
                             if (!is_const_idx) {
                                 RTLIL::IdString mem_id = RTLIL::escape_id(sig.name);
                                 if (!module->memories.count(mem_id) &&
@@ -493,16 +509,13 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                                     break;
                                 }
                             } else if (module->wire(RTLIL::escape_id(sig.name + "[0]"))) {
-                                // Constant bit-select of an UNPACKED array
+                                // Constant/genvar bit-select of an UNPACKED array
                                 // (`arr[0] <= ...`): the element is its OWN wire
                                 // \arr[0] — name the signal after it (a full wire),
                                 // not `\arr` which isn't a wire and trips "Signal
                                 // arr not found" (tcb_dev_gpio_cdc).
-                                RTLIL::SigSpec is = import_expression(idx);
-                                if (is.is_fully_const()) {
-                                    sig.name += "[" + std::to_string(is.as_const().as_int()) + "]";
-                                    sig.is_part_select = false;
-                                }
+                                sig.name += "[" + std::to_string(is.as_const().as_int()) + "]";
+                                sig.is_part_select = false;
                             }
                         }
 


### PR DESCRIPTION
…s (Ibex imd_val_q)

Follow-up to #536.  That PR stopped collect_dynamic_expanded_array_writes from registering the WHOLE array for a genvar-indexed write `arr[i] <= …`, which fixed the proc_arst "async reset yields non-constant" abort — but it left the element unregistered, so the flop was never created and the register silently collapsed to combinational logic.  Investigating the full Ibex core's 389 `check` logic-loop warnings traced back to exactly this: ibex_id_stage's `imd_val_q[2]` had NO $adff at all, so the multi-cycle mult/div feedback (imd_val_q -> ex_block/multdiv -> imd_val_d -> imd_val_q) became a real combinational loop after flatten.

Root cause is the same raw-node-type test in extract_assigned_signals: it classified `arr[i]` as a dynamic write (and skipped it) whenever `idx->VpiType() != vpiConstant`.  A genvar / gen-scope index is a ref_obj, not a literal, so the specific element was never added to the assigned-signal set and no sync rule / temp wire was created for it.

Resolve the index through import_expression instead of testing the node type: if it folds to a constant (genvar, gen-scope param, localparam) record the concrete element `\arr[N]` so its FF is built; a truly dynamic index (data wire) stays non-constant and is still skipped for the per-element mux path. This complements #536 — #536 keeps the whole array from being registered in every unrolled process; this records the one element each process actually assigns.

Result: ibex_id_stage's imd_val_q[0]/[1] get their $adff again, and the full Ibex core's flatten+check logic-loop count drops from 389 to 26 (the remainder are an unrelated ibex_compressed_decoder issue).

Repro test/genvar_async_reset_array now synthesizes to 2 $adff cells (Q=q[0], q[1]) and passes formal equivalence with the register actually present (before, q was combinational and the equivalence check passed only vacuously).