### PR TITLE
uhdm: resolve struct-parameter field VALUE in expression context

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3830,7 +3830,14 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 break;
             case vpiLShiftOp:
                 if (operands.size() == 2) {
-                    result = RTLIL::const_shl(operands[0].as_const(), operands[1].as_const(), false, false, -1);
+                    // NB: RTLIL::const_shl passes result_len straight to
+                    // extend_u0() (unlike const_shr, which guards it with
+                    // max(result_len, size)), so a result_len of -1 becomes
+                    // resize((size_t)-1) and throws std::vector::_M_fill_insert.
+                    // Pass the self-determined Verilog width (left operand size)
+                    // instead of -1; the caller applies any wider context.
+                    result = RTLIL::const_shl(operands[0].as_const(), operands[1].as_const(),
+                                              false, false, operands[0].size());
                 }
                 break;
             case vpiRShiftOp:
@@ -9937,6 +9944,33 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                     base_is_param = (a0->UhdmType() == uhdmparameter);
         }
         if (base_is_param) {
+            // A struct-typed parameter FIELD used in an expression
+            // (`Cfg.XLEN_ALIGN_BYTES` as a shift amount / replication count in
+            // CVA6 wt_dcache_wbuffer): Surelog leaves the hier_path unfolded and
+            // the struct-member path above only resolves its WIDTH.  Reduce the
+            // whole hier_path to its constant VALUE via ExprEval — the same
+            // evaluator that already resolves `Cfg.XLEN` for port widths.
+            // Without this the field returns an all-X constant whose as_int()
+            // feeds const_shl a garbage width -> std::vector::_M_fill_insert.
+            {
+                ExprEval eval;
+                bool invalidValue = false;
+                if (expr* res = eval.reduceExpr(
+                        const_cast<hier_path*>(uhdm_hier), invalidValue,
+                        current_instance ? (const any*)current_instance : (const any*)inst,
+                        uhdm_hier->VpiParent(), true)) {
+                    if (!invalidValue && res->UhdmType() == uhdmconstant) {
+                        RTLIL::SigSpec cv =
+                            import_constant(any_cast<const constant*>(res));
+                        if (cv.is_fully_const() && cv.is_fully_def()) {
+                            if (mode_debug)
+                                log("    hier_path '%s' folded to constant %s via ExprEval\n",
+                                    path_name.c_str(), cv.as_const().as_string().c_str());
+                            return cv;
+                        }
+                    }
+                }
+            }
             if (mode_debug)
                 log("    hier_path '%s' is an interface/struct parameter field; "
                     "width=%d resolved via typespec (constant, no signal)\n",

--- a/test/struct_param_field_shift/dut.sv
+++ b/test/struct_param_field_shift/dut.sv
@@ -1,0 +1,37 @@
+// Reproducer for CVA6 wt_dcache_wbuffer gen_tx_vld: a FIELD of a struct-typed
+// parameter (`Cfg.XLEN_ALIGN_BYTES`) used as a SHIFT AMOUNT / replication count
+// in a generate-scope continuous assignment, with a CONSTANT left operand (so
+// the whole shift const-folds).  Two bugs surfaced here:
+//   1. `Cfg.FIELD` in expression context was only width-resolved (returned X),
+//      never value-resolved -> garbage.  Fixed via ExprEval in import_hier_path.
+//   2. RTLIL::const_shl(result_len=-1) does resize((size_t)-1) -> throws
+//      std::vector::_M_fill_insert.  Fixed by passing the self-determined width.
+package cfg_pkg;
+  typedef struct packed {
+    int unsigned XLEN;
+    int unsigned XLEN_ALIGN_BYTES;
+  } cfg_t;
+  function automatic cfg_t build_config(int unsigned xlen);
+    cfg_t cfg;
+    cfg.XLEN = xlen;
+    cfg.XLEN_ALIGN_BYTES = $clog2(xlen / 8);   // = 3 for xlen=64
+    return cfg;
+  endfunction
+  localparam cfg_t DefaultCfg = build_config(64);
+endpackage
+
+module struct_param_field_shift #(
+    parameter cfg_pkg::cfg_t Cfg = cfg_pkg::DefaultCfg
+) (
+    input  logic [3:0]           sel_i,
+    output logic [Cfg.XLEN-1:0]  y_o
+);
+  logic [Cfg.XLEN-1:0] acc [0:1];
+  for (genvar k = 0; k < 2; k++) begin : gen_blk
+    // CONST left operand shifted by the struct-param field -> const-fold path;
+    // prepend field-count zero bits (replication count = struct-param field).
+    assign acc[k] = {{Cfg.XLEN_ALIGN_BYTES{1'b0}},
+                     (8'hAB + k) << Cfg.XLEN_ALIGN_BYTES};
+  end
+  assign y_o = sel_i[0] ? acc[0] : acc[1];
+endmodule


### PR DESCRIPTION
A field of a struct-typed parameter used in an expression — CVA6 wt_dcache_wbuffer `gen_tx_vld`: `{{Cfg.XLEN_ALIGN_BYTES{1'b0}}, wbuffer_q[..].wtag << Cfg.XLEN_ALIGN_BYTES}` — was never value-resolved. `import_hier_path`'s `base_is_param` branch only resolved the field WIDTH and returned `SigSpec(Sx, width)`; the field value came out X. Used as a shift amount / replication count that produced garbage and (via the const_shl bug below) crashed the whole module import.

Two fixes:

- import_hier_path: when the hier_path base binds to a `parameter` (`Cfg.FIELD`), fold the whole path to its constant with `ExprEval::reduceExpr` — the same evaluator that already resolves `Cfg.XLEN` for port widths — and return that constant. `Cfg.XLEN_ALIGN_BYTES` now folds to its real value (3 for XLEN=64).

- const-fold vpiLShiftOp: `RTLIL::const_shl` passes result_len straight to `extend_u0()` (unlike const_shr, which guards it with `max(result_len, size)`), so the `result_len == -1` we passed became `resize((size_t)-1)` and threw `std::vector::_M_fill_insert`. Pass the self-determined Verilog width (left-operand size) instead of -1.

With both, CVA6 (cv64a6_imafdc_sv39) imports past wt_dcache_wbuffer.

New UHDM-only test struct_param_field_shift (Yosys read_verilog can't take a struct bound to a value/type parameter): verifies `(8'hAB+k) << Cfg.XLEN_ALIGN_BYTES` folds to 0x558 / 0x560 in a generate scope.