### PR TITLE
uhdm: resolve function-computed struct-param field widths (CVA6Cfg.FI…

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3497,26 +3497,56 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
             }
             int pelem_w = (ctx_w > 0 && pat_count > 0 && ctx_w % pat_count == 0)
                           ? ctx_w / pat_count : 0;
+            // For a STRUCT target the fields have (possibly) UNEQUAL widths, so
+            // the ctx/count assumption is wrong — resolve each field's real width
+            // from the struct typespec instead.  Prefer the op's own typespec,
+            // then the threaded LHS context typespec.
+            const UHDM::struct_typespec* struct_ts = nullptr;
+            {
+                const UHDM::typespec* cand = nullptr;
+                if (uhdm_op->Typespec()) cand = uhdm_op->Typespec()->Actual_typespec();
+                if ((!cand || cand->UhdmType() != uhdmstruct_typespec) &&
+                    expression_context_typespec &&
+                    expression_context_typespec->UhdmType() == uhdmstruct_typespec)
+                    cand = expression_context_typespec;
+                if (cand && cand->UhdmType() == uhdmstruct_typespec)
+                    struct_ts = any_cast<const UHDM::struct_typespec*>(cand);
+            }
             for (auto operand : *uhdm_op->Operands()) {
                 const expr* field_expr = nullptr;
                 // Named-field patterns (`'{a: 0, b: 1, ...}`) wrap each value in a
                 // `tagged_pattern` (not an expr), so unwrap its Pattern(); these
                 // are emitted in struct field order (PatternAssignmentOfStructParam).
+                // The tagged_pattern's typespec (a string_typespec) names the
+                // target field — use it to look up that field's exact width.
+                int field_w = pelem_w;
                 if (operand->UhdmType() == uhdmtagged_pattern) {
                     auto tp = any_cast<const UHDM::tagged_pattern*>(operand);
                     if (tp && tp->Pattern())
                         field_expr = any_cast<const expr*>(tp->Pattern());
+                    if (struct_ts && struct_ts->Members() && tp && tp->Typespec()) {
+                        if (auto tag = tp->Typespec()->Actual_typespec()) {
+                            std::string fname = std::string(tag->VpiName());
+                            for (auto m : *struct_ts->Members())
+                                if (std::string(m->VpiName()) == fname) {
+                                    if (auto mt = m->Typespec())
+                                        if (auto at = mt->Actual_typespec())
+                                            field_w = get_width_from_typespec(at, inst);
+                                    break;
+                                }
+                        }
+                    }
                 } else {
                     field_expr = any_cast<const expr*>(operand);
                 }
                 if (!field_expr) continue;
                 int saved_ctx = expression_context_width;
-                if (pelem_w > 0) expression_context_width = pelem_w;
+                if (field_w > 0) expression_context_width = field_w;
                 RTLIL::SigSpec val = import_expression(field_expr, input_mapping);
                 expression_context_width = saved_ctx;
-                if (pelem_w > 0) {
-                    if (val.size() > pelem_w) val = val.extract(0, pelem_w);
-                    else if (val.size() < pelem_w) val.extend_u0(pelem_w);
+                if (field_w > 0) {
+                    if (val.size() > field_w) val = val.extract(0, field_w);
+                    else if (val.size() < field_w) val.extend_u0(field_w);
                 }
                 if (mode_debug)
                     log("UHDM: AssignmentPatternOp field size=%d\n", val.size());

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1488,7 +1488,28 @@ void UhdmImporter::import_continuous_assign(const cont_assign* uhdm_assign) {
     // Set context width from LHS so arithmetic operations produce correctly-sized results
     // Per Verilog semantics, LHS width propagates into RHS expression evaluation
     expression_context_width = lhs.size();
+    // Also thread the LHS struct/array typespec so a struct assignment pattern
+    // sizes each field by its real (possibly unequal) member width.
+    const UHDM::typespec* saved_ctx_ts = expression_context_typespec;
+    if (lhs_expr) {
+        const UHDM::ref_typespec* lrts = nullptr;
+        if (auto a = lhs_expr->UhdmType() == uhdmref_obj
+                         ? any_cast<const ref_obj*>(lhs_expr)->Actual_group()
+                         : nullptr) {
+            if (a->UhdmType() == uhdmlogic_net)
+                lrts = any_cast<const logic_net*>(a)->Typespec();
+            else if (a->UhdmType() == uhdmlogic_var)
+                lrts = any_cast<const logic_var*>(a)->Typespec();
+            else if (a->UhdmType() == uhdmstruct_net)
+                lrts = any_cast<const struct_net*>(a)->Typespec();
+            else if (a->UhdmType() == uhdmstruct_var)
+                lrts = any_cast<const struct_var*>(a)->Typespec();
+        }
+        if (!lrts) lrts = lhs_expr->Typespec();
+        if (lrts) expression_context_typespec = lrts->Actual_typespec();
+    }
     RTLIL::SigSpec rhs = import_expression(rhs_expr);
+    expression_context_typespec = saved_ctx_ts;
     expression_context_width = 0;
     
     log("  Continuous assignment: LHS size=%d, RHS size=%d, is_net_decl=%d\n", 

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1393,24 +1393,33 @@ std::string UhdmImporter::eval_param_struct_field(const hier_path* hp) {
             par->VpiParent()->UhdmType() == uhdmparam_assign)
             val = dynamic_cast<const expr*>(
                 any_cast<const param_assign*>(par->VpiParent())->Rhs());
-        // A (local)param declared in a module carries no Expr of its own; its
-        // assignment-pattern value lives in the owning module_inst's
-        // Param_assigns (degu SoC `localparam CFG_LSU = '{...}` referenced from a
-        // child's substituted `[CFG_LSU.BUS.ADR-1:0]` range).  Only accept an
-        // ASSIGNMENT-PATTERN Rhs — a cast like `part_info_t'(16)` is not walkable
-        // by the positional field walk and must fall through to the generic
-        // handler (OutputSizeWithParameterOfInstanceInitializedByStructMember).
-        if (!val && par->VpiParent() &&
-            par->VpiParent()->UhdmType() == uhdmmodule_inst) {
-            auto owner = any_cast<const module_inst*>(par->VpiParent());
-            if (owner->Param_assigns())
+        // A (local)param declared in a scope carries no Expr of its own; its
+        // value lives in the owning scope's Param_assigns as a SIBLING
+        // param_assign.  The owning scope may be a module_inst (degu SoC
+        // `localparam CFG_LSU = '{...}` referenced from a child's substituted
+        // `[CFG_LSU.BUS.ADR-1:0]` range) OR a package (`localparam cfg_t CFG =
+        // build_config()`).  Accept an ASSIGNMENT-PATTERN Rhs (positional field
+        // walk below) or a struct_var (a function-computed struct value
+        // elaborates to a struct_var whose typespec members carry the resolved
+        // field constants — read just below).  A cast like `part_info_t'(16)` is
+        // not walkable and must fall through to the generic handler
+        // (OutputSizeWithParameterOfInstanceInitializedByStructMember).
+        if (!val && par->VpiParent()) {
+            auto owner = dynamic_cast<const scope*>(par->VpiParent());
+            if (owner && owner->Param_assigns())
                 for (auto pa : *owner->Param_assigns())
                     if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
                         if (std::string(l->VpiName()) == std::string(par->VpiName())) {
                             auto rhs = dynamic_cast<const expr*>(pa->Rhs());
-                            if (rhs && rhs->UhdmType() == uhdmoperation &&
+                            // Accept an ASSIGNMENT-PATTERN (positional walk below)
+                            // or a struct_var — a function-computed struct value
+                            // (`CFG = build_config(...)`) elaborates to a
+                            // struct_var whose typespec members carry the
+                            // resolved field constants (handled just below).
+                            if (rhs && ((rhs->UhdmType() == uhdmoperation &&
                                 any_cast<const operation*>(rhs)->VpiOpType() ==
-                                    vpiAssignmentPatternOp)
+                                    vpiAssignmentPatternOp) ||
+                                rhs->UhdmType() == uhdmstruct_var))
                                 val = rhs;
                             break;
                         }
@@ -1429,6 +1438,32 @@ std::string UhdmImporter::eval_param_struct_field(const hier_path* hp) {
                 if (auto rt = lhs->Typespec()) cur_ts = rt->Actual_typespec();
     }
     if (!val) return "";
+    // A parameter bound to a function-computed struct value (CVA6
+    // `CFG = build_config(...)`) elaborates to a struct_var whose struct_typespec
+    // MEMBERS carry the resolved field values as constants (typespec_member
+    // vpiExpr).  Read the requested field's constant directly — no need to
+    // re-evaluate the producing function.  Handles a single field selector
+    // `CFG.FIELD` (the common CVA6Cfg.XLEN / .TRANS_ID_BITS shape).
+    if (pe.size() == 2) {
+        const typespec* sts = nullptr;
+        if (auto ts = val->Typespec()) sts = ts->Actual_typespec();
+        if (!sts) sts = cur_ts;
+        if (sts && sts->UhdmType() == uhdmstruct_typespec) {
+            auto st = any_cast<const struct_typespec*>(sts);
+            if (st->Members()) {
+                std::string field = std::string(pe[1]->VpiName());
+                for (auto m : *st->Members())
+                    if (std::string(m->VpiName()) == field) {
+                        const expr* mv = m->Actual_value();
+                        if (!mv) mv = m->Default_value();
+                        if (auto c = dynamic_cast<const constant*>(mv))
+                            return std::to_string(parse_vpi_value_to_int(
+                                std::string(c->VpiValue())));
+                        break;
+                    }
+            }
+        }
+    }
     // Walk pe[1..] as struct field selectors (same as eval_iface_param_field).
     for (size_t i = 1; i < pe.size() && val; i++) {
         std::string field = std::string(pe[i]->VpiName());

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -309,6 +309,12 @@ struct UhdmImporter {
     // Used to propagate LHS width into arithmetic operations per Verilog semantics
     int expression_context_width = 0;
 
+    // Context TYPESPEC for expression evaluation — the LHS's struct/array
+    // typespec, threaded so a struct assignment pattern (`'{a: x, b: y}`) can
+    // size each field to its actual (possibly UNEQUAL) member width instead of
+    // assuming ctx_width/field_count.  Null when unknown.
+    const UHDM::typespec* expression_context_typespec = nullptr;
+
     // Context signedness (LRM §11.8.1): an unsigned context-determined operator
     // forces every operand — including a signed sub-expression — to be treated
     // as unsigned (zero-extended).  e.g. in `(a+b) + 3'd0` the unsigned `3'd0`

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -196,6 +196,14 @@ svtypes_struct_array
 packed_array_elem_select
 packed_array_struct_port_sel
 
+# --- `parameter type` struct with function-computed CVA6Cfg.FIELD widths ---
+# Native read_verilog cannot parse `parameter type fu_data_t` (SV type params),
+# so there is no Verilog reference; the UHDM output is VERIFIED equal to slang
+# via a sound from-reset SAT miter (SUCCESS).  Reproducer for the CVA6
+# `fu_data_i.operand_a` struct-member port-width fix (build_config() struct
+# param → member widths resolved from the elaborated typespec's member exprs).
+struct_member_cfg_width
+
 # --- Yosys v0.67 upstream check_mem / memories additions ---
 # check_mem/init.sv (dynamic read of a 2D unpacked array), check_mem/non_zero.sv
 #   (registered 1D unpacked array written in a `for (int i=1;i<=3;i++)` always_ff),

--- a/test/struct_member_cfg_width/dut.sv
+++ b/test/struct_member_cfg_width/dut.sv
@@ -1,0 +1,37 @@
+// CVA6 mult.sv:65 `.operand_a_i(fu_data_i.operand_a)`: struct member access
+// where fu_data_t fields have function-computed CVA6Cfg.FIELD widths
+// (`logic [CVA6Cfg.XLEN-1:0] operand_a`, cva6.sv:177).  Struct total resolves,
+// member offset/width does not -> operand_a came out as bit 2, not [130:67].
+package cfg_pkg;
+  typedef struct packed { logic [31:0] XLEN; logic [31:0] TID; } cfg_t;
+  function automatic cfg_t build_config();
+    cfg_t c; c.XLEN = 32'd64; c.TID = 32'd3; return c;
+  endfunction
+  localparam cfg_t CFG = build_config();
+endpackage
+module inner (input logic [63:0] a_i, output logic [63:0] o);
+    assign o = a_i;
+endmodule
+module mid #(parameter type fu_data_t = logic) (
+    input  fu_data_t fu_data_i,
+    output logic [63:0] o
+);
+    inner c (.a_i(fu_data_i.operand_a), .o(o));
+endmodule
+module struct_member_cfg_width #(parameter cfg_pkg::cfg_t CFG = cfg_pkg::build_config()) (
+    input  logic [63:0] pa,
+    output logic [63:0] o
+);
+    typedef struct packed {
+        logic [CFG.XLEN-1:0] operand_a;
+        logic [CFG.XLEN-1:0] operand_b;
+        logic [CFG.TID-1:0]  tid;
+    } fu_data_t;
+    fu_data_t fu_data_i;
+    assign fu_data_i = '{operand_a: pa, operand_b: '0, tid: '0};
+    mid #(.fu_data_t(fu_data_t)) m (.fu_data_i(fu_data_i), .o(o));
+endmodule
+module tb;
+    logic [63:0] pa, o;
+    struct_member_cfg_width #(.CFG(cfg_pkg::build_config())) t (.pa(pa), .o(o));
+endmodule


### PR DESCRIPTION
…ELD)

A struct field whose width is a function-computed struct-parameter field — CVA6 `logic [CVA6Cfg.XLEN-1:0] operand_a` in fu_data_t, where `CVA6Cfg = build_config(...)` — collapsed to 1 bit, so a member access like `fu_data_i.operand_a` mapped to a single bit (e.g. `fu_data_i[2]`) and the connected child port was resized from 1 bit at flatten (a corrupt connection).

Root cause: `CFG = build_config()` elaborates to a `struct_var` whose value lives in a SIBLING `param_assign` of the owning scope (a package or module_inst), not on the parameter, and the parameter's own field walk could not reach it.  The elaborated `struct_typespec` MEMBERS, however, carry the resolved field values directly as constants (`typespec_member` Actual_value / Default_value), so no re-evaluation of the producing function is needed.

- eval_param_struct_field (uhdm2rtlil.cpp): reach the value through the owning scope's Param_assigns (was module_inst-only; now any scope, incl. package), accept a struct_var Rhs, and read the requested `CFG.FIELD` constant straight off the elaborated struct member.  `get_width_from_typespec` on `[CFG.XLEN-1:0]` now resolves, fixing the member offsets/widths.

A sound from-reset SAT miter surfaced a second, latent bug on the same shape: the struct assignment-pattern writer `'{operand_a: pa, ...}` assumed EQUAL-width fields (ctx_width / field_count) and dropped the value for unequal-width structs.

- import_operation AssignmentPatternOp (expression.cpp): size each field by its real struct-member width, using the tagged_pattern's field-name tag to look it up in the target struct typespec.
- import_continuous_assign (module.cpp) + expression_context_typespec (uhdm2rtlil.h): thread the LHS struct/array typespec so the pattern writer can find the member widths.

Repro test/struct_member_cfg_width: `operand_a` now maps to `fu_data_i[130:67]`; UHDM proven equal to slang via a sound from-reset SAT miter (native read_verilog cannot parse `parameter type`, so the test is listed in failing_tests.txt with a slang-verified note).  CVA6 full-design flatten 1-bit port stubs 8 -> 5.