### PR TITLE
uhdm: don't X an explicit case default's held-through signals (comb)

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10964,6 +10964,21 @@ void UhdmImporter::emit_full_case_default(const case_stmt* uhdm_case, RTLIL::Swi
     for (auto c : sw->cases) {
         if (c->compare.empty()) { default_case = c; break; }
     }
+    // An EXPLICIT `default:` clause makes the case fully covered: every value
+    // is handled, and a signal NOT assigned by the default arm must HOLD its
+    // pre-case value (the block-level default), NOT be forced to X.  The
+    // full_case X-default is ONLY the don't-care fill for the IMPLICIT default
+    // of a `unique`/`priority` case that has no default clause.  X-ing a
+    // held-through signal here is wrong: CVA6 compressed_decoder's outer
+    // `unique case (instr_i[1:0]) … default: is_compressed_o = 1'b0;` leaves
+    // instr_o at its block default `instr_o = instr_i`, but X-ing it made every
+    // UNCOMPRESSED instruction decode to X (masked before only by a buggy
+    // always-true trailing `if (illegal)`).  So in always_comb skip the
+    // X-default entirely when the user wrote a default clause.  always_ff still
+    // needs it for its blocking temps (picorv32 cpu_state unreachable-state
+    // fill), so only the comb path returns early.
+    if (default_case && !in_always_ff_context)
+        return;
     if (!default_case) {
         default_case = new RTLIL::CaseRule;
         sw->cases.push_back(default_case);

--- a/test/nested_case_concat/dut.sv
+++ b/test/nested_case_concat/dut.sv
@@ -1,17 +1,27 @@
-// Reproduces compressed_decoder.sv: a signal (illegal_o) is conditionally set
-// inside a nested unique-case, then read by a TRAILING `if (illegal_o) ...`
-// that overrides a wide output.  The frontend threads illegal_o's in-progress
-// comb value into the trailing `if` via a mux tree (thread_comb_case) that
-// must exactly mirror the nested case — if it yields the wrong value, the
-// override wrongly fires and clobbers the decoded output.
+// Reproduces compressed_decoder.sv on two fronts:
+//
+// (1) thread_comb_case/if: a signal (illegal_o) set inside a nested case/if is
+//     read by a TRAILING `if (illegal_o) instr_o = instr_i;`.  The frontend
+//     threads illegal_o's in-progress comb value into that `if`; if the thread
+//     mux is wrong the override wrongly fires and clobbers the decoded output.
+//
+// (2) emit_full_case_default: the OUTER `unique case` has an explicit
+//     `default:` that sets is_comp_o = 0 (the "uncompressed" arm) but does NOT
+//     assign instr_o — so instr_o must HOLD its block default `instr_o =
+//     instr_i` (passthrough).  X-ing it in the full_case default made every
+//     uncompressed input decode to X (masked before by a buggy always-true
+//     trailing `if`).  Here illegal_o stays 0 for that arm, so nothing masks a
+//     wrong passthrough — the miter catches it.
 module nested_case_concat (
     input  logic [31:0] instr_i,
     output logic [31:0] instr_o,
-    output logic        illegal_o
+    output logic        illegal_o,
+    output logic        is_comp_o
 );
     always_comb begin
         illegal_o = 1'b0;
-        instr_o   = instr_i;            // default passthrough
+        is_comp_o = 1'b1;
+        instr_o   = instr_i;            // block default: passthrough
         unique case (instr_i[1:0])
             2'b00: begin
                 unique case (instr_i[15:13])
@@ -27,10 +37,13 @@ module nested_case_concat (
                     default: illegal_o = 1'b1;
                 endcase
             end
-            default: illegal_o = 1'b1;
+            2'b01: instr_o = {instr_i[15:0], 16'h0001};
+            2'b10: instr_o = {16'h0002, instr_i[15:0]};
+            // Uncompressed: does NOT touch instr_o (must hold instr_i) nor illegal_o.
+            default: is_comp_o = 1'b0;
         endcase
 
-        // Trailing read of the case-accumulated illegal_o (the crux).
+        // Trailing read of the case-accumulated illegal_o (the crux of (1)).
         if (illegal_o) begin
             instr_o = instr_i;
         end


### PR DESCRIPTION
Follow-up to a943fe2a (comb case/if threading), which fixed CVA6 compressed_decoder's compressed-instruction decode but EXPOSED a latent emit_full_case_default bug: every UNCOMPRESSED instruction (instr_i[1:0]== 2'b11) then decoded to X.

compressed_decoder's outer `unique case (instr_i[1:0]) … default: is_compressed_o = 1'b0;` has an EXPLICIT default arm that assigns only is_compressed_o, leaving instr_o at its block default `instr_o = instr_i` (passthrough).  emit_full_case_default only skipped signals the default arm *assigns*, so it appended `instr_o = 32'x` to that arm — X-ing a signal that should HOLD.  Before a943fe2a a buggy always-true trailing `if (illegal_instr_o) instr_o = instr_i;` masked the X (it set instr_o = instr_i for everything); once the threading was correct the X surfaced.  id_stage feeds compressed_decoder.instr_o straight into the main decoder (`instruction_deco = instruction_rvc`), so this corrupted every uncompressed instruction.

Fix: the full_case X-default is the don't-care fill for the IMPLICIT default of a `unique`/`priority` case with NO default clause.  When the user wrote an explicit `default:` the case is fully covered and unassigned signals must hold, so in always_comb skip the X-default entirely (`if (default_case && !in_always_ff_context) return;`).  always_ff still needs the X for its blocking temps (picorv32 cpu_state unreachable-state fill), so only the comb path returns early.

Verified: cache-elaborated compressed_decoder now gives instr_o = instr_i for uncompressed input, 0x05442783 for c.lw, 0x0d043783 for c.ld, and passthrough for an illegal c.addi4spn.  test/nested_case_concat extended so its outer default is uncompressed-like (sets a status flag, not illegal) — instr_o passthrough is then unmasked and checked by formal equivalence. Case/FSM/picorv32 subsets pass unchanged.