### PR TITLE
uhdm: dedup task/function-local var wires in tf-call inliner

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -7235,7 +7235,9 @@ void UhdmImporter::import_tf_call_comb(const UHDM::tf_call* tc,
             if (task_mapping.count(var_name)) continue;
 
             std::string wire_name = context + "." + var_name;
-            RTLIL::Wire* task_wire = module->addWire(RTLIL::escape_id(wire_name), width);
+            RTLIL::IdString tw_id = RTLIL::escape_id(wire_name);
+            RTLIL::Wire* task_wire = module->wire(tw_id);
+            if (!task_wire) task_wire = module->addWire(tw_id, width);
             task_wire->attributes[ID::nosync] = RTLIL::Const(1);
             if (var) add_src_attribute(task_wire->attributes, var);
 
@@ -7537,7 +7539,13 @@ void UhdmImporter::inline_task_body_comb(const any* stmt, RTLIL::Process* proc,
                     else
                         wire_name += "." + var_name;
 
-                    RTLIL::Wire* block_wire = module->addWire(RTLIL::escape_id(wire_name), width);
+                    // Surelog may list a function-local variable in BOTH the
+                    // function's Variables() (created by the caller) AND the
+                    // body begin-block's Variables() — reuse the existing wire
+                    // rather than re-adding it (which asserts on the dup name).
+                    RTLIL::IdString bw_id = RTLIL::escape_id(wire_name);
+                    RTLIL::Wire* block_wire = module->wire(bw_id);
+                    if (!block_wire) block_wire = module->addWire(bw_id, width);
                     if (var) add_src_attribute(block_wire->attributes, var);
 
                     std::string temp_name = stringf("$0\\%s[%d:0]$%d", wire_name.c_str(), width - 1, incr_autoidx());


### PR DESCRIPTION
Inlining a task/function whose local variable is listed by Surelog in BOTH `task_def->Variables()` AND the body begin-block's `Variables()` created the same wire twice, tripping `count_id(wire->name) == 0` in RTLIL::addWire.

This is exercised by sim-only routines such as CVA6's `instr_tracer` `create_file` (a `function void` that calls `$fopen`/`$sformatf`, invoked from an always block that also does `$fwrite`/`$fdisplay`): the frontend crashed while inlining it, even though the file-I/O statements themselves are already skipped gracefully.

Make both var-wire creation sites (import_tf_call_comb IO/local vars and inline_task_body_comb block-local vars) reuse an existing wire instead of re-adding it.  The collision only occurs on Surelog-duplicated names (genuine shadowing uses a distinct block-prefixed name), so reuse is correct.  The sim-only function then inlines harmlessly.