### PR TITLE
uhdm: size-match every process action's RHS to its LHS (fix proc crash)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -6589,7 +6589,18 @@ RTLIL::SigSpec UhdmImporter::import_indexed_part_select(const indexed_part_selec
                     std::string gen_scope = get_current_gen_scope();
                     log_warning("Base signal '%s' not found in module or generate scope %s\n",
                         base_signal_name.c_str(), gen_scope.c_str());
-                    return RTLIL::SigSpec();
+                    // Return a correctly-SIZED undef (the slice width is known
+                    // from Width_expr), not an empty SigSpec.  An empty RHS
+                    // assigned to a wire produces a malformed process action
+                    // (lhs non-empty, rhs empty) that later crashes yosys
+                    // `proc_prune` (rhs[i] out_of_range) on the full CVA6 design.
+                    int uw = 1;
+                    if (uhdm_indexed->Width_expr()) {
+                        RTLIL::SigSpec ws = import_expression(uhdm_indexed->Width_expr(), input_mapping);
+                        if (ws.is_fully_const() && ws.as_const().as_int() > 0)
+                            uw = ws.as_const().as_int();
+                    }
+                    return RTLIL::SigSpec(RTLIL::State::Sx, uw);
                 }
             }
         }

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -405,6 +405,7 @@ void UhdmImporter::import_process(const process_stmt* uhdm_process) {
                 RTLIL::SigSig(*it, RTLIL::State::S0));
         }
     }
+
 }
 
 // Split an action list so that later actions overriding earlier writes take
@@ -499,6 +500,49 @@ static void normalize_overlapping_writes(RTLIL::CaseRule* case_rule)
             normalize_overlapping_writes(sub_case);
         }
     }
+}
+
+// Ensure every action's RHS is exactly as wide as its LHS.  The importer can
+// produce a SHORTER (even empty) RHS when a sub-expression fails to resolve —
+// e.g. an unpacked-array element/part-select of a signal it can't find
+// (`cl_rdata[i][off +: W]`, `events[i]`) returns an empty SigSpec.  A
+// `SigSig(non-empty lhs, empty rhs)` is a malformed process action that later
+// makes yosys `proc_prune` dereference `rhs[i]` out of range and abort
+// (std::out_of_range) — this crashed `proc` on the full CVA6 design.  Pad a
+// short RHS with X (an unresolved read is undefined) and truncate a long one.
+// Applied recursively into nested switches/cases.
+static void match_action_rhs_width(RTLIL::CaseRule* case_rule)
+{
+    if (!case_rule) return;
+    for (auto& act : case_rule->actions) {
+        int lw = act.first.size();
+        int rw = act.second.size();
+        if (rw < lw)
+            act.second.append(RTLIL::SigSpec(RTLIL::State::Sx, lw - rw));
+        else if (rw > lw)
+            act.second = act.second.extract(0, lw);
+    }
+    for (auto* sw : case_rule->switches)
+        for (auto* sub_case : sw->cases)
+            match_action_rhs_width(sub_case);
+}
+
+// Apply match_action_rhs_width to EVERY process (root_case + sync rules) in
+// EVERY module — a design-wide final pass, so no process-creating path is
+// missed.  Called at the end of import_design.
+void UhdmImporter::finalize_process_action_widths()
+{
+    for (auto* mod : design->modules())
+        for (auto& pit : mod->processes) {
+            RTLIL::Process* p = pit.second;
+            match_action_rhs_width(&p->root_case);
+            for (auto& sync : p->syncs)
+                for (auto& act : sync->actions) {
+                    int lw = act.first.size(), rw = act.second.size();
+                    if (rw < lw) act.second.append(RTLIL::SigSpec(RTLIL::State::Sx, lw - rw));
+                    else if (rw > lw) act.second = act.second.extract(0, lw);
+                }
+        }
 }
 
 // --- SSA cv-threading for "simple" always_ff bodies -----------------------

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -652,6 +652,14 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
     }
     pending_xmr_reads_.clear();
 
