### PR TITLE
uhdm: restore RTLIL `module` context across child-instance imports

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1531,6 +1531,20 @@ bool UhdmImporter::expr_uses_resolved_param(const any* e) {
 void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool create_instances) {
     if (!uhdm_module) return;
 
+    // Save/restore the current RTLIL `module`.  This function mutates `module`
+    // (looking up this instance's module, recursing into child instances) but
+    // its main path never restores it — so after importing a PARENT's child
+    // instances, the parent's own remaining body (e.g. cva6's top-level
+    // `gen_no_accelerator` continuous assigns, processed after its children)
+    // would run against a stale/null `module` (a `design->module()` miss
+    // leaves it null) and crash in import_ref_obj.  Restoring it on every exit
+    // keeps `module` pointing at the caller's module across child imports.
+    RTLIL::Module* hier_saved_module = module;
+    struct ModuleRestorer {
+        UhdmImporter* self; RTLIL::Module* saved;
+        ~ModuleRestorer() { self->module = saved; }
+    } _module_restorer{this, hier_saved_module};
+
     // Get module name
     std::string module_name = std::string(uhdm_module->VpiDefName());
     if (module_name.find("work@") == 0) {

--- a/test/genscope_module_ctx_reset/dut.sv
+++ b/test/genscope_module_ctx_reset/dut.sv
@@ -1,0 +1,37 @@
+// Reproducer for the CVA6 module-context-leak segfault: a parent module whose
+// own generate-scope continuous assign (referencing a parameter) is imported
+// AFTER a child instance whose hierarchy import overwrote the current RTLIL
+// `module`.  Without restoring `module` across child imports, the parent's
+// later gen-scope logic resolves parameters against a stale/null module and
+// segfaults in import_ref_obj.
+module gchild #(parameter int GW = 1) (
+    input  logic [GW-1:0] gi,
+    output logic          go
+);
+  assign go = ^gi;
+endmodule
+
+module child #(parameter int CW = 2) (
+    input  logic [CW-1:0] ci,
+    output logic          co
+);
+  logic g;
+  gchild #(.GW(CW)) u_g (.gi(ci), .go(g));   // grandchild -> hierarchy recursion
+  assign co = g;
+endmodule
+
+module genscope_module_ctx_reset #(parameter int WIDTH = 8) (
+    input  logic [WIDTH-1:0] in_i,
+    output logic             c_o,
+    output logic [WIDTH-1:0] p_o
+);
+  // gen scope 1: child instance (drives `module` through hierarchy recursion)
+  if (WIDTH > 1) begin : gen_inst
+    child #(.CW(4)) u_c (.ci(in_i[3:0]), .co(c_o));
+  end
+  // gen scope 2: continuous assign referencing the top PARAMETER, imported
+  // AFTER the child — must see `module` restored to this parent.
+  if (WIDTH > 1) begin : gen_use
+    assign p_o = in_i ^ {WIDTH{1'b1}};
+  end
+endmodule


### PR DESCRIPTION
CVA6 (cv64a6_imafdc_sv39) segfaulted while importing the top `cva6` module: `import_module_hierarchy` mutates the current RTLIL `module` (it looks up the instance's module at ~1801-1810 — a `design->module()` MISS leaves `module` null — and recurses into child instances) but its main path never restores it.  So after a parent's child instances are imported, the parent's OWN remaining body — cva6's top-level `gen_no_accelerator` continuous assigns, processed after its children — ran against a stale/null `module` and crashed in `import_ref_obj` (`module->parameter_default_values`).

Fix: RAII save/restore of `module` at `import_module_hierarchy` entry, so it always points at the caller's module on return (mirroring `import_instance`, which already saves/restores the full context).  This also fixes correctness within the function: the child-instance recursion no longer clobbers `module` before the parent's cell-creation step.

NOTE: `import_module` must NOT be the one to save/restore `module` — it runs `type_param_signature`'s get_width port-width probe BEFORE its own addModule, so restoring there nulls `module` during that probe and moves the crash into addWire.  The restore belongs in the hierarchy walker.

New repro test genscope_module_ctx_reset: a parent whose generate-scope continuous assign (referencing a parameter) is imported after a child instance with its own grandchild.

With this, CVA6 imports past the top module's generate scopes (next blocker is an unrelated `bht_q` gen-scope register resolution).