### PR TITLE
uhdm: CVA6 latch parity vs slang + comb-if value leak + yosys v0.68 w/ proc_dlatch memoization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,15 +3,11 @@
 	url = https://github.com/chipsalliance/Surelog.git
 [submodule "third_party/yosys"]
 	path = third_party/yosys
-	url = https://github.com/YosysHQ/yosys.git
-	# Tracking a fork branch (v0.66 + one local patch) until upstream
-	# Yosys merges the `write_verilog` signedness fix (still not upstream as of
-	# v0.66 — the backend's dump_wire does not emit `signed`; the related
-	# upstream PR #5887 fixes the READ side only).  See:
-	#   - upstream PR (placeholder):     YosysHQ/yosys#TBD (write_verilog side)
-	#   - tracking branch on the fork:   v0.66-write-verilog-signed-port
-	#   - related downstream issue:      chipsalliance/synlig#2425
-	# NOTE: yosys-slang (used by the 4-frontend matrix) officially lists support
-	# up to v0.65 only; the slang column may be unsupported on v0.66 until it
-	# bumps.  When upstream merges the write-side fix, revert this url to
-	# https://github.com/YosysHQ/yosys.git.
+	url = https://github.com/alainmarcel/yosys.git
+	# Tracking the alainmarcel fork: v0.68 + the proc_dlatch memoization patch
+	# (branch v0.68-proc-dlatch-memo, PR alainmarcel/yosys#4).  Without the
+	# patch, proc_dlatch's un-memoized find_mux_feedback/find_mux_constant DAG
+	# walks are exponential on shared mux subtrees (CVA6 cva6_tlb update_flush
+	# kept proc_dlatch spinning >9h; patched: full-core proc in ~45s).  Also a
+	# candidate for upstreaming to YosysHQ/yosys; when upstream merges it,
+	# revert this url to https://github.com/YosysHQ/yosys.git.

