### PR TITLE
uhdm: element-index a packed-array-of-struct PORT (Low_conn packed_ar…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -700,6 +700,45 @@ void UhdmImporter::import_port(const port* uhdm_port, int positional_idx) {
     // Add source attribute
     add_src_attribute(w->attributes, uhdm_port);
 
+    // A packed-array-of-struct PORT (`fu_data_t [NrALUs-1:0] fu_data_i`)
+    // presents with an EMPTY-Ranges logic_typespec (the outer dim isn't there
+    // for a type-param struct element), so the logic_typespec metadata block
+    // below can't tag it.  Its packed_array_var is reachable via the port's
+    // Low_conn ref_obj — use it to set the packed-element metadata so
+    // import_bit_select element-indexes `port[i]` as element i.  Without this
+    // CVA6 alu_wrapper `.fu_data_i(fu_data_i[0])` wired a single bit instead of
+    // the 207-bit element, resizing the alu port from 1 at flatten.
+    if (auto lc = uhdm_port->Low_conn()) {
+        if (lc->UhdmType() == uhdmref_obj) {
+            auto ag = any_cast<const UHDM::ref_obj*>(lc)->Actual_group();
+            if (ag && ag->UhdmType() == uhdmpacked_array_var) {
+                auto pav = any_cast<const UHDM::packed_array_var*>(ag);
+                int outer_l = -1, outer_r = -1;
+                if (pav->Ranges() && !pav->Ranges()->empty()) {
+                    auto r0 = (*pav->Ranges())[0];
+                    if (r0->Left_expr() && r0->Right_expr()) {
+                        RTLIL::SigSpec l = import_expression(r0->Left_expr());
+                        RTLIL::SigSpec r = import_expression(r0->Right_expr());
+                        if (l.is_fully_const() && r.is_fully_const()) {
+                            outer_l = l.as_int();
+                            outer_r = r.as_int();
+                        }
+                    }
+                }
+                int elem_w = 0;
+                if (pav->Elements() && !pav->Elements()->empty())
+                    elem_w = get_width((*pav->Elements())[0], current_instance);
+                if (elem_w > 1 && outer_l >= 0 && outer_r >= 0) {
+                    w->attributes[RTLIL::escape_id("packed_elem_width")] = RTLIL::Const(elem_w);
+                    w->attributes[RTLIL::escape_id("packed_outer_left")] = RTLIL::Const(outer_l);
+                    w->attributes[RTLIL::escape_id("packed_outer_right")] = RTLIL::Const(outer_r);
+                    log("UHDM: Port '%s' packed_array_var (Low_conn): elem_width=%d outer=[%d:%d]\n",
+                        portname.c_str(), elem_w, outer_l, outer_r);
+                }
+            }
+        }
+    }
+
     // If we recovered unpacked dims from Array_nets above, also create per-
     // element wires `\name[0..N-1]` and connect them to slices of the flat
     // port wire so `import_bit_select` resolves `name[i]` as a full element.

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -185,6 +185,17 @@ struct_array_indexed_write
 struct_little_endian_bit_array
 svtypes_struct_array
 
+# --- read_verilog mis-sizes a packed array of a struct (NOT a UHDM bug) ---
+# The Yosys read_verilog reference lowers `struct_t [N:0] arr` to a SINGLE
+# element (it sizes `my_t [1:0]` = 96 bits, not 192, and lowers `arr[0]` to a
+# 1-bit `\arr[0]` select), so the reference netlist is wrong and the SAT equiv
+# reports spurious unproven cells.  UHDM sizes it correctly (N * struct) and
+# element-indexes `arr[i]` — VERIFIED equal to slang via a sound from-reset SAT
+# miter (SUCCESS).  These are the reproducers for the CVA6 alu_wrapper
+# `fu_data_i[0]` packed-array element-select fixes.
+packed_array_elem_select
+packed_array_struct_port_sel
+
 # --- Yosys v0.67 upstream check_mem / memories additions ---
 # check_mem/init.sv (dynamic read of a 2D unpacked array), check_mem/non_zero.sv
 #   (registered 1D unpacked array written in a `for (int i=1;i<=3;i++)` always_ff),

--- a/test/packed_array_struct_port_sel/dut.sv
+++ b/test/packed_array_struct_port_sel/dut.sv
@@ -1,0 +1,15 @@
+module child (input logic [95:0] data_i, output logic [63:0] o);
+    assign o = data_i[63:0] ^ data_i[95:64];
+endmodule
+module packed_array_struct_port_sel #(parameter type T = logic) (
+    input  T [1:0] arr_i,
+    output logic [63:0] o
+);
+    child c (.data_i(arr_i[0]), .o(o));
+endmodule
+module tb;
+    typedef struct packed { logic [63:0] x; logic [31:0] y; } my_t;  // 96-bit
+    my_t [1:0] arr;
+    logic [63:0] o;
+    packed_array_struct_port_sel #(.T(my_t)) d (.arr_i(arr), .o(o));
+endmodule


### PR DESCRIPTION
…ray_var)

Sibling of the packed_array_var element-select fix, for the PORT-declared form: CVA6 alu_wrapper.sv:24 `input fu_data_t [CVA6Cfg.NrALUs-1:0] fu_data_i` with `.fu_data_i(fu_data_i[0])`.  `fu_data_i[0]` wired a single BIT instead of element 0 (the 207-bit struct), so the alu's fu_data_i port was resized from 1 bit at flatten.

Root cause: import_bit_select element-indexes via the wire's `packed_elem_width`/`packed_outer_left`/`_right` attributes.  import_port sets these from a logic_typespec, but a packed array of a type-param STRUCT presents with an EMPTY-Ranges logic_typespec (the outer dimension isn't there for a struct element), so nothing was tagged.  The array's `packed_array_var` is, however, reachable via the port's `Low_conn` ref_obj.

Fix (import_port): after creating the port wire, if its Low_conn resolves to a packed_array_var, set the packed-element metadata from it — elem_width = width of Elements()[0] (the struct), outer range from Ranges()[0].  Mirrors the packed_array_var (variable) path.

On the full cva6 flatten this clears the fu_data_i / fu_data_cpop_i / operand_a/b stubs: 1-bit port resizes 12 -> 8.

New test packed_array_struct_port_sel: a `T [1:0]` port (T bound to a 96-bit struct) with `child c(.data_i(arr_i[0]))` now connects `arr_i[95:0]` (element 0).  read_verilog mis-sizes `struct_t [N:0]` (it lowers the whole struct-array to a 1-bit select), so this and packed_array_elem_select go in failing_tests.txt for the read_verilog reference — UHDM is VERIFIED equal to slang via a sound from-reset SAT miter.