### PR TITLE
uhdm: size a packed-array-of-struct net (packed_array_net) correctly

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -15,6 +15,7 @@
 #include <uhdm/uhdm_types.h>
 #include <uhdm/union_typespec.h>
 #include <uhdm/packed_array_typespec.h>
+#include <uhdm/packed_array_net.h>
 #include <uhdm/ExprEval.h>
 #include <uhdm/func_call.h>
 #include <uhdm/function.h>
@@ -2356,6 +2357,36 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
             }
         }
         
+        // A packed array of a struct/type-param net (`struct_t [N:0] sig`)
+        // elaborates to a packed_array_net whose base Typespec() is null and
+        // whose dims live on Ranges()/Elements() — width = element_width *
+        // product(ranges), same as packed_array_var.  Without this such a net
+        // collapsed to a 1-bit wire (CVA6 cva6.sv:418
+        // `fetch_entry_t [NrIssuePorts-1:0] fetch_entry_if_id`, :660
+        // `dcache_req_i_t [2:0] dcache_req_ports_ex_cache`), so the connected
+        // submodule port (id_stage.fetch_entry_i = 366 bits) was resized from
+        // 1 bit at flatten, corrupting the connection.  Checked BEFORE the
+        // generic net branch (which returns 1 on the null typespec).
+        if (auto pan = dynamic_cast<const UHDM::packed_array_net*>(uhdm_obj)) {
+            int range_total = 1;
+            if (pan->Ranges()) {
+                for (auto r : *pan->Ranges()) {
+                    if (r->Left_expr() && r->Right_expr()) {
+                        RTLIL::SigSpec ls = import_expression(r->Left_expr());
+                        RTLIL::SigSpec rs = import_expression(r->Right_expr());
+                        if (ls.is_fully_const() && rs.is_fully_const())
+                            range_total *= std::abs(ls.as_int() - rs.as_int()) + 1;
+                    }
+                }
+            }
+            int elem_width = 1;
+            if (pan->Elements() && !pan->Elements()->empty())
+                elem_width = get_width((*pan->Elements())[0], inst);
+            log("UHDM: packed_array_net width = %d * %d = %d\n",
+                elem_width, range_total, elem_width * range_total);
+            return elem_width * range_total;
+        }
+
         // Check if it's a net and try to get typespec
         if (auto net = dynamic_cast<const UHDM::net*>(uhdm_obj)) {
             log("UHDM: Found net object\n");

--- a/test/packed_array_struct/dut.sv
+++ b/test/packed_array_struct/dut.sv
@@ -1,0 +1,22 @@
+// Reproducer: a packed array of a `localparam type` struct (a TYPE PARAMETER,
+// as CVA6 uses: cva6.sv:83 `localparam type fetch_entry_t = struct packed {…}`
+// then cva6.sv:418 `fetch_entry_t [NrIssuePorts-1:0] fetch_entry_if_id;`).
+// The packed array collapsed to a 1-bit wire, so a connected submodule port
+// (id_stage.fetch_entry_i, 366 bits) was resized from 1 bit at flatten.
+module packed_array_struct (
+    input  logic clk,
+    output logic [63:0] sum
+);
+    localparam type my_t = struct packed {
+        logic [31:0] a;
+        logic [15:0] b;
+        logic [7:0]  c;
+    };                            // 56-bit struct type-param
+
+    my_t        scalar_sig;       // 56 bits
+    my_t [2:0]  arr;              // 3*56 = 168 bits (collapses to 1 in CVA6)
+
+    assign scalar_sig = '0;
+    assign arr        = '0;
+    assign sum = scalar_sig.a + arr[0].a + arr[2].b;
+endmodule


### PR DESCRIPTION
A net declared as a packed array of a struct / `localparam type` struct — CVA6 cva6.sv:418 `fetch_entry_t [CVA6Cfg.NrIssuePorts-1:0] fetch_entry_if_id;` and :660 `dcache_req_i_t [2:0] dcache_req_ports_ex_cache;` — collapsed to a 1-BIT wire.  A connected submodule port (e.g. id_stage.fetch_entry_i, 366 bits) was then resized from 1 bit when the hierarchy flattened, corrupting the connection.

Root cause: such a net ELABORATES to a `packed_array_net`, not a logic_net. `get_width`'s generic net branch calls `net->Typespec()`, which is NULL for a packed_array_net (its dims live on Ranges()/Elements()), so the width fell through to the default 1.  A scalar struct net works because it is a plain logic_net with a resolvable struct typespec.

Fix: handle `packed_array_net` in `get_width` before the generic net branch — width = element_width * product(ranges), mirroring the existing packed_array_var path.

New test packed_array_struct (UHDM-only; native Verilog can't parse the `localparam type` form): scalar `my_t` stays 56 bits, `my_t [2:0]` is now 168 (was 1).  On the full cva6 flatten this removes the fetch_entry / dcache_req packed-array port stubs.