### PR TITLE
uhdm: link type-param child instances to their resolved module (fix b…

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1955,6 +1955,43 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                 // instance (appended after any value-parameter $paramod part).
                 cell_type += cell_tsig;
 
+                // The cell_type built above can diverge from the ACTUAL imported
+                // module name: type_param_signature() sizes the ports with
+                // get_width() at CELL-creation time (this instance's module isn't
+                // `this->module` yet, so a param-dependent range only resolves to
+                // an APPROXIMATE width), while import_module() named the module
+                // from the RESOLVED widths.  The mismatch (e.g. CVA6 frontend cell
+                // `$paramod\frontend$typaram_…_8_…_42_74` vs module
+                // `\frontend$typaram_…_134_…_365_366`) turns EVERY type-param'd
+                // child into a blackbox, so `flatten`/`synth -top cva6` yields an
+                // empty netlist.  `module` (resolved at ~line 1841) IS the module
+                // this instance points at, so when the computed type has no
+                // matching module, use the resolved module's real name — this
+                // makes the cell link so the hierarchy actually flattens.
+                if (!design->module(RTLIL::escape_id(cell_type))) {
+                    // Candidate real names, in priority order: the name
+                    // import_module recorded for THIS elaborated instance, then
+                    // the module `module` resolved to.
+                    std::vector<std::string> candidates;
+                    auto tm_it = inst_to_modname_.find(uhdm_module);
+                    if (tm_it != inst_to_modname_.end())
+                        candidates.push_back(tm_it->second);
+                    if (module)
+                        candidates.push_back(module->name.str());
+                    for (auto real : candidates) {
+                        if (!real.empty() && real[0] == '\\')
+                            real = real.substr(1);
+                        if (!real.empty() &&
+                            design->module(RTLIL::escape_id(real))) {
+                            log("UHDM: cell_type %s has no module; using resolved "
+                                "module name %s instead\n", cell_type.c_str(),
+                                real.c_str());
+                            cell_type = real;
+                            break;
+                        }
+                    }
+                }
+
                 log("UHDM: Creating cell %s of type %s in parent %s\n",
                     inst_name.c_str(), cell_type.c_str(), parent_name.c_str());
 


### PR DESCRIPTION
…lackboxes)

The full cva6 design could not be flattened/synthesized: `flatten` / `synth -top cva6` produced a ~45-cell EMPTY netlist because 0 of 116 `$paramod\...` submodule instance CELL types matched any imported MODULE name — every type-parameterized child (frontend, ex_stage, id_stage, issue_stage, csr_regfile, wt_cache_subsystem, …) was a silent blackbox. `hierarchy -check -top cva6` still returned rc=0, so this went unnoticed; the "whole design lowers to a netlist" milestone had only lowered the 61 TOP-level cells.

Root cause: import_module_hierarchy builds the child cell's type with type_param_signature(), which sizes the ports via get_width() at CELL-creation time — but this instance's module isn't `this->module` yet, so a parameter-dependent port range only resolves to an APPROXIMATE width. import_module() named the actual module from the RESOLVED widths.  The two diverge, e.g. cell `$paramod\frontend$typaram_…_8_1_…_5_42_74_1_1` vs module `\frontend$typaram_…_134_1_…_68_365_366_1_1`, so the cell references a module that doesn't exist.

Fix: after building the cell type, if no module of that name exists, fall back to the name the frontend actually recorded for THIS elaborated instance — `inst_to_modname_[uhdm_module]` (set by import_module), else the module `module` was resolved to.  Only overrides a would-be blackbox and only when the replacement names a real module, so working (non-type-param) cells like id_stage's `\compressed_decoder` are untouched.

Result: flattened cva6 goes from 45 cells to 61,642 cells (210 processes, 65k wires) — a real full-core netlist.  This unblocks full-design synthesis and simulation.