### PR TITLE
uhdm: resolve a function-argument part-select base via input_mapping

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5698,6 +5698,12 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
                     base_signal_name.c_str(), vs.c_str(), bw);
             }
         }
+        if (base.empty() && input_mapping && input_mapping->count(base_signal_name)) {
+            // Function argument sliced inside the function body (`data[hi:lo]`
+            // in repData64) — the base is the call argument in input_mapping,
+            // not a module wire.
+            base = input_mapping->at(base_signal_name);
+        }
         if (base.empty()) {
         RTLIL::Wire* wire = find_wire_in_scope(base_signal_name, "part select");
         if (wire) {
@@ -6553,6 +6559,13 @@ RTLIL::SigSpec UhdmImporter::import_indexed_part_select(const indexed_part_selec
     // Look up the wire in the current module
     RTLIL::SigSpec base;
     if (!base_signal_name.empty()) {
+        // A function argument (`repData64(input logic [..] data, ...)` used as
+        // `data[offset*8+:16]`): the base is passed via input_mapping, not a
+        // module wire (CVA6 wt_dcache_wbuffer repData64 — else "Base signal
+        // 'data' not found").  Prefer it so the slice reads the call argument.
+        if (input_mapping && input_mapping->count(base_signal_name)) {
+            base = input_mapping->at(base_signal_name);
+        } else
         // If this is a for-loop variable, substitute its current constant value
         if (loop_values.count(base_signal_name)) {
             int lv = loop_values.at(base_signal_name);

--- a/test/func_arg_partsel_loop/dut.sv
+++ b/test/func_arg_partsel_loop/dut.sv
@@ -1,0 +1,23 @@
+// Reproducer for CVA6 wt_dcache_wbuffer repData64 "Base signal 'data' not
+// found": a function INPUT argument (`data`) is part-selected inside the
+// function body (`data[offset*8+:16]`).  The base is the call argument passed
+// via input_mapping, not a module wire.
+module func_arg_partsel_loop (
+    input  logic [63:0] d_i,
+    input  logic [2:0]  off_i,
+    input  logic [1:0]  size_i,
+    output logic [63:0] o_o
+);
+  function automatic logic [63:0] rep(
+      input logic [63:0] data, input logic [2:0] offset, input logic [1:0] size);
+    logic [63:0] out;
+    unique case (size)
+      2'b00:   for (int k = 0; k < 8; k++) out[k*8+:8]   = data[offset*8+:8];
+      2'b01:   for (int k = 0; k < 4; k++) out[k*16+:16] = data[offset*8+:16];
+      2'b10:   for (int k = 0; k < 2; k++) out[k*32+:32] = data[offset*8+:32];
+      default: out = data;
+    endcase
+    return out;
+  endfunction
+  assign o_o = rep(d_i, off_i, size_i);
+endmodule


### PR DESCRIPTION
CVA6 wt_dcache_wbuffer's `repData64` part-selects a function INPUT argument inside its body — `data[offset*8 +: 16]` — where `data` is the function argument, passed at the call site through `input_mapping`. import_part_select / import_indexed_part_select resolved the base only from module wires / parameters, so it warned "Base signal 'data' not found" (14× in CVA6, once per for-loop-unrolled slice) and returned an X slice.

Fix: consult `input_mapping` for the base name first (before the wire / parameter lookups) in both part-select importers, so a sliced function argument reads the actual call argument.

New test func_arg_partsel_loop (UHDM-only — read_verilog rejects the SV): a function arg sliced by a dynamic index in a for-loop; reproduces the 14 "Base signal 'data' not found" warnings without the fix.