### PR TITLE
uhdm: don't $typaram-suffix a top-level module's name

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2676,8 +2676,13 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
     // A `parameter type` instance shares its generic DefName but has
     // specialized (e.g. struct) port types — append a per-type-binding
     // signature so it imports as its own module with the elaborated ports,
-    // instead of colliding with the 1-bit generic definition.
-    modname += type_param_signature(uhdm_module);
+    // instead of colliding with the 1-bit generic definition.  NOT for a
+    // top-level module: it is the sole instance of its def (nothing to
+    // collide with) and must keep its plain name so `hierarchy -top <name>`
+    // finds it (CVA6's top `cva6` has type params — else it imports as
+    // `cva6$typaram_...` and `hierarchy -top cva6` fails "Module not found").
+    if (!is_top_level)
+        modname += type_param_signature(uhdm_module);
 
     // Remember this instance's RTLIL module name (with any `$paramod`
     // specialization) so a nested child cell can target the correct parent.

--- a/test/top_module_type_param/dut.sv
+++ b/test/top_module_type_param/dut.sv
@@ -1,0 +1,13 @@
+// A TOP module that itself has a `parameter type`.  Its `$typaram` per-binding
+// signature must NOT be appended to the top's RTLIL name (it is the sole
+// instance of its def), so `hierarchy -top top_module_type_param` finds it
+// (CVA6's top `cva6` has type params — else it imported as `cva6$typaram_...`
+// and `hierarchy -top cva6` failed "Module not found").
+module top_module_type_param #(
+    parameter type data_t = logic [7:0]
+) (
+    input  data_t in_i,
+    output logic  parity_o
+);
+  assign parity_o = ^in_i;
+endmodule


### PR DESCRIPTION
A module instantiated with a `parameter type` gets a per-type-binding `$typaram_...` name suffix so distinct bindings don't collide with the generic definition.  But a TOP-level module is the sole instance of its def — there is nothing to collide with — and it must keep its plain name so `hierarchy -top <name>` can find it.

CVA6's top `cva6` has type parameters, so it was imported as `cva6$typaram_1_1_64_64_...` and `hierarchy -top cva6` failed with "Module `cva6' not found!".  Guard the suffix with the existing `is_top_level` flag (the surrounding code already documents that top modules must not carry parameters in their names).

With this, `hierarchy -top cva6` resolves the top after read_uhdm imports the whole design.

New test top_module_type_param: a top module that itself has a `parameter type` — imports under its plain name.