### PR TITLE
uhdm: resolve a package-localparam sliced as a part-select base

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5709,6 +5709,13 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
                 base = RTLIL::SigSpec(module->parameter_default_values.at(param_id));
                 log("      Resolved '%s' as parameter for part select (width=%d)\n",
                     base_signal_name.c_str(), base.size());
+            } else if (package_parameter_map.count(base_signal_name)) {
+                // A package localparam sliced directly, e.g. CVA6 csr_regfile
+                // `ariane_pkg::SMODE_STATUS_WRITE_MASK[CVA6Cfg.XLEN-1:0]` — the
+                // base is a compile-time package constant, not a signal.
+                base = RTLIL::SigSpec(package_parameter_map.at(base_signal_name));
+                log("      Resolved '%s' as package parameter for part select (width=%d)\n",
+                    base_signal_name.c_str(), base.size());
             } else if (RTLIL::Wire* e0 =
                            (name_map.count(base_signal_name + "[0]")
                                 ? name_map[base_signal_name + "[0]"]
@@ -6561,6 +6568,10 @@ RTLIL::SigSpec UhdmImporter::import_indexed_part_select(const indexed_part_selec
                 RTLIL::IdString param_id = RTLIL::escape_id(base_signal_name);
                 if (module->parameter_default_values.count(param_id)) {
                     base = RTLIL::SigSpec(module->parameter_default_values.at(param_id));
+                } else if (package_parameter_map.count(base_signal_name)) {
+                    // Package localparam sliced with a dynamic/indexed range,
+                    // e.g. `ariane_pkg::SMODE_STATUS_WRITE_MASK[XLEN-1:0]`.
+                    base = RTLIL::SigSpec(package_parameter_map.at(base_signal_name));
                 } else {
                     std::string gen_scope = get_current_gen_scope();
                     log_warning("Base signal '%s' not found in module or generate scope %s\n",

--- a/test/pkg_localparam_partsel/dut.sv
+++ b/test/pkg_localparam_partsel/dut.sv
@@ -1,0 +1,16 @@
+// Reproducer for CVA6 csr_regfile `ariane_pkg::SMODE_STATUS_WRITE_MASK[XLEN-1:0]`
+// "Base signal not found" warning: a PACKAGE localparam sliced directly as the
+// base of a part-select.  It is a compile-time constant, not a signal, so it
+// must resolve from the package parameter map.
+package mask_pkg;
+  localparam logic [63:0] MASK = 64'hDEADBEEF_12345678;
+endpackage
+
+module pkg_localparam_partsel #(
+    parameter int XLEN = 32
+) (
+    input  logic            sel_i,
+    output logic [XLEN-1:0] o_o
+);
+  assign o_o = sel_i ? mask_pkg::MASK[XLEN-1:0] : '0;
+endmodule


### PR DESCRIPTION
CVA6 csr_regfile slices a package localparam directly — `ariane_pkg::SMODE_STATUS_WRITE_MASK[CVA6Cfg.XLEN-1:0]` (and `HSTATUS_WRITE_MASK`).  The base is a compile-time package constant, not a signal, so `import_part_select` / `import_indexed_part_select` failed to find a wire (or a module parameter) for it and warned "Base signal '…' not found", returning an empty/X slice.

Fix: after the module-parameter lookup, also consult `package_parameter_map` (keyed `pkg::name`, already used by import_hier_path) for the base — resolve the slice against the package constant's value.

Clears the SMODE_STATUS_WRITE_MASK / HSTATUS_WRITE_MASK warnings in CVA6.

New test pkg_localparam_partsel (passes formal equivalence): a package localparam sliced as `pkg::MASK[XLEN-1:0]`.