### PR TITLE
build: add `make test-cores` (rp32 + Ibex) and refresh README test co…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Top-level Makefile for uhdm2rtlil
-.PHONY: all debug test test-read-sv test-all test-yosys frontends test-matrix clean plugin install help
+.PHONY: all debug test test-read-sv test-all test-cores test-yosys frontends test-matrix clean plugin install help
 
 # Use bash as the default shell
 SHELL := /usr/bin/env bash
@@ -39,6 +39,11 @@ test: all test-read-sv
 test-all: all
 	@echo "Running all tests (internal + Yosys)..."
 	@cd test && ./run_all_tests.sh --all
+
+# Test cores target - runs only the rp32 and Ibex core IP tests
+test-cores: all
+	@echo "Running core IP tests (rp32 + Ibex)..."
+	@cd test && ./run_all_tests.sh --cores
 
 # Test Yosys target - runs only Yosys tests
 test-yosys: all preprocess-yosys-tests

--- a/README.md
+++ b/README.md
@@ -51,49 +51,78 @@ report **0 Miter-Formal escapes** — no real UHDM≠Verilog difference slips th
 Run via `make test-all --all` (the internal SystemVerilog suite **plus** the
 upstream Yosys test suite under `third_party/yosys/tests/`):
 
-- **Total Tests**: 1304
-- **Success Rate**: 96% (1246/1304 tests functional), 1 crash, **0 Miter-Formal
+- **Total Tests**: 1316
+- **Success Rate**: 95% (1262/1316 tests functional), 2 crashes, **0 Miter-Formal
   escapes** (no UHDM≠Verilog diff slips past `equiv_induct`)
-- **Passing**: 864 tests with formal equivalence verified between the UHDM and Verilog frontends
-- **UHDM-Only Success**: 382 tests verified end-to-end against Verilator (the UHDM frontend handles SystemVerilog the Verilog frontend can't, so formal equivalence isn't possible — see below)
-- **Equivalence failures**: 19 — all caught by `equiv_induct` (0 Miter-Formal
-  escapes): internal `CastStructArray`, `ibex_register_file_fpga`, `rp32_r5p_mouse`,
-  and three packed struct-array tests (`struct_array_indexed_write`,
-  `struct_little_endian_bit_array`, `svtypes_struct_array`); plus 13 from the
+- **Passing**: 874 tests with formal equivalence verified between the UHDM and Verilog frontends
+- **UHDM-Only Success**: 388 tests verified end-to-end against Verilator (the UHDM frontend handles SystemVerilog the Verilog frontend can't, so formal equivalence isn't possible — see below)
+- **Equivalence failures**: 17 — all caught by `equiv_induct` (0 Miter-Formal
+  escapes): internal `CastStructArray`, `rp32_r5p_mouse`, and three packed
+  struct-array tests (`struct_array_indexed_write`,
+  `struct_little_endian_bit_array`, `svtypes_struct_array`); plus 12 from the
   upstream Yosys suite (`arch/nanoxplore/meminit`, `check_mem/sub_addr`,
-  `sat/{alu,grom_computer,grom_cpu,ram_memory}`, `simple/{loops,module_scope_case}`,
+  `sat/{alu,grom_computer,grom_cpu,ram_memory}`, `simple/module_scope_case`,
   `sva/extnets`, `svtypes/{array_assign,struct_array}`, `verific/ext_ramnet_err`,
   `verilog/mem_bounds`).  The exact set varies run-to-run (seq-equiv induction is
   inductively incomplete on some designs).
-- **True failures** (no output generated): 17 — three imported Ibex modules whose
-  advanced SV the frontend does not yet fully read (`ibex_core`,
-  `ibex_cs_registers`, `ibex_icache`); the other 14 are all from the upstream
-  Yosys suite (`arch/fabulous/{arith,custom,ff,io,regfile}_map`,
-  `functional/picorv32_tb`, `hana/test_simulation_vlib`, `memories/wide_all`,
-  `opt/opt_rmdff`, `rpc/design`, `svinterfaces/{load_and_derive,resolve_types}`,
-  `techmap/mem_simple_4x1_map`, `verific/mixed_flist`)
-- **Crashes**: 1 (`techmap/recursive_map`)
-- **Verilator sim-equiv warnings**: 102 (undocumented divergences — now hard errors
+- **True failures** (no output generated): 14 — **all** from the upstream Yosys
+  suite (`arch/fabulous/{arith,custom,ff,io,regfile}_map`, `functional/picorv32`,
+  `functional/picorv32_tb`, `hana/test_simulation_vlib`, `opt/opt_rmdff`,
+  `rpc/design`, `svinterfaces/{load_and_derive,resolve_types}`,
+  `techmap/mem_simple_4x1_map`, `verific/mixed_flist`).  Every internal test —
+  including the full Ibex core (`ibex_core`, `ibex_cs_registers`, `ibex_icache`,
+  `ibex_top`) — now reads and produces output.
+- **Crashes**: 2 (`memories/wide_all`, `techmap/recursive_map` — both upstream Yosys)
+- **Verilator sim-equiv warnings**: 108 (undocumented divergences — now hard errors
   unless documented in `test/sim_equiv_analyzed.txt`), plus **72 analyzed** known
   non-bug divergences — of which 58 are sim/synth artefacts where a SAT miter
   proves UHDM == Verilog, and the rest are uhdm-only don't-care divergences (e.g.
   `rp32_r5p_alu/wbu/mdu`, where the Verilog frontend can't synthesize the SV so no
   miter is possible)
 
