### PR TITLE
uhdm: fail loudly on assign_stmt-vs-assignment mis-cast (require_assi…

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -11243,7 +11243,7 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
     switch (stmt_type) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            auto assign = any_cast<const assignment*>(uhdm_stmt);
+            auto assign = require_assignment(uhdm_stmt, "import_statement_comb(CaseRule*)");
 
             // Dynamic indexed_part_select LHS (e.g. `dword[8*sel +:8] =
             // vect`) — when the index expression isn't constant we

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -1283,7 +1283,7 @@ void UhdmImporter::collect_blocking_assigned_names(const any* stmt, std::set<std
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            const assignment* assign = any_cast<const assignment*>(stmt);
+            const assignment* assign = require_assignment(stmt, "collect_blocking_assigned_names");
             if (assign->VpiBlocking()) {
                 std::vector<AssignedSignal> sigs;
                 extract_assigned_signals(stmt, sigs);
@@ -1411,7 +1411,7 @@ void UhdmImporter::collect_memory_write_lhs(const any* stmt,
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            const assignment* assign = any_cast<const assignment*>(stmt);
+            const assignment* assign = require_assignment(stmt, "collect_memory_write_lhs");
             if (is_memory_write(assign, module)) {
                 if (auto lhs = assign->Lhs()) {
                     if (lhs->VpiType() == vpiBitSelect) {
@@ -1471,7 +1471,7 @@ void UhdmImporter::scan_for_memory_writes(const any* stmt, std::set<std::string>
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            const assignment* assign = any_cast<const assignment*>(stmt);
+            const assignment* assign = require_assignment(stmt, "scan_for_memory_writes");
             if (is_memory_write(assign, module)) {
                 if (auto lhs = assign->Lhs()) {
                     if (lhs->VpiType() == vpiBitSelect) {
@@ -1576,7 +1576,7 @@ void UhdmImporter::collect_dynamic_expanded_array_writes(
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            const assignment* assign = any_cast<const assignment*>(stmt);
+            const assignment* assign = require_assignment(stmt, "collect_dynamic_expanded_array_writes");
             if (auto lhs = assign->Lhs()) {
                 if (lhs->VpiType() == vpiBitSelect) {
                     const bit_select* bs = any_cast<const bit_select*>(lhs);
@@ -1723,7 +1723,7 @@ const assignment* UhdmImporter::find_assignment_for_lhs(const any* stmt, const e
     switch (stmt->VpiType()) {
         case vpiAssignment:
         case vpiAssignStmt: {
-            auto assign = any_cast<const assignment*>(stmt);
+            auto assign = require_assignment(stmt, "find_assignment_for_lhs");
             if (assign->Lhs() == lhs_expr) {
                 return assign;
             }

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -42,6 +42,33 @@ YOSYS_NAMESPACE_BEGIN
 
 using namespace UHDM;
 
+// Cast a statement that a case-label assumes is a `vpiAssignment` to `assignment*`.
+//
+// IMPORTANT: `vpiAssignment` (UHDM class `assignment`) and `vpiAssignStmt` (UHDM
+// class `assign_stmt`) are DISTINCT, `final` UHDM classes with DIFFERENT member
+// layouts — `assignment` additionally carries `vpiOpType_`/`vpiBlocking_`/delay/
+// event members, so `Lhs()`/`Rhs()` sit at different offsets, and `assign_stmt`
+// has NO `VpiBlocking()`/`VpiOpType()` at all.  `UHDM::any_cast` is RTTI-checked,
+// so `any_cast<const assignment*>(assign_stmt)` returns `nullptr`; any code that
+// shares a single `case vpiAssignment: case vpiAssignStmt:` and then dereferences
+// the `assignment*` will CRASH (or silently drop the statement) on an
+// `assign_stmt`.  Such sites must be given proper per-type handling (see the
+// correct pattern at process.cpp:7740 / process_helper.cpp:406, which dispatch to
+// `assign_stmt` explicitly).  Until a given site is converted, route its cast
+// through this helper so we FAIL LOUDLY with an actionable message instead of
+// crashing or corrupting memory.
+static inline const UHDM::assignment* require_assignment(const UHDM::any* s,
+                                                         const char* ctx) {
+    if (auto a = any_cast<const UHDM::assignment*>(s)) return a;
+    log_error("UHDM: %s: statement is a %s, not a vpiAssignment(assignment). This "
+              "code path shares one case for vpiAssignment/vpiAssignStmt but only "
+              "handles `assignment`; `assign_stmt` is a different UHDM class (no "
+              "VpiBlocking/VpiOpType, different layout) and needs its own handling. "
+              "Please add per-type handling here.\n",
+              ctx, s ? UHDM::UhdmName(s->UhdmType()).c_str() : "<null>");
+    return nullptr;  // unreachable: log_error() aborts
+}
+
 // Parse VpiValue format strings ("HEX:BB", "BIN:1010", "UINT:42", etc.) to integer
 static inline int parse_vpi_value_to_int(const std::string& vpi_value) {
     size_t colon_pos = vpi_value.find(':');


### PR DESCRIPTION
…gnment helper)

`vpiAssignment` (UHDM class `assignment`) and `vpiAssignStmt` (UHDM class `assign_stmt`) are DISTINCT `final` classes with different member layouts — `assignment` additionally carries vpiOpType_/vpiBlocking_/delay/event members, so Lhs()/Rhs() sit at different offsets, and `assign_stmt` has no VpiBlocking()/ VpiOpType() at all.  UHDM::any_cast is RTTI-checked, so `any_cast<const assignment*>(assign_stmt)` returns nullptr; a `case vpiAssignment: case vpiAssignStmt:` that shares one cast and then dereferences the `assignment*` crashes (or silently drops) on an `assign_stmt`.

Audit of all such shared-label casts in the frontend:
  - Correctly dispatched already (per-type): process.cpp:682/4770/7740, process_helper.cpp:406, uhdm2rtlil.cpp scanners (null-guarded).
  - UNGUARDED deref (would crash on assign_stmt): process.cpp import_statement_comb (CaseRule*), and process_helper.cpp collect_blocking_assigned_names / collect_memory_write_lhs / scan_for_memory_writes / collect_dynamic_expanded_array_writes / find_assignment_for_lhs.

Route those six through a new `require_assignment(stmt, ctx)` helper that returns the `assignment*` when the cast is valid and otherwise aborts with an actionable message naming the site — so the latent bug fails loudly with guidance to add per-type handling instead of corrupting memory.  No behavior change for the current all-`assignment` statement streams (regression sample unaffected).