### PR TITLE
uhdm: coerce immediate-assert $check condition to 1 bit

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -174,6 +174,21 @@ static RTLIL::Cell* build_check_cell(UhdmImporter* self,
                                      const std::string& flavor,
                                      RTLIL::Wire*& enable_wire) {
     RTLIL::SigSpec condition = self->import_expression(expr);
+    // $check's A port is a 1-bit boolean.  import_expression can yield a wider
+    // value — e.g. a plain struct-parameter field used directly as the
+    // condition (`assert (Cfg.AxiIdWidth)`) that Surelog/ExprEval folds to a
+    // multi-bit constant.  Coerce to 1 bit (true = non-zero), matching the
+    // Verilog frontend's boolean coercion, else the $check cell fails RTLIL's
+    // port-width check (CVA6 axi_shim `initial assert`).
+    if (condition.size() != 1) {
+        if (condition.is_fully_const())
+            condition = condition.as_const().as_bool()
+                            ? RTLIL::State::S1 : RTLIL::State::S0;
+        else if (condition.size() == 0)
+            condition = RTLIL::State::S1;
+        else
+            condition = self->module->ReduceBool(NEW_ID, condition);
+    }
 
     enable_wire = self->module->addWire(NEW_ID);
     enable_wire->width = 1;

--- a/test/assert_wide_const_cond/dut.sv
+++ b/test/assert_wide_const_cond/dut.sv
@@ -1,0 +1,21 @@
+// Reproducer for CVA6 axi_shim "$check cell error": an immediate assert whose
+// condition is a struct-parameter-field comparison (`Cfg.W >= 2`) that folds to
+// a WIDE (64-bit) constant.  $check's A port must be 1-bit — build_check_cell
+// must reduce the condition.
+package cfg_pkg;
+  typedef struct packed { int unsigned W; } cfg_t;
+  localparam cfg_t DefaultCfg = '{W: 32'd4};
+endpackage
+
+module assert_wide_const_cond #(
+    parameter cfg_pkg::cfg_t Cfg = cfg_pkg::DefaultCfg
+) (
+    input logic clk_i,
+    input logic a_i,
+    output logic o_o
+);
+  initial begin
+    assert (Cfg.W) else $error("W must be nonzero");
+  end
+  assign o_o = a_i;
+endmodule


### PR DESCRIPTION
CVA6 failed hierarchy check with "Found error in internal cell … ($check)" (rtlil.cc:1685, port-width check): the $check cell's A port (the assert condition) was wider than 1 bit.  build_check_cell set A directly to import_expression(cond), and a plain struct-parameter field used as the condition (`initial assert (Cfg.AxiIdWidth)` in axi_shim) folds via Surelog/ExprEval to a multi-bit constant.

Fix: coerce the condition to a 1-bit boolean (true = non-zero) before wiring it to A, matching the Verilog frontend — fold constants inline, reduce a wider dynamic value with ReduceBool.

With this, CVA6 (cv64a6_imafdc_sv39) reads through the UHDM frontend and passes `hierarchy -check -top cva6` (196 modules, 0 fatal errors) — this was the last fatal blocker.

New test assert_wide_const_cond (UHDM-only): `initial assert (Cfg.W)` on a struct-parameter field — reproduces the $check port-width error.