-> The **internal** SystemVerilog suite alone is **762 tests, 0 crashes** — the
-> only true failures are three imported Ibex modules whose advanced SV the
-> frontend does not yet fully read (`ibex_core`, `ibex_cs_registers`,
-> `ibex_icache`).  Equivalence failures are `CastStructArray` (a
-> Yosys-Verilog-frontend bug, not UHDM), `ibex_register_file_fpga` and
-> `rp32_r5p_mouse` (reset/X-dependent, not cleanly equiv-able), and three packed
-> struct-array tests (`struct_array_indexed_write`,
+> The **internal** SystemVerilog suite alone is **774 tests, 0 crashes, 0 true
+> failures** — every internal design reads and produces output, including the
+> complete Ibex core (all modules + `ibex_top`) and the rp32 cores/SoCs. The only
+> internal equivalence failures are `CastStructArray` (a Yosys-Verilog-frontend
+> bug, not UHDM), `rp32_r5p_mouse` (reset/X-dependent, not cleanly equiv-able),
+> and three packed struct-array tests (`struct_array_indexed_write`,
 > `struct_little_endian_bit_array`, `svtypes_struct_array`) that a SAT miter
-> proves UHDM == Verilog, i.e. `equiv_induct` incompleteness, not real diffs). The
-> figures above are the combined `--all` run; the remaining failures/crash come
-> from the imported upstream Yosys suite (feature gaps / non-synthesizable
-> constructs), tracked in `test/failing_tests.txt` and
+> proves UHDM == Verilog (i.e. `equiv_induct` incompleteness, not real diffs). The
+> figures above are the combined `--all` run; all 14 true failures and both
+> crashes come from the imported upstream Yosys suite (feature gaps /
+> non-synthesizable constructs), tracked in `test/failing_tests.txt` and
 > `test/imported_tests_status.txt` and fixed incrementally. No pre-existing
 > internal test regressed.
