### PR TITLE
uhdm: skip never-instantiated module definitions in AllModules import

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -463,6 +463,23 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
                 log("UHDM: Skipping top module %s from AllModules (will import from hierarchy)\n", mod_name.c_str());
                 continue;
             }
+            // Skip modules that are never instantiated in the elaborated top
+            // hierarchy.  These are dead in this configuration (e.g. an
+            // OpenPiton/L15 cache adapter in an AXI build, or a
+            // `//pragma translate_off` tracer), and importing their DEFINITION
+            // with default parameters (a width param left 0 -> `[-1:3]`
+            // part-selects, etc.) produces invalid RTLIL / crashes, even though
+            // the module is not part of the synthesized design.  Only applied
+            // when an elaborated hierarchy exists (a standalone module read with
+            // no TopModules still imports every definition).
+            if (!hierarchy_reachable_modules.empty() &&
+                hierarchy_reachable_modules.find(mod_name) ==
+                    hierarchy_reachable_modules.end()) {
+                log("UHDM: Skipping %s from AllModules (not instantiated in top "
+                    "hierarchy)\n",
+                    mod_name.c_str());
+                continue;
+            }
             // Skip modules that contain source-level generate statements
             // (vpiGenStmt). The AllModules form has the un-elaborated gen_region,
             // so cont_assigns like `assign bar[0].a = A;` reference generate-scope


### PR DESCRIPTION
The AllModules loop imported every module DEFINITION, including modules that are never instantiated in the elaborated top hierarchy.  In a configuration that excludes whole subsystems (e.g. CVA6 cv64a6_imafdc_sv39, which uses the AXI cache subsystem and not the OpenPiton/L15 adapter), those dead definitions are elaborated with their DEFAULT parameters -- a width parameter left 0 then yields invalid part-selects such as `addr[-1:3]` (negative-size SigSpec) and crashes the import, even though the module is not part of the synthesized design.

Skip an AllModules definition when its name is absent from `hierarchy_reachable_modules` (the set of module names reached by walking the TopModules instance tree).  Guarded by `!hierarchy_reachable_modules.empty()` so a standalone module read with no TopModules still imports every definition.

On CVA6 cv64a6_imafdc_sv39 this skips 163 dead module definitions (OpenPiton/ L15 adapters, PITON-only blocks, and -- with Surelog `-synth` honoring `//pragma translate_off` -- the instr_tracer), clearing two import crashes.