--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3151,16 +3151,24 @@ RTLIL::SigSpec UhdmImporter::import_constant(const constant* uhdm_const) {
             if (mode_debug)
                 log("    vpiUIntConst: value='%s', size=%d\n", value.c_str(), size);
             try {
+                // An UNSIZED value (vpiSize == -1, e.g. the folded `~'hF` in
+                // cva6_tlb's napot mask) must not pass -1 as the Const width —
+                // yosys v0.68's WIDTH_LIMIT assert rejects it (v0.67 silently
+                // built a bogus Const).  Use the propagated context width, else
+                // the natural 64 bits of the folded value.
+                int w = size > 0 ? size
+                        : (expression_context_width > 0 ? expression_context_width
+                                                        : 64);
                 // Handle UHDM format: "UINT:value"
                 if (value.substr(0, 5) == "UINT:") {
                     std::string num_str = value.substr(5);
                     // Use stoull to handle large values like 18446744073709551615 (0xFFFFFFFFFFFFFFFF)
                     unsigned long long uint_val = std::stoull(num_str);
-                    return RTLIL::SigSpec(RTLIL::Const(uint_val, size));
+                    return RTLIL::SigSpec(RTLIL::Const(uint_val, w));
                 } else {
                     // Handle plain number format
                     unsigned long long uint_val = std::stoull(value);
-                    return RTLIL::SigSpec(RTLIL::Const(uint_val, size));
+                    return RTLIL::SigSpec(RTLIL::Const(uint_val, w));
                 }
             } catch (const std::exception& e) {
                 log_warning("Failed to parse UInt constant '%s': %s\n", value.c_str(), e.what());

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -10689,13 +10689,34 @@ void UhdmImporter::import_if_else_comb(const UHDM::if_else* uhdm_if_else, RTLIL:
         RTLIL::SigSpec condition_sig = import_expression(
             condition, current_comb_process ? &current_comb_values : nullptr);
 
-        // Reduce multi-bit conditions to 1 bit for switch/compare matching
+        // Reduce multi-bit conditions to 1 bit for switch/compare matching.
+        // A CONSTANT multi-bit condition must reduce to a constant BIT, not a
+        // $reduce_bool cell (same as import_if_stmt_comb / the sync paths).
         if (condition_sig.size() > 1) {
-            condition_sig = module->ReduceBool(NEW_ID, condition_sig);
+            if (condition_sig.is_fully_const())
+                condition_sig = condition_sig.as_const().as_bool()
+                                    ? RTLIL::SigSpec(RTLIL::State::S1)
+                                    : RTLIL::SigSpec(RTLIL::State::S0);
+            else
+                condition_sig = module->ReduceBool(NEW_ID, condition_sig);
         }
 
         if (mode_debug)
             log("    If_else condition: %s\n", log_signal(condition_sig));
+
+        // Compile-time-constant condition: import only the TAKEN branch
+        // (mirrors import_if_stmt_comb and the CaseRule vpiIf path) — a
+        // false struct-param guard's branch must not leave conditional
+        // structure behind.
+        if (condition_sig.is_fully_const()) {
+            const any* taken = condition_sig.as_const().as_bool()
+                                   ? uhdm_if_else->VpiStmt()
+                                   : uhdm_if_else->VpiElseStmt();
+            if (taken)
+                import_statement_comb(taken, proc);
+            current_if_qualifier = saved_qualifier;
+            return;
+        }
 
         // Create a switch statement for the if
         RTLIL::SwitchRule* sw = new RTLIL::SwitchRule;
@@ -10783,9 +10804,19 @@ void UhdmImporter::import_if_stmt_comb(const UHDM::if_stmt* uhdm_if, RTLIL::Proc
         RTLIL::SigSpec condition_sig = import_expression(
             condition, current_comb_process ? &current_comb_values : nullptr);
 
-        // Reduce multi-bit conditions to 1 bit for switch/compare matching
+        // Reduce multi-bit conditions to 1 bit for switch/compare matching.
+        // A CONSTANT multi-bit condition must reduce to a constant BIT, not a
+        // $reduce_bool cell (same as the sync/CaseRule paths, #572) — else a
+        // folded struct-param guard (`if (CVA6Cfg.RVS)` == 32'1 in
+        // csr_regfile's S-CSR default block) becomes a runtime wire, the
+        // defaults turn conditional, and every S-CSR `_d` slice latches.
         if (condition_sig.size() > 1) {
-            condition_sig = module->ReduceBool(NEW_ID, condition_sig);
+            if (condition_sig.is_fully_const())
+                condition_sig = condition_sig.as_const().as_bool()
+                                    ? RTLIL::SigSpec(RTLIL::State::S1)
+                                    : RTLIL::SigSpec(RTLIL::State::S0);
+            else
+                condition_sig = module->ReduceBool(NEW_ID, condition_sig);
         }
 
         if (mode_debug)

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -1069,16 +1069,19 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                 // so making them async-reset FFs gives a non-constant (self)
                 // reset value that `proc` rejects ("Async reset yields
                 // non-constant value 32'mmm..m", CVA6 cva6_fifo_v3).  Match slang
-                // and leave them undriven.  Only prune when we found at least one
-                // live assignment somewhere (empty set => couldn't fold guards,
-                // so keep everything to stay conservative).
-                std::set<std::string> live_signals;
+                // and leave them undriven.  Prune only names PRESENT in the
+                // unfolded scan but ABSENT from the live scan, so LHS shapes the
+                // scan can't name (concats, var_selects) are never pruned.
+                std::set<std::string> live_signals, all_signals;
                 collect_live_assigned_signals(stmt, true, live_signals);
-                if (!live_signals.empty())
+                collect_live_assigned_signals(stmt, true, all_signals,
+                                              /*fold_guards=*/false);
+                if (live_signals.size() < all_signals.size())
                     assigned_signals.erase(
                         std::remove_if(assigned_signals.begin(), assigned_signals.end(),
                             [&](const AssignedSignal& s){
-                                return live_signals.count(s.name) == 0;
+                                return all_signals.count(s.name) > 0 &&
+                                       live_signals.count(s.name) == 0;
                             }),
                         assigned_signals.end());
 
@@ -2733,6 +2736,29 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
         block_local_promoted.clear();
         create_block_local_wires(actual_stmt);
         extract_assigned_signals(actual_stmt, assigned_signals);
+
+        // Drop signals assigned ONLY under a compile-time-FALSE guard
+        // (`if (CVA6Cfg.RVH) lsu_tinst_n = …` with RVH==0, CVA6 cva6_mmu
+        // data_interface).  The body import folds the dead branch away, but
+        // without this prune the pre-pass below still creates a `$0\sig` temp
+        // with a self-hold default plus an STa update — net effect `sig = sig`,
+        // which proc_dlatch turns into a spurious latch (read_verilog/slang
+        // leave the signal undriven; slang infers 0 latches on all of CVA6).
+        // Prune only names PRESENT in the unfolded scan but ABSENT from the
+        // live scan: LHS shapes the scan can't name land in neither set and
+        // are kept (conservative).
+        std::set<std::string> live_assigned, all_assigned;
+        collect_live_assigned_signals(actual_stmt, true, live_assigned);
+        collect_live_assigned_signals(actual_stmt, true, all_assigned,
+                                      /*fold_guards=*/false);
+        if (live_assigned.size() < all_assigned.size())
+            assigned_signals.erase(
+                std::remove_if(assigned_signals.begin(), assigned_signals.end(),
+                    [&](const AssignedSignal& s){
+                        return all_assigned.count(s.name) > 0 &&
+                               live_assigned.count(s.name) == 0;
+                    }),
+                assigned_signals.end());
     }
     
     // Create temporary wires for assigned signals (one per unique signal name)
@@ -7210,6 +7236,27 @@ void UhdmImporter::import_begin_block_comb(const UHDM::scope* uhdm_begin, RTLIL:
             int width = get_width(var, current_instance);
             if (width <= 0) width = 16;
 
+            // Reuse the simple-named wire create_block_local_wires() already
+            // made for this always-block block-local (same gating as the
+            // CaseRule vpiBegin handler): the enclosing always block's $0-temp
+            // machinery drives and reads that wire, so creating a second
+            // scoped wire here SPLITS the writes — the block's top-level init
+            // (`sgn = 1'b0`) targets the scoped wire while a nested-if write
+            // (`sgn = 1'b1`) targets the bare one, whose self-hold default
+            // then survives every path and proc_dlatch infers a spurious
+            // latch (CVA6 alu.sv:199 `sgn`, lsu_bypass.sv:67 status_cnt/
+            // read_pointer/write_pointer; slang infers none).  Gate on
+            // block_local_promoted so a block-local merely SHADOWING a module
+            // signal still gets its own scoped wire.
+            if (block_local_promoted.count(var_name))
+            if (RTLIL::Wire* pre = module->wire(RTLIL::escape_id(var_name))) {
+                if (name_map.count(var_name) && name_map[var_name] != pre)
+                    saved_name_map[var_name] = name_map[var_name];
+                name_map[var_name] = pre;
+                block_local_vars.insert(var_name);
+                continue;
+            }
+
             // Create hierarchical wire: \blockname.varname
             std::string hier_name = block_name + "." + var_name;
             RTLIL::Wire* block_wire = module->addWire(RTLIL::escape_id(hier_name), width);
@@ -10666,12 +10713,20 @@ void UhdmImporter::import_if_else_comb(const UHDM::if_else* uhdm_if_else, RTLIL:
         true_case->compare.push_back(RTLIL::SigSpec(RTLIL::State::S1));
         add_src_attribute(true_case->attributes, uhdm_if_else);
 
+        // Snapshot current_comb_values around each branch import (see
+        // import_if_stmt_comb): the branch bodies record their blocking
+        // writes LIVE, so without restores the then-branch's values leak
+        // into the else-branch import AND thread_comb_if's "pre" lookup
+        // reads a branch's own value instead of the pre-if value.
+        auto saved_ccv = current_comb_values;
+
         // Import then statement
         if (auto then_stmt = uhdm_if_else->VpiStmt()) {
             if (mode_debug)
                 log("    Importing then statement\n");
             import_statement_comb(then_stmt, true_case);
         }
+        current_comb_values = saved_ccv;
 
         sw->cases.push_back(true_case);
 
@@ -10687,6 +10742,7 @@ void UhdmImporter::import_if_else_comb(const UHDM::if_else* uhdm_if_else, RTLIL:
             import_statement_comb(else_stmt, else_case);
             log("    Else case has %d actions after import\n", (int)else_case->actions.size());
             log("    Else case has %d switches after import\n", (int)else_case->switches.size());
+            current_comb_values = saved_ccv;
 
             sw->cases.push_back(else_case);
             thread_comb_if(condition_sig, true_case, else_case);
@@ -10766,14 +10822,25 @@ void UhdmImporter::import_if_stmt_comb(const UHDM::if_stmt* uhdm_if, RTLIL::Proc
         RTLIL::CaseRule* true_case = new RTLIL::CaseRule;
         true_case->compare.push_back(RTLIL::SigSpec(RTLIL::State::S1));
         add_src_attribute(true_case->attributes, uhdm_if);
-        
+
+        // Snapshot current_comb_values around the branch import (same
+        // discipline as the CaseRule vpiIf path): the branch body records its
+        // blocking writes LIVE into current_comb_values, so without a restore
+        // thread_comb_if's "pre" lookup reads the branch's own value (tv == ev
+        // -> no merge) and the conditional value leaks to later same-block
+        // reads as if unconditional — `sgn = 1'b0; if (op==…) sgn = 1'b1;
+        // less = …sgn…` read sgn as constant 1 (CVA6 alu.sv:199; UHDM != slang
+        // SAT miter, masked by a read_verilog blind spot).
+        auto saved_ccv = current_comb_values;
+
         // Import then statement
         if (auto then_stmt = uhdm_if->VpiStmt()) {
             if (mode_debug)
                 log("    Importing then statement\n");
             import_statement_comb(then_stmt, true_case);
         }
-        
+        current_comb_values = saved_ccv;
+
         sw->cases.push_back(true_case);
         
         // For simple if statements (not if_else), create empty default case

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -346,52 +346,98 @@ int UhdmImporter::const_cond_value(const any* cond) {
         if (!v.empty())
             return atoi(v.c_str()) == 0 ? 0 : 1;
     }
+    // Logical operations over resolvable constants (`if (!CVA6Cfg.RVC)` in CVA6
+    // branch_unit, `if (FPGA_EN && FPGA_ALTERA)` in cva6_fifo_v3) — fold
+    // recursively, still without creating cells.  Short-circuit so one
+    // resolvable dominant operand (0 for &&, 1 for ||) suffices.
+    if (cond->UhdmType() == uhdmoperation) {
+        auto op = any_cast<const operation*>(cond);
+        auto ops = op->Operands();
+        if (!ops || ops->empty()) return -1;
+        int a0 = const_cond_value((*ops)[0]);
+        switch (op->VpiOpType()) {
+        case vpiNotOp:
+            return a0 < 0 ? -1 : (a0 ? 0 : 1);
+        case vpiLogAndOp: {
+            if (ops->size() < 2) return -1;
+            int a1 = const_cond_value((*ops)[1]);
+            if (a0 == 0 || a1 == 0) return 0;
+            if (a0 == 1 && a1 == 1) return 1;
+            return -1;
+        }
+        case vpiLogOrOp: {
+            if (ops->size() < 2) return -1;
+            int a1 = const_cond_value((*ops)[1]);
+            if (a0 == 1 || a1 == 1) return 1;
+            if (a0 == 0 && a1 == 0) return 0;
+            return -1;
+        }
+        default: return -1;
+        }
+    }
     return -1;
 }
 
 void UhdmImporter::collect_live_assigned_signals(const any* stmt, bool live,
-                                                 std::set<std::string>& out) {
+                                                 std::set<std::string>& out,
+                                                 bool fold_guards) {
     if (!stmt) return;
     switch (stmt->VpiType()) {
         case vpiAssignment: {
             if (!live) break;
             auto a = any_cast<const assignment*>(stmt);
-            if (a->Lhs() && !a->Lhs()->VpiName().empty())
-                out.insert(std::string(a->Lhs()->VpiName()));
+            if (a->Lhs() && !a->Lhs()->VpiName().empty()) {
+                // Record the LHS name AND every dot-prefix of it: a struct-FIELD
+                // write (`branch_exception_o.cause = …`, hier_path LHS) has
+                // VpiName "branch_exception_o.cause", but the temp-wire pre-pass
+                // (extract_assigned_signals) records the BASE wire name
+                // ("branch_exception_o") — the prune compares against that name,
+                // so a base assigned only through its fields must still count as
+                // assigned.
+                std::string nm = std::string(a->Lhs()->VpiName());
+                out.insert(nm);
+                for (size_t dot = nm.rfind('.'); dot != std::string::npos;
+                     dot = nm.rfind('.'))
+                    { nm = nm.substr(0, dot); out.insert(nm); }
+            }
             break;
         }
         case vpiBegin:
         case vpiNamedBegin:
             if (auto stmts = begin_block_stmts(stmt))
-                for (auto s : *stmts) collect_live_assigned_signals(s, live, out);
+                for (auto s : *stmts)
+                    collect_live_assigned_signals(s, live, out, fold_guards);
             break;
         case vpiIf: {
             auto ist = any_cast<const if_stmt*>(stmt);
             bool tk = live;
-            if (live && const_cond_value(ist->VpiCondition()) == 0) tk = false;
-            collect_live_assigned_signals(ist->VpiStmt(), tk, out);
+            if (fold_guards && live && const_cond_value(ist->VpiCondition()) == 0)
+                tk = false;
+            collect_live_assigned_signals(ist->VpiStmt(), tk, out, fold_guards);
             break;
         }
         case vpiIfElse: {
             auto ie = any_cast<const if_else*>(stmt);
             bool tk = live, ek = live;
-            if (live) {
+            if (fold_guards && live) {
                 int c = const_cond_value(ie->VpiCondition());
                 if (c == 0) tk = false;
                 else if (c == 1) ek = false;
             }
-            collect_live_assigned_signals(ie->VpiStmt(), tk, out);
-            collect_live_assigned_signals(ie->VpiElseStmt(), ek, out);
+            collect_live_assigned_signals(ie->VpiStmt(), tk, out, fold_guards);
+            collect_live_assigned_signals(ie->VpiElseStmt(), ek, out, fold_guards);
             break;
         }
         case vpiFor:
-            collect_live_assigned_signals(any_cast<const for_stmt*>(stmt)->VpiStmt(), live, out);
+            collect_live_assigned_signals(any_cast<const for_stmt*>(stmt)->VpiStmt(),
+                                          live, out, fold_guards);
             break;
         case vpiCase: {
             auto cs = any_cast<const case_stmt*>(stmt);
             if (cs->Case_items())
                 for (auto item : *cs->Case_items())
-                    collect_live_assigned_signals(item->Stmt(), live, out);
+                    collect_live_assigned_signals(item->Stmt(), live, out,
+                                                  fold_guards);
             break;
         }
         default: break;

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -337,7 +337,7 @@ void UhdmImporter::import_design(UHDM::design* uhdm_design) {
     // from AllModules loses its memories; the elaborated instance carries the
     // correct array_var.  Used below to import such modules from the elaborated
     // form instead.
-    std::map<std::string, const module_inst*> elab_inst_by_def;
+    elab_inst_by_def.clear();
     if (uhdm_design->TopModules()) {
         std::function<void(const module_inst*)> walk = [&](const module_inst* m) {
             if (!m) return;
@@ -1453,6 +1453,33 @@ std::string UhdmImporter::eval_param_struct_field(const hier_path* hp) {
             for (auto pa : *current_instance->Param_assigns())
                 if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
                     if (std::string(l->VpiName()) == bname) { a = l; break; }
+    }
+    // When importing from an AllModules DEFINITION (VpiName empty), the def's
+    // param_assign holds the DECLARATION DEFAULT (CVA6 branch_unit:
+    // `CVA6Cfg = cva6_cfg_empty` == cva6_cfg_t'(0), a 1-operand pattern) — NOT
+    // the elaborated override.  Field resolution against it either fails
+    // ("Could not resolve struct member access 'CVA6Cfg.RVC'" → guard never
+    // folds → spurious latch) or silently yields the DEFAULT's value for
+    // positional index 0.  Re-resolve the parameter from a representative
+    // ELABORATED instance of this def, whose param_assign carries the real
+    // value (vpiOverriden).
+    if (current_instance && current_instance->VpiName().empty()) {
+        std::string dn = std::string(current_instance->VpiDefName());
+        if (dn.rfind("work@", 0) == 0) dn = dn.substr(5);
+        auto eit = elab_inst_by_def.find(dn);
+        if (eit != elab_inst_by_def.end() && eit->second != current_instance) {
+            std::string bname = std::string(bref->VpiName());
+            const any* ea = nullptr;
+            if (eit->second->Parameters())
+                for (auto p : *eit->second->Parameters())
+                    if (std::string(p->VpiName()) == bname &&
+                        p->UhdmType() == uhdmparameter) { ea = p; break; }
+            if (!ea && eit->second->Param_assigns())
+                for (auto pa : *eit->second->Param_assigns())
+                    if (auto l = dynamic_cast<const parameter*>(pa->Lhs()))
+                        if (std::string(l->VpiName()) == bname) { ea = l; break; }
+            if (ea) a = ea;
+        }
     }
     if (!a) return "";
     const expr* val = nullptr;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -313,6 +313,13 @@ struct UhdmImporter {
     const UHDM::module_inst* current_instance = nullptr;
     const UHDM::scope* current_scope = nullptr;
 
+    // Module DEFINITION name (work@ stripped) -> first-seen ELABORATED instance
+    // of that def in the TopModules hierarchy.  AllModules defs carry only
+    // DECLARATION-DEFAULT parameter values (e.g. CVA6's `CVA6Cfg =
+    // cva6_cfg_empty`), so anything that needs a real parameter VALUE while a
+    // def is being imported must consult the elaborated instance instead.
+    std::map<std::string, const UHDM::module_inst*> elab_inst_by_def;
+
     // Current generate scope for naming (deprecated - use gen_scope_stack)
     std::string current_gen_scope;
     
@@ -884,9 +891,15 @@ struct UhdmImporter {
     void collect_for_loop_var_names(const any* stmt, std::set<std::string>& names);
     // Collect names of signals with at least one LIVE (not statically
     // dead-guarded by a const-false/true `if`) assignment.  A register assigned
-    // ONLY in dead branches must not become an (async-reset) FF.
+    // ONLY in dead branches must not become an (async-reset) FF, and a comb
+    // signal assigned only in dead branches must not get a self-hold temp
+    // (spurious latch).  With fold_guards=false every branch is treated as
+    // live — the two runs' set difference is exactly the dead-guarded names,
+    // so LHS shapes this scan can't see (concats, var_selects) land in
+    // neither set and are never pruned.
     void collect_live_assigned_signals(const UHDM::any* stmt, bool live,
-                                       std::set<std::string>& out);
+                                       std::set<std::string>& out,
+                                       bool fold_guards = true);
     // Evaluate an `if` condition to a compile-time constant WITHOUT creating
     // cells: 0 (false), 1 (true), or -1 (not a resolvable constant).
     int const_cond_value(const UHDM::any* cond);

--- a/test/comb_dead_guard_latch/dut.sv
+++ b/test/comb_dead_guard_latch/dut.sv
@@ -1,0 +1,51 @@
+// Repro of CVA6 cva6_mmu.sv:522 `data_interface` spurious-latch class: an
+// always_comb where some signals are assigned ONLY under a compile-time-FALSE
+// parameter guard (`if (CVA6Cfg.RVH) begin lsu_tinst_n = …; end` with RVH==0).
+// The body import folds the dead branch away, but the pre-pass still creates a
+// `$0\sig` temp with a self-hold default (`$0\sig = \sig`) and an STa update
+// (`\sig <= $0\sig`) for every syntactically-assigned signal — leaving the net
+// effect `sig = sig`, which proc_dlatch turns into a latch.  read_verilog and
+// slang leave the signal undriven instead (0 latches on the whole of CVA6).
+//
+// `dead_n` (internal) and `dead_o` (output port, like csr_hs_ld_st_inst_o)
+// are only assigned under the dead guard and must NOT get temps/updates.
+// `mix_n` has both a live and a dead assignment and must be kept.
+// `fld_s` is assigned ONLY via struct-FIELD writes (hier_path LHS, like
+// branch_unit's branch_exception_o) — all live — and must survive the prune
+// (guards the collect/extract name-scheme mismatch).
+module comb_dead_guard_latch #(
+    parameter bit EN  = 1'b0,
+    parameter bit SEL = 1'b1
+) (
+    input  logic [3:0] a_i,
+    input  logic [3:0] b_i,
+    input  logic       c_i,
+    output logic [3:0] y_o,
+    output logic [3:0] z_o,
+    output logic       dead_o,
+    output logic [4:0] f_o
+);
+  typedef struct packed {
+    logic       v;
+    logic [3:0] d;
+  } fld_t;
+
+  logic [3:0] dead_n;
+  logic [3:0] mix_n;
+  fld_t       fld_s;
+
+  always_comb begin
+    y_o   = a_i;
+    mix_n = a_i & b_i;
+    fld_s.v = c_i;
+    fld_s.d = a_i ^ b_i;
+    if (EN) begin
+      dead_n = a_i ^ b_i;
+      mix_n  = a_i | b_i;
+      dead_o = c_i;
+    end
+    if (SEL) y_o = a_i + b_i;
+    z_o = mix_n & dead_n;
+    f_o = {fld_s.v, fld_s.d};
+  end
+endmodule

--- a/test/comb_dead_guard_latch/test_slang_equiv.ys
+++ b/test/comb_dead_guard_latch/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for comb_dead_guard_latch.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top comb_dead_guard_latch
+flatten; proc; opt -fast
+rename comb_dead_guard_latch gold
+design -stash gold
+
+read_slang dut.sv --top comb_dead_guard_latch
+hierarchy -check -top comb_dead_guard_latch
+flatten; proc; opt -fast
+rename comb_dead_guard_latch gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/comb_local_init_latch/dut.sv
+++ b/test/comb_local_init_latch/dut.sv
@@ -1,0 +1,18 @@
+// Repro of CVA6 alu.sv:199 spurious latch on a block-local comb variable that
+// IS unconditionally initialized: `logic sgn; sgn = 1'b0; if (…) sgn = 1'b1;`
+// inside always_comb.  read_verilog/slang infer no latch (the init covers all
+// paths); the UHDM import promoted `sgn` to a module wire with a self-hold
+// default that survives, so proc_dlatch created a latch.
+module comb_local_init_latch (
+    input  logic [3:0] op,
+    input  logic [7:0] a,
+    input  logic [7:0] b,
+    output logic       less
+);
+  always_comb begin
+    logic sgn;
+    sgn = 1'b0;
+    if (op == 4'd3 || op == 4'd5) sgn = 1'b1;
+    less = ($signed({sgn & a[7], a}) < $signed({sgn & b[7], b}));
+  end
+endmodule

--- a/test/comb_local_init_latch/test_slang_equiv.ys
+++ b/test/comb_local_init_latch/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for comb_local_init_latch.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top comb_local_init_latch
+flatten; proc; opt -fast
+rename comb_local_init_latch gold
+design -stash gold
+
+read_slang dut.sv --top comb_local_init_latch
+hierarchy -check -top comb_local_init_latch
+flatten; proc; opt -fast
+rename comb_local_init_latch gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/def_ctx_struct_param/dut.sv
+++ b/test/def_ctx_struct_param/dut.sv
@@ -1,0 +1,74 @@
+// Repro of the CVA6 branch_unit def-context struct-param staleness: a module
+// with NO generate statements is imported from its AllModules DEFINITION
+// (VpiName empty), where the struct parameter's param_assign holds the
+// DECLARATION DEFAULT (`Cfg = CfgEmpty` == cfg_t'(0)) — not the elaborated
+// override passed down the hierarchy.  `Cfg.RVC` then either fails to resolve
+// ("Could not resolve struct member access" → guard stays a runtime wire →
+// spurious latch; CVA6 jump_taken) or silently folds to the DEFAULT's 0
+// instead of the overridden 1, killing the live `if (Cfg.RVC)` branch —
+// functionally wrong (y_o stuck at 0).
+package dcs_cfg_pkg;
+  typedef struct packed {
+    logic [31:0] XLEN;
+    logic        RVC;
+    logic        RVH;
+  } cfg_t;
+  // Same shapes as CVA6: a cast'(0) declaration default (elaborates to a
+  // 1-operand pattern in the AllModules def) and a function-built override
+  // (elaborates to a struct_var whose typespec members carry the values).
+  // NOTE: read_verilog cannot parse these — this test is adjudicated against
+  // read_slang (test_slang_equiv.ys), not the Verilog frontend.
+  // NOTE an initial whole-struct assignment (`c = cfg_t'(0);`) before the
+  // member writes makes Surelog's const-eval return the CAST value and drop
+  // the member writes entirely (upstream Surelog bug, not hit by CVA6 —
+  // build_config_pkg.sv declares `cfg` and assigns members only).
+  localparam cfg_t CfgEmpty = cfg_t'(0);
+  function automatic cfg_t build_config();
+    cfg_t c;
+    c.XLEN = 32;
+    c.RVC  = 1'b1;
+    c.RVH  = 1'b0;
+    return c;
+  endfunction
+  localparam cfg_t CfgDefault = build_config();
+endpackage
+
+module dcs_leaf #(
+    parameter dcs_cfg_pkg::cfg_t Cfg = dcs_cfg_pkg::CfgEmpty
+) (
+    input  logic a_i,
+    input  logic b_i,
+    output logic y_o,
+    output logic z_o,
+    output logic h_o
+);
+  always_comb begin
+    z_o = a_i ^ b_i;
+    y_o = 1'b0;
+    h_o = 1'b0;
+    if (Cfg.RVC) y_o = a_i & b_i;  // LIVE: override has RVC=1
+    if (Cfg.RVH) h_o = a_i | b_i;  // DEAD: override has RVH=0
+  end
+endmodule
+
+module dcs_mid #(
+    parameter dcs_cfg_pkg::cfg_t Cfg = dcs_cfg_pkg::CfgEmpty
+) (
+    input  logic a_i,
+    input  logic b_i,
+    output logic y_o,
+    output logic z_o,
+    output logic h_o
+);
+  dcs_leaf #(.Cfg(Cfg)) u_leaf (.*);
+endmodule
+
+module def_ctx_struct_param (
+    input  logic a_i,
+    input  logic b_i,
+    output logic y_o,
+    output logic z_o,
+    output logic h_o
+);
+  dcs_mid #(.Cfg(dcs_cfg_pkg::CfgDefault)) u_mid (.*);
+endmodule

--- a/test/def_ctx_struct_param/test_slang_equiv.ys
+++ b/test/def_ctx_struct_param/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for def_ctx_struct_param.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top def_ctx_struct_param
+flatten; proc; opt -fast
+rename def_ctx_struct_param gold
+design -stash gold
+
+read_slang dut.sv --top def_ctx_struct_param
+hierarchy -check -top def_ctx_struct_param
+flatten; proc; opt -fast
+rename def_ctx_struct_param gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -194,7 +194,7 @@ svtypes_struct_array
 # miter (SUCCESS).  These are the reproducers for the CVA6 alu_wrapper
 # `fu_data_i[0]` packed-array element-select fixes.
 packed_array_elem_select
-packed_array_struct_port_sel
+# packed_array_struct_port_sel  (now PASSES: runner classifies "UHDM succeeds where Verilog fails" as pass)
 
 # --- `parameter type` struct with function-computed CVA6Cfg.FIELD widths ---
 # Native read_verilog cannot parse `parameter type fu_data_t` (SV type params),
@@ -202,7 +202,7 @@ packed_array_struct_port_sel
 # via a sound from-reset SAT miter (SUCCESS).  Reproducer for the CVA6
 # `fu_data_i.operand_a` struct-member port-width fix (build_config() struct
 # param → member widths resolved from the elaborated typespec's member exprs).
-struct_member_cfg_width
+# struct_member_cfg_width  (now PASSES: runner classifies "UHDM succeeds where Verilog fails" as pass)
 
 # --- `parameter type` port bound to a computed-width logic vector ---
 # Native read_verilog cannot parse `parameter type dtype` (SV type params), so
@@ -212,7 +212,7 @@ struct_member_cfg_width
 # PORT typespec stays at the default `logic` (1 bit) while the port VARIABLE
 # carries the resolved range — import_port now recovers the width from the
 # logic_var/enum_var when the port typespec collapsed to <=1.
-param_type_logic_width
+# param_type_logic_width  (now PASSES: runner classifies "UHDM succeeds where Verilog fails" as pass)
 
 # --- `parameter type` module instantiated inside a generate block ---
 # Native read_verilog cannot parse `parameter type T` (SV type params), so there
@@ -222,7 +222,7 @@ param_type_logic_width
 # per-type-binding $typaram signature, so the cell referenced bare `\leaf` while
 # the module was imported as `\leaf$typaram_...` -> unresolved blackbox that
 # `hierarchy -check` rejects.
-gen_scope_typaram
+# gen_scope_typaram  (now PASSES: runner classifies "UHDM succeeds where Verilog fails" as pass)
 
 # --- Yosys v0.67 upstream check_mem / memories additions ---
 # check_mem/init.sv (dynamic read of a 2D unpacked array), check_mem/non_zero.sv
@@ -282,3 +282,14 @@ rp32_r5p_mouse
 #   sva/extnets — external-net SVA harness; equiv_induct-only Induct-Formal.
 simple/module_scope_case.v
 sva/extnets.sv
+
+# --- def-context struct-param staleness reproducer (CVA6 branch_unit) ---
+# Native read_verilog cannot parse the CVA6-realistic shapes (cfg_t'(0) cast
+# default, automatic function with member writes + return), so there is no
+# Verilog reference; the UHDM output is VERIFIED equal to slang via a sound SAT
+# miter (test_slang_equiv.ys in the test dir, SUCCESS).  Reproducer for the
+# AllModules-def import reading the DECLARATION-DEFAULT struct-param value
+# (cva6_cfg_empty) instead of the elaborated override — eval_param_struct_field
+# now re-resolves from a representative elaborated instance (elab_inst_by_def).
+# def_ctx_struct_param  (PASSES: runner classifies "UHDM succeeds where Verilog fails" as pass;
+#   kept documented here for the slang-miter verification pointer)


### PR DESCRIPTION
## Summary

CVA6 emitted ~130 spurious `proc_dlatch` latches where `read_slang` emits **zero**, and `proc` on the core hung for **9+ hours**. This PR brings the count to 79 (remainder is mostly the legitimate runtime-incomplete-assignment class where slang's unassigned-path-X choice is the outlier), makes full-core `proc` finish in ~45 s, and fixes one **real correctness bug** that read_verilog equivalence could not see.

### Frontend fixes
1. **Comb dead-guard prune** (`import_always_comb`): signals assigned only under compile-time-false guards (`if (CVA6Cfg.RVH) …`) no longer get a self-hold `$0` temp + STa update (net `x = x` → spurious latch). Safer dead-set predicate (unfolded-scan minus live-scan) now used by both the comb and ff paths; `collect_live_assigned_signals` records dot-prefixes so field writes count for their base.
2. **Def-context struct-param staleness** (`eval_param_struct_field`): modules without generate statements import from the AllModules def whose param value is the *declaration default* (`cva6_cfg_empty`); re-resolve from a representative elaborated instance (`elab_inst_by_def`).
3. **`const_cond_value` operation folding**: `!CVA6Cfg.RVC`, `FPGA_EN && FPGA_ALTERA` guards now fold (recursive Not/LogAnd/LogOr, short-circuit, cell-free).
4. **Begin-block promoted-wire reuse** (`import_begin_block_comb`): top-level init and nested-if writes of a block-local no longer split across scoped/bare wires (alu `sgn`, lsu_bypass pointers, tlb plru temps).
5. **Correctness: comb-if branch-value leak** (`import_if_stmt_comb`/`import_if_else_comb`): branch bodies record blocking writes live into `current_comb_values` with no snapshot/restore, so `thread_comb_if`'s pre-value lookup read the branch's own value and the conditional value leaked to later same-block reads as if unconditional (`sgn = 1'b0; if (…) sgn = 1'b1; less = …sgn…` read `sgn ≡ 1`). Pre-existing; **masked by read_verilog equivalence** — caught by the UHDM-vs-slang SAT miter.
6. **Const-aware condition reduce** in the Process-path comb if handlers (a folded `if (CVA6Cfg.RVS)` was re-wrapped in a `$reduce_bool` cell → csr_regfile's S-CSR defaults turned conditional, 52 latches).
7. `import_constant` vpiUIntConst: clamp unsized (`vpiSize == -1`) widths (yosys v0.68's `WIDTH_LIMIT` assert rejects the old `-1` pass-through).

### Yosys v0.68 bump + proc_dlatch memoization
- `.gitmodules` → `alainmarcel/yosys`, pinned to `v0.68-proc-dlatch-memo` (v0.68 + memoized `find_mux_feedback`/`find_mux_constant`). The un-memoized recursion over the post-`proc_mux` mux DAG is exponential on shared subtrees — CVA6's `cva6_tlb` `update_flush` (~950 muxes, nodes shared 16×) kept `proc_dlatch` spinning >9 h; memoized it's <1 s. See **alainmarcel/yosys#4** — ⚠️ CI cannot fetch the pinned commit until that PR is merged.

### Tests
- `test/comb_dead_guard_latch` — dead-guard prune (0 latches; formal equiv + slang SAT miter)
- `test/def_ctx_struct_param` — def staleness (slang miter only; read_verilog cannot parse the CVA6-realistic `cfg_t'(0)` / function-with-member-writes shapes). Also documents an upstream Surelog const-eval bug (initial whole-struct assign drops later member writes).
- `test/comb_local_init_latch` — the `sgn` leak (slang miter FAIL→SUCCESS)
- `failing_tests.txt`: 4 stale `parameter type` entries commented out (runner now classifies "UHDM succeeds where Verilog fails" as PASS)

### Validation (on v0.68)
Full sweep 802/808 functional, same 6 expected Induct-Formal failures, co-sim warning set identical to the pre-change baseline (48). CVA6 `read_uhdm → hierarchy → proc` in ~45 s, 130 → 79 latches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)