### PR TITLE
uhdm: import 2D unpacked array_net register from elaborated instance

### DIFF
--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -597,6 +597,7 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                             base = full_name.substr(0, dot_pos);
                         else
                             base = full_name;
+                        bool hp_expanded = false;
 
                         // Interface ports have a 1-bit `\<port>`
                         // placeholder wire (set in `import_port` with
@@ -646,13 +647,39 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                                     sig.is_part_select = true;
                                 sig.name = chosen;
                             } else {
-                                sig.name = base;
+                                // Per-element unpacked array (`bht_q[i][j] <= …`
+                                // where `bht_q` was materialised as per-element
+                                // wires \bht_q[0..N-1]): the base isn't a wire
+                                // but its elements are.  Register each element so
+                                // the async-ff temp-wire path finds them (CVA6
+                                // bht.sv bht_q; else "Signal bht_q not found").
+                                // Mirrors the whole-array ref_obj expansion above.
+                                if (!module->wire(RTLIL::escape_id(base)) &&
+                                    module->wire(RTLIL::escape_id(base + "[0]"))) {
+                                    for (int i = 0; module->wire(RTLIL::escape_id(
+                                             base + "[" + std::to_string(i) + "]"));
+                                         i++) {
+                                        AssignedSignal es;
+                                        es.name = base + "[" + std::to_string(i) + "]";
+                                        es.lhs_expr = sig.lhs_expr;
+                                        es.is_part_select = false;
+                                        signals.push_back(es);
+                                    }
+                                    log("extract_assigned_signals: expanded hier_path "
+                                        "unpacked array '%s' to per-element\n",
+                                        base.c_str());
+                                    hp_expanded = true;
+                                } else {
+                                    sig.name = base;
+                                }
                             }
                         }
 
-                        signals.push_back(sig);
-                        log("extract_assigned_signals: Found assignment to hier_path of '%s' (using '%s')\n",
-                            full_name.c_str(), sig.name.c_str());
+                        if (!hp_expanded) {
+                            signals.push_back(sig);
+                            log("extract_assigned_signals: Found assignment to hier_path of '%s' (using '%s')\n",
+                                full_name.c_str(), sig.name.c_str());
+                        }
                     }
                 }
             }

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -492,19 +492,25 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
             // AllModules represents an unpacked memory array as a scalar net
             // (the [0:N] dimension is dropped) — so a submodule memory collapses
             // to a wire and its dynamic accesses become $shiftx.  The elaborated
-            // instance carries the correct array_var; when the def is missing an
-            // array_var that its elaborated instance has, import that instead.
-            auto has_array_var = [](const module_inst* m) -> bool {
-                if (m && m->Variables())
+            // instance carries the correct array_var / array_net; when the def
+            // is missing an unpacked array that its elaborated instance has,
+            // import that instead.  Covers both an `array_var` (in Variables())
+            // and an `array_net` (in Array_nets()) — the CVA6 `bht` submodule's
+            // `bht_q[NR_ROWS][INSTR_PER_FETCH]` is an array_net.
+            auto has_unpacked_array = [](const module_inst* m) -> bool {
+                if (!m) return false;
+                if (m->Variables())
                     for (auto v : *m->Variables())
                         if (v->UhdmType() == uhdmarray_var) return true;
+                if (m->Array_nets() && !m->Array_nets()->empty())
+                    return true;
                 return false;
             };
             const module_inst* to_import = module_def;
             auto eit = elab_inst_by_def.find(mod_name);
-            if (eit != elab_inst_by_def.end() && has_array_var(eit->second) &&
-                !has_array_var(module_def)) {
-                log("UHDM: Importing %s from elaborated instance (has memory array_var lost in AllModules)\n",
+            if (eit != elab_inst_by_def.end() && has_unpacked_array(eit->second) &&
+                !has_unpacked_array(module_def)) {
+                log("UHDM: Importing %s from elaborated instance (has memory array lost in AllModules)\n",
                     mod_name.c_str());
                 to_import = eit->second;
             }


### PR DESCRIPTION
CVA6 aborted with "Signal bht_q not found in module".  bht.sv's `bht_q` is a MODULE-level 2D unpacked array of a packed struct (`bht_q[NR_ROWS][INSTR_PER_FETCH]`, inner dim from the struct-parameter field `CVA6Cfg.INSTR_PER_FETCH`), registered by an always_ff in the `gen_asic_bht` generate scope.

Two causes:

1. The submodule was imported from its AllModules DEFINITION, where the unpacked dimensions are stripped — `bht_q` is a collapsed scalar `logic_net` (import_net sized it from the element struct alone, wrongly width 2, dropping both array dims).  The "import from the elaborated instance when the def lost a memory array" guard only detected `array_var` (in Variables()); `bht_q` is an `array_net`.  Extend it to also detect `array_net` (Array_nets() non-empty).  The elaborated instance then flows through the existing Array_nets() materialisation loop, which creates per-element wires `\bht_q[0..N-1]` (struct width now correct = 3).

2. extract_assigned_signals' hier_path LHS path (`bht_q[i][j] <= '0`, the unrolled reset) set sig.name to the bare `bht_q`, which is not a wire (only per-element `\bht_q[k]` exist) → "not found".  Add per-element expansion mirroring the existing whole-array ref_obj path: when the base is not a wire but `base[0]` is, register each element so the async-ff temp-wire/sync path finds them.

With both, CVA6 (cv64a6_imafdc_sv39) imports past the bht module.

No minimal repro: the array_net collapse only manifests under CVA6's deep config-paramod hierarchy (minimal DUTs materialise the array as an `array_var` and resolve without either path).  Validated on CVA6 plus the array/memory/async-ff test suite.