### PR TITLE
uhdm: recover parameter-type port width from the elaborated port vari…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2403,6 +2403,34 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
                 // w == 0/1 only — never the interface sentinel (-1), whose port is
                 // a signal bundle, not a bit-vector.
                 if (w >= 0 && w <= 1 && inst) {
+                    // A `parameter type` port bound to a computed-width logic
+                    // vector (CVA6 load_store_unit `shift_reg
+                    // #(.dtype(logic [$bits(...)-1:0]))`) leaves the PORT typespec
+                    // at the generic default `logic` (1 bit), while the elaborated
+                    // port VARIABLE (logic_var/enum_var/bit_var) carries the
+                    // resolved range on its own typespec.  Recover from it — but
+                    // only when the port typespec itself collapsed to <=1, so a
+                    // genuinely wider port typespec (the packed-array `reg8_t[0:3]`
+                    // case, where the NET typespec is the narrower element) is
+                    // never overridden.
+                    if (auto lc = port->Low_conn()) {
+                        if (lc->UhdmType() == uhdmref_obj) {
+                            if (auto a = any_cast<const UHDM::ref_obj*>(lc)->Actual_group()) {
+                                UHDM::UHDM_OBJECT_TYPE at = a->UhdmType();
+                                if (a != uhdm_obj &&
+                                    (at == uhdmlogic_var || at == uhdmenum_var ||
+                                     at == uhdmbit_var)) {
+                                    int aw = get_width(a, inst);
+                                    if (aw > 1) {
+                                        log("UHDM: Port '%s' width from Low_conn %s var: %d\n",
+                                            std::string(port->VpiName()).c_str(),
+                                            UHDM::UhdmName(at).c_str(), aw);
+                                        return aw;
+                                    }
+                                }
+                            }
+                        }
+                    }
                     int wd = width_from_def_port(std::string(inst->VpiDefName()),
                                                  std::string(port->VpiName()), inst);
                     if (wd > w) {

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -204,6 +204,16 @@ packed_array_struct_port_sel
 # param → member widths resolved from the elaborated typespec's member exprs).
 struct_member_cfg_width
 
+# --- `parameter type` port bound to a computed-width logic vector ---
+# Native read_verilog cannot parse `parameter type dtype` (SV type params), so
+# there is no Verilog reference; the UHDM output is VERIFIED equal to slang via a
+# sound SAT miter (SUCCESS).  Reproducer for the CVA6 load_store_unit
+# `shift_reg #(.dtype(logic [$bits(...)-1:0]))` port-width fix: the elaborated
+# PORT typespec stays at the default `logic` (1 bit) while the port VARIABLE
+# carries the resolved range — import_port now recovers the width from the
+# logic_var/enum_var when the port typespec collapsed to <=1.
+param_type_logic_width
+
 # --- Yosys v0.67 upstream check_mem / memories additions ---
 # check_mem/init.sv (dynamic read of a 2D unpacked array), check_mem/non_zero.sv
 #   (registered 1D unpacked array written in a `for (int i=1;i<=3;i++)` always_ff),

--- a/test/param_type_logic_width/dut.sv
+++ b/test/param_type_logic_width/dut.sv
@@ -1,0 +1,28 @@
+// CVA6 load_store_unit.sv:614 `shift_reg #(.dtype(logic [$bits(a)+$bits(b)-1:0]))`:
+// a `parameter type` port bound to a computed-width `logic` vector.  The port
+// `input dtype d_i` collapsed to 1 bit -> resized at flatten (corrupt conn).
+module shift_reg #(parameter type dtype = logic) (
+    input  dtype d_i,
+    output dtype d_o
+);
+    assign d_o = d_i;
+endmodule
+
+module param_type_logic_width #(parameter int W = 5) (
+    input  logic [7:0] a,
+    input  logic [W-1:0] b,
+    output logic [8+W-1:0] o
+);
+    // dtype bound to a logic vector whose width is a $bits() sum
+    shift_reg #(.dtype(logic [$bits(a) + $bits(b) - 1:0])) u (
+        .d_i({a, b}),
+        .d_o(o)
+    );
+endmodule
+
+module tb;
+    logic [7:0] a;
+    logic [4:0] b;
+    logic [12:0] o;
+    param_type_logic_width #(.W(5)) t (.a(a), .b(b), .o(o));
+endmodule


### PR DESCRIPTION
…able

A `parameter type` port bound to a computed-width logic vector — CVA6 load_store_unit `shift_reg #(.dtype(logic [$bits(ld_valid) + $bits(ld_trans_id)
+ $bits(ld_result) + $bits(ld_ex) - 1:0]))` — collapsed to a 1-bit port, so the connected `d_i`/`d_o` was resized from 1 bit at flatten (a corrupt connection).

Root cause is the port-vs-net typespec inconsistency (CLAUDE.md #6): in the elaborated instance the PORT's typedef typespec still points at the generic default `logic` (1 bit), while the port's VARIABLE (a logic_var) and the `type_parameter dtype` both point at the resolved, const-folded bound typespec (`logic [12:0]`).  import_port read the stale port typespec.

Fix in get_width (module.cpp): when the port's own typespec collapses to <=1, recover the width from the port's Low_conn variable (logic_var / enum_var / bit_var) — mirroring the existing struct_var/packed_array_var Low_conn path, but gated on the port typespec being <=1 so a genuinely wider port typespec (the packed-array `reg8_t [0:3]` case, where the NET typespec is the narrower element) is never overridden.

Repro test/param_type_logic_width: `shift_reg`'s `d_i`/`d_o` now 13 bits (was 1); UHDM proven equal to slang via a sound SAT miter (native read_verilog cannot parse `parameter type`, so listed in failing_tests.txt with a slang-verified note).  The enum_var arm also covers store_buffer's `cbo_t cbo_op_i` port.  CVA6 full-design flatten 1-bit port stubs 5 -> 0 (the port-stub campaign is complete: 19 -> 0).