### PR TITLE
uhdm: element-index a packed-array-of-struct variable (packed_array_var)

### DIFF
--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -3585,7 +3585,39 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                     wire_map[var] = wire;
                     name_map[var_name] = wire;
                     add_src_attribute(wire->attributes, var);
-                    
+
+                    // A packed array of a struct / type-param (`struct_t [N:0]
+                    // arr`) is elaborated as a packed_array_var and its flat wire
+                    // is created here.  Tag it with packed-element metadata so
+                    // import_bit_select resolves `arr[i]` as ELEMENT i
+                    // (struct-width bits), not bit i.  Without this CVA6
+                    // alu_wrapper `.fu_data_i(fu_data_i[0])` (fu_data_t
+                    // [NrALUs-1:0]) wired bit 0 (1 bit) instead of element 0.
+                    if (auto pav = dynamic_cast<const UHDM::packed_array_var*>(var)) {
+                        int outer_l = -1, outer_r = -1;
+                        if (pav->Ranges() && !pav->Ranges()->empty()) {
+                            auto r0 = (*pav->Ranges())[0];
+                            if (r0->Left_expr() && r0->Right_expr()) {
+                                RTLIL::SigSpec l = import_expression(r0->Left_expr());
+                                RTLIL::SigSpec r = import_expression(r0->Right_expr());
+                                if (l.is_fully_const() && r.is_fully_const()) {
+                                    outer_l = l.as_int();
+                                    outer_r = r.as_int();
+                                }
+                            }
+                        }
+                        int elem_w = 0;
+                        if (pav->Elements() && !pav->Elements()->empty())
+                            elem_w = get_width((*pav->Elements())[0], uhdm_module);
+                        if (elem_w > 1 && outer_l >= 0 && outer_r >= 0) {
+                            wire->attributes[RTLIL::escape_id("packed_elem_width")] = RTLIL::Const(elem_w);
+                            wire->attributes[RTLIL::escape_id("packed_outer_left")] = RTLIL::Const(outer_l);
+                            wire->attributes[RTLIL::escape_id("packed_outer_right")] = RTLIL::Const(outer_r);
+                            log("UHDM: packed_array_var '%s' elem_width=%d outer=[%d:%d]\n",
+                                var_name.c_str(), elem_w, outer_l, outer_r);
+                        }
+                    }
+
                     // Import attributes (e.g., (* keep *), (* anyconst *))
                     if (auto variables = any_cast<const UHDM::variables*>(var)) {
                         if (variables->Attributes()) {

--- a/test/packed_array_elem_select/dut.sv
+++ b/test/packed_array_elem_select/dut.sv
@@ -1,0 +1,18 @@
+module child (
+    input  logic [95:0] data_i,
+    output logic [63:0] o
+);
+    assign o = data_i[63:0] ^ data_i[95:64];
+endmodule
+
+module packed_array_elem_select (
+    input  logic [95:0] a0,
+    input  logic [95:0] a1,
+    output logic [63:0] o
+);
+    typedef struct packed { logic [63:0] x; logic [31:0] y; } my_t;  // 96-bit
+    my_t [1:0] arr;
+    assign arr[0] = a0;
+    assign arr[1] = a1;
+    child c (.data_i(arr[0]), .o(o));
+endmodule


### PR DESCRIPTION
`arr[i]` on a packed array of a struct (`struct_t [N:0] arr`) returned BIT i, not ELEMENT i (struct-width bits).  CVA6 alu_wrapper.sv:36 `.fu_data_i(fu_data_i[0])` and similar wired a single bit where an element was meant, so the connected 207-bit port was resized from 1 bit at flatten.

import_bit_select element-indexes when the base wire carries the `packed_elem_width` / `packed_outer_left` / `packed_outer_right` attributes. import_port sets these for a logic_typespec port, but such an array is elaborated as a `packed_array_var` whose flat wire is created by the generic "Regular variable" path in import_module — which never tagged it.  So `arr[i]` fell through to a 1-bit select.

Fix: after creating the variable's wire, if it is a packed_array_var, set the packed-element metadata — elem_width = width of Elements()[0] (the struct), outer range from Ranges()[0].  Mirrors the packed_array_net width fix and the import_port path.

New test packed_array_elem_select (UHDM-only): `my_t [1:0] arr; child c(.data_i(arr[0]))` now connects `arr[95:0]` (element 0), not `{95'0, arr[0]}`.  On the full cva6 flatten this clears a packed-array element-select port stub (1-bit resizes 13 -> 12).  A remaining sibling case is the same shape on a PORT declaration (alu_wrapper's `fu_data_i`), whose packed-array metadata still needs setting in import_port.