### PR TITLE
uhdm: struct-field read prefers in-flight blocking value (Ibex cs_reg…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7088,11 +7088,16 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
         if (all_ref && (pec.size() >= 4 || base_in_im)) {
             auto base_ref = any_cast<const ref_obj*>(pec[0]);
             std::string base_name = std::string(base_ref->VpiName());
+            // Prefer the in-flight blocking value (input_mapping /
+            // current_comb_values) over the module wire: a struct-field read
+            // `s.f` after an earlier same-block write to `s` must see the
+            // written value, not the final \s net (which the read then drives —
+            // a combinational loop; Ibex ibex_cs_registers mstatus_d.mpp).
             RTLIL::SigSpec base_sig;
-            if (name_map.count(base_name))
-                base_sig = RTLIL::SigSpec(name_map[base_name]);
-            else if (input_mapping && input_mapping->count(base_name))
+            if (input_mapping && input_mapping->count(base_name))
                 base_sig = input_mapping->at(base_name);
+            else if (name_map.count(base_name))
+                base_sig = RTLIL::SigSpec(name_map[base_name]);
 
             // Base typespec (union or struct).
             const UHDM::typespec* cur_ts = nullptr;
@@ -7150,8 +7155,6 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                     cur_ts = mts;
                 }
                 if (ok && field_w > 0 && off + field_w <= base_sig.size()) {
-                    log("    hier_path: packed member chain %s.* -> [%d+:%d]\n",
-                        base_name.c_str(), off, field_w);
                     return base_sig.extract(off, field_w);
                 }
             }


### PR DESCRIPTION
…isters mstatus_d loop)

The last 6 combinational loops in the full Ibex core were in ibex_cs_registers, on the struct comb variables mstatus_d and dcsr_d.  The RTL writes the whole struct then reads a field in a later condition of the same always_comb:

  mstatus_d = '{ mie:…, mpp:…, … };            // whole-struct pattern write
  if ((mstatus_d.mpp != PRIV_LVL_M) &&
      (mstatus_d.mpp != PRIV_LVL_U))            // READ field mstatus_d.mpp
    mstatus_d.mpp = PRIV_LVL_U;                 // WRITE field

import_hier_path's packed-struct-member handler resolved the base signal (`mstatus_d`) preferring the module wire (name_map) over the in-flight blocking value threaded in via input_mapping / current_comb_values.  So a field read `mstatus_d.mpp` extracted its slice from the FINAL \mstatus_d net — which the field write then drives — closing a combinational loop.

Prefer input_mapping over name_map for the base, matching the write-then-read threading that scalar reads already get: a field read now observes the value written earlier in the same block, and only falls back to the wire when the base isn't threaded.

Full Ibex core (ibex_top + all submodules) flatten+check logic loops: 6 -> 0 (ibex_cs_registers standalone likewise 6 -> 0).  This completes the Ibex comb-loop cleanup — the whole core now reads, flattens and passes `check` with zero logic loops and zero undriven nets (down from 389 at the start of the campaign).