### PR TITLE
uhdm: resolve gen-scope register declared in an ancestor generate scope

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -1052,13 +1052,33 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
             // ref name "rr_ptr".  Resolve each to its actual wire so the
             // async-reset register temp-wire / sync-rule path below finds it
             // (issue #441 — else "Signal rr_ptr not found in module").
+            //
+            // The declaration may live in the CURRENT generate scope, in any
+            // ANCESTOR scope, or at module level, while the always_ff sits in a
+            // deeper nested scope.  CVA6 rr_arb_tree: `rr_q` is declared in
+            // `gen_arbiter` but its always_ff `p_rr_regs` is in the nested
+            // `gen_arbiter.gen_int_rr` — so walk the scope path from the
+            // innermost prefix outward and use the first matching wire (SV
+            // scoping: the innermost declaration wins).
             {
                 std::string gs = get_current_gen_scope();
                 if (!gs.empty())
-                    for (auto& sig : assigned_signals)
-                        if (!module->wire(RTLIL::escape_id(sig.name)) &&
-                            module->wire(RTLIL::escape_id(gs + "." + sig.name)))
-                            sig.name = gs + "." + sig.name;
+                    for (auto& sig : assigned_signals) {
+                        if (module->wire(RTLIL::escape_id(sig.name)))
+                            continue;  // already a module-level wire
+                        std::string prefix = gs;
+                        while (!prefix.empty()) {
+                            std::string cand = prefix + "." + sig.name;
+                            if (module->wire(RTLIL::escape_id(cand))) {
+                                sig.name = cand;
+                                break;
+                            }
+                            size_t dot = prefix.rfind('.');
+                            if (dot == std::string::npos)
+                                break;
+                            prefix = prefix.substr(0, dot);
+                        }
+                    }
             }
 
             // Create ONE temp wire per unique signal (not per assignment)

--- a/test/genscope_outer_reg_inner_ff/dut.sv
+++ b/test/genscope_outer_reg_inner_ff/dut.sv
@@ -1,0 +1,37 @@
+// Reproducer for CVA6 rr_arb_tree "Signal rr_q not found in module": a register
+// declared in an OUTER generate scope whose driving `always_ff` lives in a
+// NESTED inner generate scope.  Mirrors rr_arb_tree's `gen_arbiter` (outer,
+// declares rr_q) / `gen_int_rr` (inner else-branch, holds p_rr_regs) nesting,
+// so the gen-scope wire resolution must walk UP the scope hierarchy.
+module genscope_outer_reg_inner_ff #(
+    parameter int  NumIn   = 4,
+    parameter bit  ExtPrio = 1'b0
+) (
+    input  logic                     clk_i,
+    input  logic                     rst_ni,
+    input  logic                     flush_i,
+    input  logic [NumIn-1:0]         req_i,
+    input  logic                     gnt_i,
+    input  logic [$clog2(NumIn)-1:0] rr_i,
+    output logic [$clog2(NumIn)-1:0] rr_o
+);
+  localparam int IdxW = $clog2(NumIn);
+  if (NumIn > 1) begin : gen_arbiter
+    logic [IdxW-1:0] rr_q;                 // declared in OUTER scope
+
+    if (ExtPrio) begin : gen_ext_rr
+      assign rr_q = rr_i;
+    end else begin : gen_int_rr            // nested inner scope
+      logic [IdxW-1:0] rr_d;
+      assign rr_d = (gnt_i && |req_i) ?
+                    ((rr_q == IdxW'(NumIn-1)) ? '0 : rr_q + 1'b1) : rr_q;
+      // always_ff in the INNER scope assigns the OUTER-scope rr_q
+      always_ff @(posedge clk_i or negedge rst_ni) begin : p_rr_regs
+        if (!rst_ni)      rr_q <= '0;
+        else if (flush_i) rr_q <= '0;
+        else              rr_q <= rr_d;
+      end
+    end
+    assign rr_o = rr_q;
+  end
+endmodule


### PR DESCRIPTION
A register whose driving always_ff lives in a NESTED generate scope but whose declaration sits in an OUTER (ancestor) generate scope was reported "Signal <x> not found in module".  CVA6 rr_arb_tree: `rr_q` is declared in `gen_arbiter` while its `always_ff p_rr_regs` is in the nested `gen_arbiter.gen_int_rr`, so `extract_assigned_signals` records the bare name `rr_q` and the async-reset register temp-wire path could not find a wire for it.

The existing gen-scope resolution (issue #441) only tried the single current-scope prefix (`gen_arbiter.gen_int_rr.rr_q`).  Walk the scope path from the innermost prefix outward and use the first matching wire (`gen_arbiter.rr_q`) — SV scoping: the innermost declaration wins.  The bare module-level name is still checked first, so nothing changes for signals that already resolve.

Repro test genscope_outer_reg_inner_ff (passes formal equivalence): a register declared in an outer generate block, driven by an always_ff in a nested inner block.  Reproduces the abort without the fix.

With this, CVA6 (cv64a6_imafdc_sv39) imports past rr_arb_tree.