### PR TITLE
uhdm: clear comb-value map per always_ff + guard against cross-module…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -735,7 +735,14 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
     
     // Clear pending assignments from any previous process
     pending_sync_assignments.clear();
-    
+    // Also clear the blocking-value map: a multi-async-reset / SR-FF body is
+    // imported via import_statement_comb, which calls thread_comb_if — that reads
+    // current_comb_values[nm] as the pre-branch value.  A stale entry left by a
+    // PREVIOUS process (even in another module — e.g. dffsr2_sub's `q`) would make
+    // dffa4's mux reference a foreign wire, tripping write_rtlil's
+    // chunk_.wire->module assert.  Start every always_ff with a clean map.
+    current_comb_values.clear();
+
     // Set the always_ff attribute
     log("      Setting always_ff attribute\n");
     log_flush();

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -696,6 +696,54 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
     }
     log("UHDM: End of debug listing\n");
     log_flush();
+
+    // Consistency check: every SigSpec in a module's connections, cells and
+    // processes must only reference wires OWNED by that module.  A cross-module
+    // reference is always an importer bug — it produces structurally invalid
+    // RTLIL and otherwise surfaces only as an opaque `chunk_.wire->module ==
+    // mod` assert deep in write_rtlil.  Catch it here with an actionable message
+    // (which module, which wire, and which module actually owns it) and fail
+    // hard, so such leaks — e.g. a stale current_comb_values entry threaded into
+    // another module's mux — are diagnosed at their source.
+    int foreign = 0;
+    for (auto mod : design->modules()) {
+        auto chk = [&](const RTLIL::SigSpec &s, const std::string &where) {
+            for (auto &c : s.chunks())
+                if (c.wire && c.wire->module != mod) {
+                    foreign++;
+                    log_warning("UHDM: cross-module wire reference in module %s at "
+                                "%s: wire %s is owned by %s.\n",
+                                log_id(mod->name), where.c_str(), log_id(c.wire->name),
+                                c.wire->module ? log_id(c.wire->module->name) : "<null>");
+                }
+        };
+        for (auto cell : mod->cells())
+            for (auto &conn : cell->connections())
+                chk(conn.second, "cell " + std::string(log_id(cell->name)) + "." +
+                                 std::string(log_id(conn.first)));
+        for (auto &c : mod->connections()) { chk(c.first, "connect-lhs"); chk(c.second, "connect-rhs"); }
+        for (auto &pp : mod->processes) {
+            RTLIL::Process *proc = pp.second;
+            std::function<void(RTLIL::CaseRule*)> scan_case = [&](RTLIL::CaseRule *cs) {
+                for (auto &a : cs->actions) { chk(a.first, "process-action-lhs"); chk(a.second, "process-action-rhs"); }
+                for (auto sw : cs->switches) {
+                    chk(sw->signal, "process-switch-sig");
+                    for (auto sc : sw->cases) {
+                        for (auto &cmp : sc->compare) chk(cmp, "process-case-compare");
+                        scan_case(sc);
+                    }
+                }
+            };
+            scan_case(&proc->root_case);
+            for (auto sync : proc->syncs) {
+                chk(sync->signal, "process-sync-sig");
+                for (auto &a : sync->actions) { chk(a.first, "process-sync-lhs"); chk(a.second, "process-sync-rhs"); }
+            }
+        }
+    }
+    if (foreign)
+        log_error("UHDM: import produced %d cross-module wire reference(s) "
+                  "(see warnings above) — this is an importer bug.\n", foreign);
 }
 
 // Within a struct value `val` (an assignment-pattern operation), return the


### PR DESCRIPTION
… wires

`import_always_ff` left the member `current_comb_values` map populated from a previous process.  A multi-async-reset / SR flip-flop body is imported via import_statement_comb, which calls thread_comb_if; that reads `current_comb_values[nm]` as the pre-branch value when a branch does not write `nm`.  A stale entry from an EARLIER process — even one in another module, e.g. dffsr2_sub's `q` — then became the mux input, so the mux built for dffa4 referenced a wire owned by dffsr2_sub.  That cross-module reference produced structurally invalid RTLIL that tripped write_rtlil's `chunk_.wire->module == mod` assert (test/dff_different_styles asserted, UHDM produced no output).  The leak was latent and surfaced only at a particular binary layout (exposed by the #568 import_instance change), which is exactly why it needs a structural guard, not just the point fix.

- process.cpp: clear `current_comb_values` at the start of import_always_ff, next to the existing pending_sync_assignments reset, so every always_ff begins with a clean blocking-value map (normal always_ff is unaffected — it runs in in_always_ff_body_mode, where thread_comb_if returns early and the map is suppressed).

- uhdm2rtlil.cpp: after import_design completes, scan every module's connections, cell ports and process (case/switch/sync) SigSpecs for chunks whose wire is owned by a DIFFERENT module, and fail hard (log_error) naming the module, the location, the wire and its real owner.  This turns the opaque deep-in-write_rtlil assert into an actionable importer-side error so future cross-module leaks are caught at their source.

Verified: dffa4 imports cleanly and is proven equal to the Verilog frontend via a SAT miter; the guard fires with the diagnostic message when the fix is disabled and passes with it; full regression shows zero cross-module firings.