### PR TITLE
uhdm: link generate-scope `parameter type` instances (id_stage decode…

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1866,7 +1866,18 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
             module_name = "$paramod\\" + base_module_name + param_string;
         }
     }
-    
+
+    // A `parameter type` instance is imported by import_module under a uniquified
+    // name (base + any $paramod value-params + a per-type-binding signature from
+    // the resolved port widths).  import_instance builds only the value-param
+    // part, so WITHOUT this the cell would reference the bare `\decoder` while
+    // import_module registered the module as `\decoder$typaram_...`, leaving the
+    // cell an unresolved blackbox that `hierarchy -check` rejects (CVA6
+    // id_stage's genblk3[0].decoder_i).  Append the same signature here so the
+    // cell type matches; the authoritative name is re-read from inst_to_modname_
+    // after import (the widths computed here can be approximate).
+    module_name += type_param_signature(uhdm_inst);
+
     // Check if the module definition has interface ports
     // We need to look at the module being instantiated to see if it uses interfaces
     bool has_interface_ports = false;
@@ -1970,6 +1981,21 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
         }
     }
     
+    // import_module records the exact RTLIL name it created for THIS elaborated
+    // instance (with any $paramod / $typaram specialization).  Prefer it: the
+    // type_param_signature computed above can diverge from the real one because
+    // a param-dependent port range only resolves to an approximate width at
+    // cell-creation time (this instance's module isn't `this->module` yet).
+    // Without this the cell would blackbox on the width mismatch, same failure
+    // as the missing-signature case.
+    {
+        auto it = inst_to_modname_.find(uhdm_inst);
+        if (it != inst_to_modname_.end()) {
+            RTLIL::IdString real_id = RTLIL::escape_id(it->second);
+            if (design->module(real_id)) module_id = real_id;
+        }
+    }
+
     log("UHDM: Creating cell '%s' of type '%s'\n", inst_name.c_str(), module_id.c_str());
     RTLIL::Cell* cell = module->addCell(new_id(inst_name), module_id);
     

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -214,6 +214,16 @@ struct_member_cfg_width
 # logic_var/enum_var when the port typespec collapsed to <=1.
 param_type_logic_width
 
+# --- `parameter type` module instantiated inside a generate block ---
+# Native read_verilog cannot parse `parameter type T` (SV type params), so there
+# is no Verilog reference; the UHDM output is VERIFIED equal to slang via a sound
+# SAT miter (SUCCESS).  Reproducer for the CVA6 id_stage `genblk3[0].decoder_i`
+# hierarchy-link fix: import_instance (the generate-scope cell path) omitted the
+# per-type-binding $typaram signature, so the cell referenced bare `\leaf` while
+# the module was imported as `\leaf$typaram_...` -> unresolved blackbox that
+# `hierarchy -check` rejects.
+gen_scope_typaram
+
 # --- Yosys v0.67 upstream check_mem / memories additions ---
 # check_mem/init.sv (dynamic read of a 2D unpacked array), check_mem/non_zero.sv
 #   (registered 1D unpacked array written in a `for (int i=1;i<=3;i++)` always_ff),

--- a/test/gen_scope_typaram/dut.sv
+++ b/test/gen_scope_typaram/dut.sv
@@ -1,0 +1,26 @@
+// CVA6 id_stage genblk3[0].decoder_i: a `parameter type` module instantiated
+// inside a GENERATE block.  import_instance built the cell type without the
+// per-type-binding $typaram signature, so the cell referenced bare `\leaf`
+// while the module was imported as `\leaf$typaram_...` -> unresolved blackbox
+// that `hierarchy -check` rejects.
+module leaf #(parameter type T = logic) (
+    input  T d_i,
+    output T d_o
+);
+    assign d_o = d_i;
+endmodule
+
+module gen_scope_typaram (
+    input  logic [7:0] a,
+    output logic [7:0] o
+);
+    typedef struct packed { logic [3:0] x; logic [3:0] y; } pair_t;
+    for (genvar i = 0; i < 1; i++) begin : blk
+        leaf #(.T(pair_t)) u (.d_i(a), .d_o(o));
+    end
+endmodule
+
+module tb;
+    logic [7:0] a, o;
+    gen_scope_typaram t (.a(a), .o(o));
+endmodule


### PR DESCRIPTION
…r_i)

A `parameter type` module instantiated inside a generate block — CVA6 id_stage's `genblk3[0].decoder_i` — was left an unresolved blackbox: the cell referenced the bare `\decoder` while import_module had registered the elaborated module under `\decoder$typaram_...`.  `hierarchy -check -top cva6` aborted with "Module `\decoder' ... is not part of the design", blocking the whole flatten.

Root cause: import_instance (the generate-scope / nested cell-creation path) builds the cell's module type with only the `$paramod` value-parameter part and never appends the per-type-binding `$typaram_<port widths>` signature that import_module uses to uniquify a `parameter type` instance.  import_module_hierarchy already does both (append the signature + fall back to the recorded real name); import_instance did neither.

Fix in import_instance (module.cpp):
- append type_param_signature(uhdm_inst) to module_name, matching import_module's naming (empty for non-type-param modules, so ordinary instances are unchanged);
- after import, re-read the authoritative RTLIL name from inst_to_modname_ (the exact name import_module created for this elaborated instance) — the width computed here can be approximate because the instance's own module isn't the active `this->module` yet, so trust the recorded name over the recomputed sig.

Repro test/gen_scope_typaram: a `parameter type` leaf instantiated in a `for` generate block now links (`\leaf$typaram_8_8`) instead of blackboxing; `hierarchy -check` passes and the netlist is proven equal to slang via a sound SAT miter (native read_verilog cannot parse `parameter type`, so listed in failing_tests.txt with a slang-verified note).

Full CVA6 `hierarchy -check -top cva6` now PASSES (0 unresolved-module errors, was aborting at decoder) and the full-design flatten completes.  This links many previously-blackboxed generate-scope type-param cells; flatten now descends into them and surfaces 30 newly-reachable internal width stubs (sram byte-enable we_i/req_i, fpnew_top opgroup operands_i/tag_o) — the next frontier, previously unreachable behind the abort.