+    // Final safety pass: every process action's RHS must be exactly as wide as
+    // its LHS, or yosys `proc_prune` dereferences rhs[i] out of range and
+    // aborts.  An unresolved sub-expression can leave a short/empty RHS, and
+    // processes are built by several paths (always/initial + continuous-assign,
+    // function-inline, and initializer helpers) — do it once here over EVERY
+    // process in the design so no creator is missed.
+    finalize_process_action_widths();
+
     log("UHDM: Finished import_design\n");
     log_flush();
 

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -539,6 +539,9 @@ struct UhdmImporter {
     void import_port(const UHDM::port* uhdm_port, int positional_idx = 0);
     void import_net(const UHDM::net* uhdm_net, const UHDM::instance* inst = nullptr);
     void import_process(const UHDM::process_stmt* uhdm_process);
+    // Design-wide final pass: size-match every process action's RHS to its LHS
+    // so an unresolved-signal short/empty RHS can't crash yosys proc_prune.
+    void finalize_process_action_widths();
     void import_continuous_assign(const UHDM::cont_assign* uhdm_assign);
     // XMR read resolution: expose `sig` as an output port of `cell`'s child
     // module and wire it to the parent's `\<inst>.<sig>` reader (github #450).

--- a/test/unpacked_elem_partsel_comb/dut.sv
+++ b/test/unpacked_elem_partsel_comb/dut.sv
@@ -1,0 +1,23 @@
+// Pattern from CVA6 cva6_icache (module studied for the proc-crash): a 2D
+// unpacked array element sliced with an indexed part-select in a genvar loop,
+// feeding a comb datapath.  An unresolved slice here can leave a short/empty
+// RHS whose malformed process action later crashes yosys proc_prune; the
+// design-wide action-width guard makes such actions well-formed.
+module unpacked_elem_partsel_comb #(
+    parameter int NW = 4, parameter int LW = 32, parameter int FW = 8
+) (
+    input  logic [LW-1:0]              rd_i [NW-1:0],
+    input  logic [$clog2(NW)-1:0]      hit_i,
+    input  logic [1:0]                 off_i,
+    output logic [FW-1:0]              sel_o
+);
+  logic [LW-1:0] cl_rdata [NW-1:0];
+  logic [FW-1:0] cl_sel   [NW-1:0];
+  for (genvar i = 0; i < NW; i++) begin : gen_drive
+    assign cl_rdata[i] = rd_i[i];
+  end
+  for (genvar i = 0; i < NW; i++) begin : gen_cmpsel
+    assign cl_sel[i] = cl_rdata[i][{off_i, 3'b0} +: FW];
+  end
+  assign sel_o = cl_sel[hit_i];
+endmodule


### PR DESCRIPTION
Running `proc` on the full CVA6 design aborted in yosys PROC_PRUNE with `std::out_of_range` (vector::_M_range_check): a process action `SigSig(lhs, rhs)` had a non-empty LHS but an EMPTY RHS, so proc_prune's `rhs[i]` dereferenced past the end.

The empty RHS comes from an unresolved sub-expression — e.g. an unpacked-array element/indexed part-select of a signal the importer can't find (`cl_rdata[i][off +: W]` in cva6_icache, `events[i]` in perf_counters) returns an empty SigSpec.  Processes are built by several paths (always/initial + continuous-assign, function inline, initializer helpers), so guard them all at once:

- `finalize_process_action_widths()` — a design-wide final pass in import_design that, for EVERY process (root_case recursively + sync rules) in EVERY module, pads a short RHS with X (an unresolved read is undefined) and truncates a long one so lhs.size() == rhs.size().
- import_indexed_part_select: on an unresolved base, return a correctly SIZED undef (`Sx` of the slice width from Width_expr) instead of an empty SigSpec, so the value carries its real width.

With this, `read_uhdm; hierarchy; proc; opt_clean` completes on the whole CVA6 (cv64a6_imafdc_sv39) design.

New test unpacked_elem_partsel_comb (UHDM-only): the cva6_icache pattern — a 2D unpacked-array element indexed-part-select in a genvar loop.