### PR TITLE
uhdm: match under-resolved part-select port connection to child port …

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2287,6 +2287,37 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
                                 }
                             }
 
+                            // A child port connection that is a full-width part
+                            // select `base[EXPR-1:0]` whose range EXPR is a
+                            // struct-parameter field the frontend can't fold
+                            // (CVA6 `.boot_addr_i(boot_addr_i[CVA6Cfg.VLEN-1:0])`,
+                            // CVA6Cfg computed by build_config()) resolves to
+                            // `base[0]` — 1 bit.  When the base wire AND the child
+                            // port are both wider and the select starts at bit 0,
+                            // the intended connection is the base's low port-width
+                            // bits.  Reconstruct it so the port isn't wired 1-bit
+                            // and silently zero-extended at flatten (which drops
+                            // base[hi:1]).  Guard is tight: only a single-chunk,
+                            // offset-0 connection NARROWER than the port on a
+                            // wide-enough base — a shape a legitimate connection
+                            // never has (that would be an SV width mismatch).
+                            if (high_conn->UhdmType() == uhdmpart_select &&
+                                conn.is_chunk() && !conn.empty()) {
+                                RTLIL::Module* tgt = design->module(cell->type);
+                                RTLIL::Wire* pw = tgt ?
+                                    tgt->wire(RTLIL::escape_id(port_name)) : nullptr;
+                                RTLIL::SigChunk ch = conn.as_chunk();
+                                if (pw && ch.wire && ch.offset == 0 &&
+                                    conn.size() < pw->width &&
+                                    ch.wire->width >= pw->width) {
+                                    conn = RTLIL::SigSpec(ch.wire, 0, pw->width);
+                                    log("UHDM: port %s part-select under-resolved "
+                                        "(%d bits); using base %s[%d:0]\n",
+                                        port_name.c_str(), ch.width,
+                                        ch.wire->name.c_str(), pw->width - 1);
+                                }
+                            }
+
                             // For signed constants connected to wider ports, create a signed
                             // intermediate wire so the hierarchy pass will sign-extend them.
                             // Unsigned constants are left as-is (hierarchy zero-extends).

--- a/test/portsel_struct_param/dut.sv
+++ b/test/portsel_struct_param/dut.sv
@@ -1,0 +1,33 @@
+// Reproducer for CVA6 `.boot_addr_i(boot_addr_i[CVA6Cfg.VLEN-1:0])` (cva6.sv:692).
+// The CHILD port resolves to the correct width (like id_stage.fetch_entry_i =
+// 366), but the parent's port-connection part-select range uses a struct-param
+// field CFG.VLEN that the frontend can't fold (CFG computed by build_config()),
+// so the connection collapses to `boot_addr_i[0]` (1 bit) and gets resized from
+// 1 bit at flatten — dropping boot_addr_i[63:1].
+package cfg_pkg;
+  typedef struct packed { logic [31:0] VLEN; logic [31:0] XLEN; } cfg_t;
+  localparam int unsigned CVA6ConfigXlen = 64;
+  function automatic cfg_t build_config();
+    cfg_t c; c.VLEN = CVA6ConfigXlen; c.XLEN = CVA6ConfigXlen; return c;
+  endfunction
+  localparam cfg_t CFG = build_config();
+endpackage
+
+module child (
+    input  logic [63:0] addr_i,      // fixed 64-bit port (resolves correctly)
+    output logic [63:0] addr_o
+);
+    assign addr_o = addr_i ^ 64'h1;
+endmodule
+
+module portsel_struct_param #(
+    parameter cfg_pkg::cfg_t CFG = cfg_pkg::build_config()
+) (
+    input  logic [63:0] boot_addr_i,
+    output logic [63:0] out
+);
+    child c (
+        .addr_i(boot_addr_i[CFG.VLEN-1:0]),  // part-select range = CFG.VLEN
+        .addr_o(out)
+    );
+endmodule


### PR DESCRIPTION
…width

CVA6 `.boot_addr_i(boot_addr_i[CVA6Cfg.VLEN-1:0])` (cva6.sv:692) wired the child port with `boot_addr_i[0]` — 1 bit — because the part-select range `CVA6Cfg.VLEN-1` couldn't be folded: CVA6Cfg is computed by `build_config_pkg::build_config(...)`, and neither eval_param_struct_field (it only walks an assignment-pattern parameter value, not a function-computed one) nor ExprEval::reduceExpr can evaluate it, so `CVA6Cfg.VLEN` resolved to
1.  Surelog leaves this range UNfolded (unlike the wire declaration's typespec, which it pre-folds), so the parent-side connection collapsed and was zero-extended from 1 bit at flatten — silently dropping boot_addr_i[63:1].

Fix (import_module_hierarchy): after importing a port connection, if the high_conn is a `part_select`, the connection is a single chunk at offset 0 that is NARROWER than the child port, and the base wire is at least the port width, reconnect the base's low port-width bits.  The intended value of a `base[WIDTH-1:0]` select whose WIDTH matches the (correctly-resolved) child port is exactly base[port_width-1:0].  The guard shape (offset-0 chunk narrower than the port on a wide-enough base) is one a legitimate connection never has — that would be an SV width mismatch — so it only rescues the under-resolved case.

On the full cva6 flatten this removes the boot_addr_i / hart_id_i / vaddr_from_lsu_i CVA6Cfg-field part-select port stubs (flatten 1-bit resizes 16 -> 13).  New test portsel_struct_param (UHDM-only) reproduces the exact shape: a fixed-width child port fed `base[CFG.VLEN-1:0]` with CFG built by a function; the connection is now the full base, not base[0].