+
+### Supported Core IP (rp32 & Ibex)
+
+Two real-world RISC-V IP families are imported from their upstream RTL (kept
+verbatim under `test/ibex/` and `test/rp32/`) and exercised end-to-end through
+the UHDM frontend. Run just these with `make test-cores` (or
+`bash run_all_tests.sh --cores`): **41 tests, 40 functional (97%), 0 crashes**.
+
+| IP | What it is | Tests | Result |
+|----|------------|-------|--------|
+| **lowRISC [Ibex](https://github.com/lowRISC/ibex)** | 2-stage 32-bit RISC-V core (RV32IMC + PMP, ICache, dummy-instr/lockstep security) | **28** — every RTL module plus the full `ibex_top` / `ibex_top_tracing` integration | **28 / 28 pass**, 0 crashes |
+| **rp32 (R5P)** | 32-bit RISC-V cores + TCB-interface SoCs (degu, mouse, v-friendly) | **13** — ALU, BRU, CSR, GPR, MDU, WBU, the `degu`/`hamster`/`mouse` cores and their SoC tops | **12 / 13 pass**, 0 crashes |
+
+Highlights:
+
+- The **entire Ibex hierarchy** (all 30 RTL files + prim leaves, top `ibex_top`)
+  reads, `flatten`s, and passes Yosys `check` with **0 logic loops and 0
+  undriven nets** — a campaign that fixed a series of real frontend bugs
+  (comb-only array inference, `initial for` `$meminit`, genvar async-reset flops,
+  comb write-then-read threading, struct-field in-flight reads) that took the
+  loop count from **389 → 0**.
+- `ibex_register_file_fpga` is verified by **formal equivalence** (its
+  power-up `$meminit` now matches the Verilog frontend); the other advanced-SV
+  Ibex modules are UHDM-only (the native Verilog frontend cannot parse them) and
+  verified against **Verilator** co-simulation.
+- Both interface-based rp32 SoCs (`degu`, `mouse`) boot and run a program
+  end-to-end in a Yosys functional simulation of the UHDM-synthesised netlist.
+- The single non-pass, `rp32_r5p_mouse`, is a known `equiv_induct` incompleteness
+  (a reset/X-dependent design where seq-equiv induction can't close), **not** a
+  UHDM≠Verilog difference — 0 Miter-Formal escapes.
 
 ### SystemVerilog Frontend Comparison
 
@@ -363,6 +392,9 @@ make test
 # Run all tests (internal + Yosys tests)
 make test-all
 
+# Run only the core IP tests (rp32 RISC-V SoC + lowRISC Ibex)
+make test-cores
+
 # Run Yosys tests only
 make test-yosys
 
@@ -374,6 +406,7 @@ bash test_uhdm_workflow.sh simple_counter
 cd test
 bash run_all_tests.sh                    # Run internal tests only
 bash run_all_tests.sh --all              # Run all tests (internal + Yosys)
+bash run_all_tests.sh --cores            # Run only rp32 + Ibex core IP tests
 bash run_all_tests.sh --yosys           # Run all Yosys tests
 bash run_all_tests.sh --yosys add_sub   # Run specific Yosys test pattern
 

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -47,6 +47,7 @@ declare -A TEST_START_TIMES
 RUN_LOCAL=true
 RUN_YOSYS=false
 SPECIFIC_TEST=""
+CORES_ONLY=false
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -61,12 +62,18 @@ while [[ $# -gt 0 ]]; do
             RUN_YOSYS=true
             shift
             ;;
+        --cores)
+            # Run only the CPU-core IP tests: rp32 (RISC-V SoC) and Ibex.
+            CORES_ONLY=true
+            shift
+            ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS] [TEST_PATTERN]"
             echo ""
             echo "Options:"
             echo "  --yosys       Run only Yosys tests from third_party/yosys/tests/"
             echo "  --all         Run both local tests and Yosys tests"
+            echo "  --cores       Run only the rp32 and Ibex core IP tests"
             echo "  --help, -h    Show this help message"
             echo ""
             echo "Arguments:"
@@ -78,6 +85,7 @@ while [[ $# -gt 0 ]]; do
             echo "  $0 --yosys            # Run all Yosys tests"
             echo "  $0 --yosys simple     # Run Yosys tests matching 'simple'"
             echo "  $0 --all              # Run all local and Yosys tests"
+            echo "  $0 --cores            # Run only rp32 + Ibex core IP tests"
             exit 0
             ;;
         *)
@@ -337,9 +345,17 @@ if [ "$RUN_LOCAL" = true ]; then
                 # Remove trailing slash from directory name
                 TEST_NAME="${dir%/}"
                 # Skip the run directory (used for Yosys tests)
-                if [ "$TEST_NAME" != "run" ]; then
-                    TEST_DIRS+=("$TEST_NAME")
+                if [ "$TEST_NAME" = "run" ]; then
+                    continue
                 fi
+                # --cores: keep only the rp32 and Ibex core IP tests.
+                if [ "$CORES_ONLY" = true ]; then
+                    case "$TEST_NAME" in
+                        rp32*|ibex*) ;;
+                        *) continue ;;
+                    esac
+                fi
+                TEST_DIRS+=("$TEST_NAME")
             fi
         done
     fi


### PR DESCRIPTION
…unts

Add a `--cores` mode to run_all_tests.sh and a `make test-cores` target that run only the CPU-core IP tests (the rp32_* and ibex_* directories), reusing the existing per-test workflow and reporting.

Refresh the README Test Suite Status to the latest `make test-all` run and add a "Supported Core IP (rp32 & Ibex)" section:

- Full suite: 1316 tests, 1262 functional (95%), 0 Miter-Formal escapes.  All 14 true failures and both crashes are now in the imported upstream Yosys suite — every internal test (including the complete Ibex core and rp32 SoCs) reads and produces output.  The internal suite alone is 774 tests, 0 crashes, 0 true failures.
- Core IP: `make test-cores` runs 41 tests — Ibex 28/28, rp32 12/13 (the one non-pass, rp32_r5p_mouse, is equiv_induct incompleteness, not a real diff), 0 crashes.  ibex_register_file_fpga is now formally equivalent; the full Ibex hierarchy flattens with 0 logic loops and 0 undriven nets.