### PR TITLE
uhdm: promote block-local vars in always_comb (fix chunk-width assert)

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -2601,6 +2601,15 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
                 actual_stmt = event_ctrl->Stmt();
             }
         }
+        // Promote begin-block-local variables (`always_comb begin automatic
+        // satp_t vsatp; … end`) to module wires with their real width BEFORE
+        // the assigned-signal scan tries to resolve them — otherwise a
+        // block-local struct var falls back to a width-1 "unknown signal" wire
+        // and a member slice (`vsatp.asid`, off 44 +: 16) overflows it,
+        // tripping the RTLIL chunk-width assert (CVA6 csr_regfile).  The
+        // always_ff path already does this.
+        block_local_promoted.clear();
+        create_block_local_wires(actual_stmt);
         extract_assigned_signals(actual_stmt, assigned_signals);
     }
     

--- a/test/blocklocal_struct_width/dut.sv
+++ b/test/blocklocal_struct_width/dut.sv
@@ -1,0 +1,26 @@
+// Reproducer for CVA6 csr_regfile chunk-width assert: a block-local
+// `automatic <struct> var` inside an always_comb whose struct has fields, with
+// a member write (`v.field = ...`).  If get_width collapses the block-local
+// struct_var to width 1, the member slice `\v[off+:w]` overflows.
+package p;
+  typedef struct packed {
+    logic [3:0]  mode;
+    logic [15:0] asid;
+    logic [43:0] ppn;
+  } satp_t;
+endpackage
+
+module blocklocal_struct_width (
+    input  logic        clk_i,
+    input  logic [63:0] wdata_i,
+    output logic [15:0] asid_o
+);
+  p::satp_t satp_q;
+  always_comb begin : upd
+    automatic p::satp_t vsatp;
+    vsatp = satp_q;
+    vsatp.asid = vsatp.asid & 16'hFF00;
+    asid_o = vsatp.asid;
+  end
+  always_ff @(posedge clk_i) satp_q <= p::satp_t'(wdata_i);
+endmodule


### PR DESCRIPTION
CVA6 aborted with `chunk_.offset + chunk_.width <= chunk_.wire->width` (rtlil.cc:5425).  Root cause: a block-local `automatic satp_t vsatp` in an always_comb (csr_regfile) was never promoted to a wire — `create_block_local_wires` was called only from `import_always_ff`.  In always_comb the block-local struct var therefore fell back to a width-1 "unknown signal" wire, so its member slice `vsatp.asid` (offset 44 +: 16) overflowed the 1-bit wire and tripped the RTLIL chunk-width assert.

Fix: call `create_block_local_wires(actual_stmt)` in `import_always_comb` before the assigned-signal scan, exactly as the always_ff path already does, so the block-local var gets a wire with its real (struct) width.

With this, read_uhdm imports the entire CVA6 (cv64a6_imafdc_sv39) design.

New test blocklocal_struct_width (passes formal equivalence): a block-local `automatic <struct> var` in an always_comb with a member write — reproduces the assert without the fix.