### PR TITLE
uhdm: fix segfault computing type_param_signature before module exists

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6698,7 +6698,16 @@ void UhdmImporter::resolve_xmr_read(RTLIL::Module* mod, RTLIL::Cell* cell, const
 RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const scope* inst, const std::map<std::string, RTLIL::SigSpec>* input_mapping) {
     if (mode_debug)
         log("    Importing hier_path\n");
-    
+
+    // Guard: import_hier_path dereferences `module` (e.g. module->cell()) while
+    // resolving cell/instance references.  type_param_signature() computes port
+    // widths via get_width()->import_expression() BEFORE the RTLIL module is
+    // created, so `module` can be null here — bail out safely instead of
+    // crashing (CVA6 axi_shim ports have a cast in their range that reaches
+    // this path during name computation).
+    if (!module)
+        return RTLIL::SigSpec();
+
     // Get the full path name first
     std::string path_name;
     std::string_view name_view = uhdm_hier->VpiName();

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2513,13 +2513,18 @@ void UhdmImporter::create_parameterized_modules() {
 std::string UhdmImporter::type_param_signature(const module_inst* uhdm_module) {
     if (!uhdm_module || !uhdm_module->Parameters()) return "";
     bool has_type_param = false;
-    for (auto p : *uhdm_module->Parameters()) {
+    for (auto p : *uhdm_module->Parameters())
         if (p && p->UhdmType() == uhdmtype_parameter) { has_type_param = true; break; }
-    }
     if (!has_type_param) return "";
     // Distinguish type bindings by the instance's resolved port widths (a
-    // `parameter type` changes them, e.g. a 134-bit struct vs default 1-bit
+    // `parameter type` changes them, e.g. a struct vs the default 1-bit
     // logic).  Two instances with identical port widths share one module.
+    // NOTE: get_width() may need to evaluate a port's range via
+    // import_expression, but this runs before `this->module` is created — the
+    // null-module guard at the top of import_hier_path keeps that safe (a
+    // range that can't be sized here just yields a stable approximate width,
+    // which still distinguishes bindings; struct ports are member-summed
+    // without hitting import_expression at all).
     std::string sig = "$typaram";
     if (uhdm_module->Ports()) {
         for (auto port : *uhdm_module->Ports()) {


### PR DESCRIPTION
type_param_signature() runs while a module's RTLIL name is being decided — before `this->module` is created — and calls get_width() on each port. A port whose range holds a cast (CVA6 axi_shim `axi_req_o`) makes get_width() evaluate the range via import_expression -> import_operation (cast) -> import_hier_path, which dereferences the not-yet-created `module` (module->cell()) and segfaults.

Guard import_hier_path with an early `if (!module) return {};`.  During normal signal import `module` is always set, so the guard only fires in the type_param_signature naming path, where returning an empty SigSpec yields a stable (approximate) width that still distinguishes bindings. Struct-typed ports are member-summed without reaching import_expression, so their real widths are unaffected.

With this, CVA6 (cv64a6_imafdc_sv39) reads through the parameter-type modules without crashing.