### PR TITLE
build: update Yosys compile message to v0.68

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ else()
     add_custom_target(yosys DEPENDS ${INSTALL_DIR}/bin/yosys)
     add_custom_command(
       OUTPUT ${INSTALL_DIR}/bin/yosys
-      COMMAND ${CMAKE_COMMAND} -E echo "Compiling Yosys v0.67 via CMake, slang=${UHDM2RTLIL_ENABLE_SLANG}"
+      COMMAND ${CMAKE_COMMAND} -E echo "Compiling Yosys v0.68 via CMake, slang=${UHDM2RTLIL_ENABLE_SLANG}"
       COMMAND ${CMAKE_COMMAND} -B ${YOSYS_BUILD_DIR} -S ${YOSYS_SRC_DIR}
               -DCMAKE_BUILD_TYPE=Release
               -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}


### PR DESCRIPTION
One-line cosmetic fix: the top-level CMakeLists echo still said "Compiling Yosys v0.67" after the v0.68 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)