### PR TITLE
uhdm: unpacked-array materialization + dynamic element-field writes (CVA6 latch triage round 2)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5136,23 +5136,33 @@ RTLIL::SigSpec UhdmImporter::import_ref_obj(const ref_obj* uhdm_ref, const UHDM:
     // flattened formal lines up (mat[i] == a[i]).  Without this the bare name
     // resolved to a 1-bit unknown wire and the callee read garbage.
     // (SelectFromUnpackedInFunction / 2DUnpackedFunctionArgument.)
-    if (!name_map.count(ref_name) && name_map.count(ref_name + "[0]")) {
-        std::string gs = get_current_gen_scope();
-        RTLIL::SigSpec arr;
-        for (int i = 0; ; i++) {
-            std::string en = ref_name + "[" + std::to_string(i) + "]";
-            RTLIL::Wire* ew = nullptr;
-            if (!gs.empty() && name_map.count(gs + "." + en))
-                ew = name_map[gs + "." + en];
-            else if (name_map.count(en))
-                ew = name_map[en];
-            if (!ew) break;
-            arr.append(RTLIL::SigSpec(ew));
-        }
-        if (arr.size() > 0) {
-            log("    ref_obj: whole unpacked array %s -> %d-bit element concat\n",
-                ref_name.c_str(), arr.size());
-            return arr;
+    if (!name_map.count(ref_name)) {
+        // Probe the array's low bound — usually 0, but a `[N:1]` declaration
+        // (CVA6 perf_counters) starts at 1.
+        int wa_low = -1;
+        for (int probe = 0; probe <= 64; probe++)
+            if (name_map.count(ref_name + "[" + std::to_string(probe) + "]")) {
+                wa_low = probe;
+                break;
+            }
+        if (wa_low >= 0) {
+            std::string gs = get_current_gen_scope();
+            RTLIL::SigSpec arr;
+            for (int i = wa_low; ; i++) {
+                std::string en = ref_name + "[" + std::to_string(i) + "]";
+                RTLIL::Wire* ew = nullptr;
+                if (!gs.empty() && name_map.count(gs + "." + en))
+                    ew = name_map[gs + "." + en];
+                else if (name_map.count(en))
+                    ew = name_map[en];
+                if (!ew) break;
+                arr.append(RTLIL::SigSpec(ew));
+            }
+            if (arr.size() > 0) {
+                log("    ref_obj: whole unpacked array %s -> %d-bit element concat\n",
+                    ref_name.c_str(), arr.size());
+                return arr;
+            }
         }
     }
 
@@ -5977,14 +5987,27 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
     }
     
     // Check for expanded array: individual element wires exist (not a $memory object).
-    // Handles both constant and dynamic indices.
+    // Handles both constant and dynamic indices.  The low bound is usually 0,
+    // but a `[N:1]` declaration (CVA6 perf_counters
+    // `generic_counter_q[MHPMCounterNum:1]`) starts at 1 — probe for the first
+    // declared element instead of requiring `[0]`.
     if (!module->memories.count(mem_id)) {
-        RTLIL::Wire* first_elem = module->wire(RTLIL::escape_id(signal_name + "[0]"));
+        int arr_low = -1;
+        for (int probe = 0; probe <= 64; probe++)
+            if (module->wire(RTLIL::escape_id(
+                    signal_name + "[" + std::to_string(probe) + "]"))) {
+                arr_low = probe;
+                break;
+            }
+        RTLIL::Wire* first_elem = arr_low < 0 ? nullptr
+            : module->wire(RTLIL::escape_id(
+                  signal_name + "[" + std::to_string(arr_low) + "]"));
         if (first_elem) {
             int elem_w = first_elem->width;
-            // Count elements
+            // Count elements from the low bound up
             int num_elems = 0;
-            while (module->wire(RTLIL::escape_id(signal_name + "[" + std::to_string(num_elems) + "]")))
+            while (module->wire(RTLIL::escape_id(
+                       signal_name + "[" + std::to_string(arr_low + num_elems) + "]")))
                 num_elems++;
 
             RTLIL::SigSpec idx = import_expression(uhdm_bit->VpiIndex(), input_mapping);
@@ -6005,18 +6028,18 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                 // Constant index outside the array bounds reads X — SV leaves an
                 // out-of-range access unspecified (verilog/mem_bounds.sv reads
                 // `mem[-1]` and asserts it is all-X via $countbits).
-                if (num_elems > 0 && (i < 0 || i >= num_elems))
+                if (num_elems > 0 && (i < arr_low || i >= arr_low + num_elems))
                     return RTLIL::SigSpec(RTLIL::State::Sx, elem_w);
             } else {
-                // Dynamic index — build mux chain.
-                int last = num_elems - 1;
+                // Dynamic index — build mux chain over DECLARED indices.
+                int last = arr_low + num_elems - 1;
                 int idx_w = GetSize(idx);
                 // Can the index address a non-existent element?  If the
                 // index width can represent a value >= num_elems, an
                 // out-of-range read is possible and needs an explicit
                 // fall-through value.  Otherwise every representable index
                 // is valid and the last element serves as the default.
-                bool oob_possible = (idx_w >= 31) ||
+                bool oob_possible = (idx_w >= 31) || (arr_low > 0) ||
                                     ((1LL << idx_w) > (long long)num_elems);
                 RTLIL::SigSpec result;
                 int start;
@@ -6041,7 +6064,7 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                     start = last - 1;
                 }
 
-                for (int i = start; i >= 0; i--) {
+                for (int i = start; i >= arr_low; i--) {
                     std::string ename = signal_name + "[" + std::to_string(i) + "]";
                     RTLIL::SigSpec elem_val;
                     if (current_comb_values.count(ename))

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -6619,6 +6619,24 @@ void UhdmImporter::emit_comb_assign(RTLIL::SigSpec lhs, RTLIL::SigSpec rhs, RTLI
         auto alias_it = comb_value_aliases.find(signal_name);
         if (alias_it != comb_value_aliases.end())
             current_comb_values[alias_it->second] = rhs;
+    } else if (!in_always_ff_body_mode) {
+        // Concat LHS over FULL element wires (a whole-array copy
+        // `counter_d = counter_q` expanded to {\arr[N]..\arr[1]} =
+        // {\q[N]..\q[1]}): record each element's in-flight value too, so a
+        // later dynamic-index element write's read-modify-write mux uses the
+        // default (`\q[k]`) instead of the raw element wire — the raw wire
+        // would be a self-hold inside the write's conditional arm and
+        // proc_dlatch would latch every element (CVA6 perf_counters).
+        int off = 0;
+        for (const auto& chunk : lhs.chunks()) {
+            if (chunk.wire && chunk.offset == 0 &&
+                chunk.width == chunk.wire->width) {
+                std::string nm = chunk.wire->name.str();
+                if (!nm.empty() && nm[0] == '\\') nm = nm.substr(1);
+                current_comb_values[nm] = rhs.extract(off, chunk.width);
+            }
+            off += chunk.width;
+        }
     }
 }
 
@@ -9271,14 +9289,26 @@ bool UhdmImporter::emit_dynamic_unpacked_array_write(
     if (!bs) return false;
     std::string base_name = std::string(bs->VpiName());
     if (base_name.empty()) return false;
-    // Expanded unpacked array: element wires \base[0], \base[1], … exist.
+    // Expanded unpacked array: element wires \base[low..high] exist.  The low
+    // bound is usually 0, but a `[N:1]` declaration (CVA6 perf_counters
+    // `generic_counter_d[MHPMCounterNum:1]`) starts at 1 — probe a small
+    // range for the first declared element instead of requiring `[0]`.
     // (A real $memory has no such wires — bail so the memory path handles it.)
-    RTLIL::Wire* first = module->wire(RTLIL::escape_id(base_name + "[0]"));
-    if (!first) return false;
+    int array_low = -1;
+    for (int probe = 0; probe <= 64; probe++) {
+        if (module->wire(RTLIL::escape_id(
+                base_name + "[" + std::to_string(probe) + "]"))) {
+            array_low = probe;
+            break;
+        }
+    }
+    if (array_low < 0) return false;
+    RTLIL::Wire* first = module->wire(RTLIL::escape_id(
+        base_name + "[" + std::to_string(array_low) + "]"));
     int elem_w = first->width;
     int num_elems = 0;
     while (module->wire(RTLIL::escape_id(
-               base_name + "[" + std::to_string(num_elems) + "]")))
+               base_name + "[" + std::to_string(array_low + num_elems) + "]")))
         num_elems++;
     if (num_elems <= 0) return false;
 
@@ -9298,7 +9328,7 @@ bool UhdmImporter::emit_dynamic_unpacked_array_write(
     if (rhs.size() < elem_w) rhs.extend_u0(elem_w, rhs_signed);
     else if (rhs.size() > elem_w) rhs = rhs.extract(0, elem_w);
 
-    for (int k = 0; k < num_elems; k++) {
+    for (int k = array_low; k < array_low + num_elems; k++) {
         std::string ename = base_name + "[" + std::to_string(k) + "]";
         RTLIL::Wire* ew = module->wire(RTLIL::escape_id(ename));
         if (!ew) continue;
@@ -9544,6 +9574,192 @@ bool UhdmImporter::emit_dynamic_struct_field_bit_write(
     return true;
 }
 
+// `arr[idx].field = rhs` with a DYNAMIC element index on an unpacked array of
+// structs represented as a FLAT wire (the whole-array-access shape from
+// import_module: `\arr` = N*elem_w bits + per-element slice aliases).  No
+// RTLIL LHS form captures a runtime-indexed element's field, so synthesise a
+// full-width mask/shift/or rewrite of the flat wire:
+//   shift = (idx - low) * elem_w + field_off
+//   new   = (cur & ~(field_mask << shift)) | (rhs << shift)
+// `cur` comes from current_comb_values so earlier same-block writes (the
+// whole-array default `mem_n = mem_q`) are preserved.  Without this the LHS
+// fell through to import_hier_path's READ path ("Could not resolve struct
+// member access 'mem_n[wptr_i].valid'") and the write was DROPPED — CVA6
+// cva6_fifo_v3 / lsu_bypass / store_buffer commit_queue_n.
+bool UhdmImporter::emit_dynamic_array_elem_field_write(
+        const UHDM::hier_path* hp,
+        const UHDM::any* rhs_any,
+        RTLIL::Process* proc,
+        RTLIL::CaseRule* case_rule) {
+    if (!hp || !hp->Path_elems() || hp->Path_elems()->size() != 2) return false;
+    auto& pe = *hp->Path_elems();
+    if (pe[0]->UhdmType() != uhdmbit_select) return false;
+    if (pe[1]->UhdmType() != uhdmref_obj) return false;
+    const bit_select* bs       = any_cast<const bit_select*>(pe[0]);
+    const ref_obj*    field_rf = any_cast<const ref_obj*>(pe[1]);
+    if (!bs || !field_rf || !bs->VpiIndex()) return false;
+
+    std::string base_name  = std::string(bs->VpiName());
+    std::string field_name = std::string(field_rf->VpiName());
+    if (base_name.empty() || field_name.empty()) return false;
+
+    // Only the FLAT representation is handled here: `\arr` exists as one wide
+    // wire AND per-element aliases `\arr[k]` exist (the per-element-only
+    // representation goes through emit_dynamic_unpacked_array_write).
+    RTLIL::Wire* base_wire = module->wire(RTLIL::escape_id(base_name));
+    if (!base_wire) return false;
+    int base_w = base_wire->width;
+
+    // Element struct typespec via the inner net mapped to the flat wire.
+    const UHDM::struct_typespec* st = nullptr;
+    for (auto& kv : wire_map) {
+        if (kv.second != base_wire) continue;
+        const ref_typespec* rts = nullptr;
+        if (auto ln = dynamic_cast<const UHDM::logic_net*>(kv.first)) rts = ln->Typespec();
+        else if (auto lv = dynamic_cast<const UHDM::logic_var*>(kv.first)) rts = lv->Typespec();
+        else if (auto sv = dynamic_cast<const UHDM::struct_var*>(kv.first)) rts = sv->Typespec();
+        else if (auto sn = dynamic_cast<const UHDM::struct_net*>(kv.first)) rts = sn->Typespec();
+        if (rts)
+            if (auto ats = rts->Actual_typespec())
+                if (ats->UhdmType() == uhdmstruct_typespec)
+                    st = any_cast<const UHDM::struct_typespec*>(ats);
+        if (st) break;
+    }
+    if (!st || !st->Members()) return false;
+
+    int elem_w = get_width_from_typespec(st, current_instance);
+    if (elem_w <= 0 || base_w % elem_w != 0) return false;
+    int n_elems = base_w / elem_w;
+
+    // Element index low bound: smallest k with an `\arr[k]` alias wire.
+    int array_low = -1;
+    for (int k = 0; k <= n_elems; k++) {
+        if (module->wire(RTLIL::escape_id(
+                base_name + "[" + std::to_string(k) + "]"))) {
+            array_low = k;
+            break;
+        }
+    }
+    if (array_low < 0) return false;
+
+    // Field offset within the element (last listed member = LSB).
+    int field_offset = 0, field_width = 0;
+    bool found_field = false;
+    for (int i = (int)st->Members()->size() - 1; i >= 0; i--) {
+        auto m = (*st->Members())[i];
+        int mw = 0;
+        if (auto mts = m->Typespec())
+            if (auto ats = mts->Actual_typespec())
+                mw = get_width_from_typespec(ats, current_instance);
+        if (std::string(m->VpiName()) == field_name) {
+            field_width = mw;
+            found_field = true;
+            break;
+        }
+        field_offset += mw;
+    }
+    if (!found_field || field_width <= 0) return false;
+    if (field_offset + field_width > elem_w) return false;
+
+    // Constant index: static slice write through the normal machinery.
+    RTLIL::SigSpec idx_sig = import_expression(bs->VpiIndex(), comb_read_map());
+    if (idx_sig.is_fully_const()) {
+        int k = idx_sig.as_const().as_int();
+        int off = (k - array_low) * elem_w + field_offset;
+        if (off < 0 || off + field_width > base_w) return false;
+        auto rhs_e = dynamic_cast<const UHDM::expr*>(rhs_any);
+        if (!rhs_e) return false;
+        int prev_ctx = expression_context_width;
+        expression_context_width = field_width;
+        RTLIL::SigSpec rhs = import_expression(rhs_e, comb_read_map());
+        expression_context_width = prev_ctx;
+        if (rhs.size() < field_width) rhs.extend_u0(field_width, is_expr_signed(rhs_e));
+        else if (rhs.size() > field_width) rhs = rhs.extract(0, field_width);
+        RTLIL::SigSpec lhs_slice = RTLIL::SigSpec(base_wire).extract(off, field_width);
+        if (proc) emit_comb_assign(lhs_slice, rhs, proc);
+        else if (case_rule) {
+            std::string temp_name = "$0\\" + base_name;
+            if (RTLIL::Wire* tw = module->wire(temp_name))
+                case_rule->actions.push_back(RTLIL::SigSig(
+                    RTLIL::SigSpec(tw).extract(off, field_width), rhs));
+            else
+                case_rule->actions.push_back(RTLIL::SigSig(lhs_slice, rhs));
+        }
+        if (!in_always_ff_body_mode) {
+            RTLIL::SigSpec cur = current_comb_values.count(base_name)
+                                     ? current_comb_values[base_name]
+                                     : RTLIL::SigSpec(base_wire);
+            cur.replace(off, rhs);
+            current_comb_values[base_name] = cur;
+        }
+        return true;
+    }
+
+    // Dynamic index: full-width RMW on the flat wire.
+    int shamt_w = std::max(idx_sig.size() + 6, 32);
+    RTLIL::SigSpec idx_ext = idx_sig;
+    idx_ext.extend_u0(shamt_w, false);
+    RTLIL::SigSpec pos = idx_ext;
+    if (array_low != 0) {
+        RTLIL::Wire* pw = module->addWire(NEW_ID, shamt_w);
+        module->addSub(NEW_ID, idx_ext,
+                       RTLIL::SigSpec(RTLIL::Const(array_low, shamt_w)), pw, true);
+        pos = RTLIL::SigSpec(pw);
+    }
+    RTLIL::Wire* elem_shift = module->addWire(NEW_ID, shamt_w);
+    module->addMul(NEW_ID, pos,
+                   RTLIL::SigSpec(RTLIL::Const(elem_w, shamt_w)), elem_shift, true);
+    RTLIL::Wire* bit_shift = module->addWire(NEW_ID, shamt_w);
+    module->addAdd(NEW_ID, RTLIL::SigSpec(elem_shift),
+                   RTLIL::SigSpec(RTLIL::Const(field_offset, shamt_w)), bit_shift, true);
+
+    auto rhs_e = dynamic_cast<const UHDM::expr*>(rhs_any);
+    if (!rhs_e) return false;
+    int prev_ctx = expression_context_width;
+    expression_context_width = field_width;
+    RTLIL::SigSpec rhs = import_expression(rhs_e, comb_read_map());
+    expression_context_width = prev_ctx;
+    if (rhs.size() < field_width) rhs.extend_u0(field_width, is_expr_signed(rhs_e));
+    else if (rhs.size() > field_width) rhs = rhs.extract(0, field_width);
+
+    std::vector<RTLIL::State> mask_bits(base_w, RTLIL::State::S0);
+    for (int i = 0; i < field_width; i++) mask_bits[i] = RTLIL::State::S1;
+    RTLIL::SigSpec mask_const = RTLIL::SigSpec(RTLIL::Const(mask_bits));
+    RTLIL::SigSpec rhs_wide = rhs;
+    rhs_wide.extend_u0(base_w, false);
+
+    RTLIL::Wire* mask_sh = module->addWire(NEW_ID, base_w);
+    module->addShl(NEW_ID, mask_const, RTLIL::SigSpec(bit_shift), mask_sh, false);
+    RTLIL::Wire* val_sh = module->addWire(NEW_ID, base_w);
+    module->addShl(NEW_ID, rhs_wide, RTLIL::SigSpec(bit_shift), val_sh, false);
+    RTLIL::Wire* inv_mask = module->addWire(NEW_ID, base_w);
+    module->addNot(NEW_ID, RTLIL::SigSpec(mask_sh), inv_mask);
+
+    RTLIL::SigSpec cur = current_comb_values.count(base_name)
+                             ? current_comb_values[base_name]
+                             : RTLIL::SigSpec(base_wire);
+    RTLIL::Wire* cleared = module->addWire(NEW_ID, base_w);
+    module->addAnd(NEW_ID, cur, RTLIL::SigSpec(inv_mask), cleared);
+    RTLIL::Wire* new_full = module->addWire(NEW_ID, base_w);
+    module->addOr(NEW_ID, RTLIL::SigSpec(cleared),
+                  RTLIL::SigSpec(val_sh), new_full);
+
+    if (proc) {
+        emit_comb_assign(RTLIL::SigSpec(base_wire), RTLIL::SigSpec(new_full), proc);
+    } else if (case_rule) {
+        std::string temp_name = "$0\\" + base_name;
+        if (RTLIL::Wire* tw = module->wire(temp_name))
+            case_rule->actions.push_back(
+                RTLIL::SigSig(RTLIL::SigSpec(tw), RTLIL::SigSpec(new_full)));
+        else
+            case_rule->actions.push_back(
+                RTLIL::SigSig(RTLIL::SigSpec(base_wire), RTLIL::SigSpec(new_full)));
+    }
+    if (!in_always_ff_body_mode)
+        current_comb_values[base_name] = RTLIL::SigSpec(new_full);
+    return true;
+}
+
 // Import assignment for comb context (Process* variant)
 void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::Process* proc) {
     // `base[offset +: width] = rhs` with dynamic `offset` — no RTLIL LHS form
@@ -9560,10 +9776,14 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
 
     // `s.field[idx] = rhs` with dynamic `idx` on a packed struct's
     // packed-array field — synthesise mask/shift/or write into `\s`.
+    // `arr[idx].field = rhs` on a flat unpacked struct array — RMW into `\arr`.
     if (auto lhs_e = uhdm_assign->Lhs()) {
         if (lhs_e->VpiType() == vpiHierPath) {
             auto hp = any_cast<const hier_path*>(lhs_e);
             if (emit_dynamic_struct_field_bit_write(
+                    hp, uhdm_assign->Rhs(), proc, nullptr))
+                return;
+            if (emit_dynamic_array_elem_field_write(
                     hp, uhdm_assign->Rhs(), proc, nullptr))
                 return;
         }
@@ -10145,6 +10365,25 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
                                 ff_blocking_temps[bn] = RTLIL::SigSpec(tw);
                     }
                 }
+                // Comb: record each FULL-wire chunk's in-flight value (a
+                // whole-array copy `counter_d = counter_q` lowers to a concat
+                // over element wires) so a later dynamic-index element write's
+                // read-modify-write mux uses the default value instead of the
+                // raw element wire — the raw wire would be a self-hold inside
+                // the write's conditional arm and proc_dlatch would latch
+                // every element (CVA6 perf_counters generic_counter_d).
+                if (!in_always_ff_body_mode) {
+                    int off = 0;
+                    for (const auto& ch : lhs.chunks()) {
+                        if (ch.wire && ch.offset == 0 &&
+                            ch.width == ch.wire->width) {
+                            std::string bn = ch.wire->name.str();
+                            if (!bn.empty() && bn[0] == '\\') bn = bn.substr(1);
+                            current_comb_values[bn] = rhs.extract(off, ch.width);
+                        }
+                        off += ch.width;
+                    }
+                }
                 return;
             }
         }
@@ -10191,6 +10430,9 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
         if (lhs_e->VpiType() == vpiHierPath) {
             auto hp = any_cast<const hier_path*>(lhs_e);
             if (emit_dynamic_struct_field_bit_write(
+                    hp, uhdm_assign->Rhs(), nullptr, case_rule))
+                return;
+            if (emit_dynamic_array_elem_field_write(
                     hp, uhdm_assign->Rhs(), nullptr, case_rule))
                 return;
         }
@@ -11435,6 +11677,23 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                     auto bs = any_cast<const bit_select*>(lhs_e);
                     if (emit_dynamic_unpacked_array_write(
                             bs, assign->Rhs(), nullptr, case_rule))
+                        return;
+                }
+            }
+
+            // `s.field[idx] = rhs` / `arr[idx].field = rhs` hier_path LHS —
+            // same routing as import_assignment_comb; without it the write
+            // falls through to the generic LHS import's READ path and is
+            // dropped (CVA6 cva6_fifo_v3 `mem_n[wptr].valid = …` under
+            // `if (push_i)`).
+            if (auto lhs_e = assign->Lhs()) {
+                if (lhs_e->VpiType() == vpiHierPath) {
+                    auto hp = any_cast<const hier_path*>(lhs_e);
+                    if (emit_dynamic_struct_field_bit_write(
+                            hp, assign->Rhs(), nullptr, case_rule))
+                        return;
+                    if (emit_dynamic_array_elem_field_write(
+                            hp, assign->Rhs(), nullptr, case_rule))
                         return;
                 }
             }

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -207,7 +207,7 @@ void UhdmImporter::extract_lhs_signals(const expr* lhs_expr, std::vector<Assigne
             if (!is_const_idx) {
                 RTLIL::IdString mem_id = RTLIL::escape_id(sig.name);
                 if (!module->memories.count(mem_id) &&
-                    module->wire(RTLIL::escape_id(sig.name + "[0]"))) {
+                    expanded_array_low(sig.name) >= 0) {
                     return;
                 }
             }
@@ -309,6 +309,16 @@ void UhdmImporter::collect_for_loop_var_names(const any* stmt, std::set<std::str
         }
         default: break;
     }
+}
+
+int UhdmImporter::expanded_array_low(const std::string& base_name) {
+    if (base_name.empty() || !module) return -1;
+    for (int probe = 0; probe <= 64; probe++) {
+        std::string en = base_name + "[" + std::to_string(probe) + "]";
+        if (name_map.count(en) || module->wire(RTLIL::escape_id(en)))
+            return probe;
+    }
+    return -1;
 }
 
 int UhdmImporter::const_cond_value(const any* cond) {
@@ -479,9 +489,9 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                         // Expand to per-element so the async-ff temp-wire path
                         // finds them (tcb_dev_gpio_cdc; else "Signal arr not
                         // found in module").  lhs_expr stays the whole-array LHS.
-                        if (!module->wire(RTLIL::escape_id(nm)) &&
-                            module->wire(RTLIL::escape_id(nm + "[0]"))) {
-                            for (int i = 0; module->wire(RTLIL::escape_id(
+                        if (int alow; !module->wire(RTLIL::escape_id(nm)) &&
+                            (alow = expanded_array_low(nm)) >= 0) {
+                            for (int i = alow; module->wire(RTLIL::escape_id(
                                      nm + "[" + std::to_string(i) + "]")); i++) {
                                 AssignedSignal es;
                                 es.name = nm + "[" + std::to_string(i) + "]";
@@ -545,8 +555,7 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                         // (MemorySlice's shift `mem[N-1:1] <= mem[N-2:0]`).
                         bool elem_array_handled = false;
                         if (!sig.name.empty() &&
-                            (name_map.count(sig.name + "[0]") ||
-                             module->wire(RTLIL::escape_id(sig.name + "[0]")))) {
+                            expanded_array_low(sig.name) >= 0) {
                             int el = -1, er = -1;
                             if (auto le = part_sel->Left_range()) {
                                 RTLIL::SigSpec s = import_expression(le);
@@ -636,12 +645,12 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                             if (!is_const_idx) {
                                 RTLIL::IdString mem_id = RTLIL::escape_id(sig.name);
                                 if (!module->memories.count(mem_id) &&
-                                    module->wire(RTLIL::escape_id(sig.name + "[0]"))) {
+                                    expanded_array_low(sig.name) >= 0) {
                                     log("extract_assigned_signals: Skipping dynamic write to expanded array '%s'\n",
                                         sig.name.c_str());
                                     break;
                                 }
-                            } else if (module->wire(RTLIL::escape_id(sig.name + "[0]"))) {
+                            } else if (expanded_array_low(sig.name) >= 0) {
                                 // Constant/genvar bit-select of an UNPACKED array
                                 // (`arr[0] <= ...`): the element is its OWN wire
                                 // \arr[0] — name the signal after it (a full wire),
@@ -787,9 +796,9 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                                 // the async-ff temp-wire path finds them (CVA6
                                 // bht.sv bht_q; else "Signal bht_q not found").
                                 // Mirrors the whole-array ref_obj expansion above.
-                                if (!module->wire(RTLIL::escape_id(base)) &&
-                                    module->wire(RTLIL::escape_id(base + "[0]"))) {
-                                    for (int i = 0; module->wire(RTLIL::escape_id(
+                                if (int blow; !module->wire(RTLIL::escape_id(base)) &&
+                                    (blow = expanded_array_low(base)) >= 0) {
+                                    for (int i = blow; module->wire(RTLIL::escape_id(
                                              base + "[" + std::to_string(i) + "]"));
                                          i++) {
                                         AssignedSignal es;
@@ -1614,9 +1623,9 @@ void UhdmImporter::collect_dynamic_expanded_array_writes(
             }
         }
         if (const_idx) return;
-        // Expanded array, not a real $memory: element wire \base[0] exists.
+        // Expanded array, not a real $memory: a low element wire exists.
         if (!module->memories.count(RTLIL::escape_id(base)) &&
-            module->wire(RTLIL::escape_id(base + "[0]")))
+            expanded_array_low(base) >= 0)
             names.insert(base);
     };
     switch (stmt->VpiType()) {

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -3296,8 +3296,24 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                         if (op->Operands()) for (auto o : *op->Operands()) scan(o);
                     break;
                 case vpiBegin: case vpiNamedBegin:
-                    if (auto b = any_cast<const begin*>(node))
-                        if (b->Stmts()) for (auto s : *b->Stmts()) scan(s);
+                    // begin_block_stmts handles BOTH `begin` and `named_begin`
+                    // (a NAMED block — `begin : read_write_comb` — is a
+                    // different UHDM class; the old any_cast<const begin*>
+                    // returned null for it, so a whole-array assignment
+                    // `mem_n = mem_q` inside a named comb block was never
+                    // flagged and the array collapsed to one element).
+                    if (auto stmts = begin_block_stmts(node))
+                        for (auto s : *stmts) scan(s);
+                    break;
+                case vpiFor:
+                    if (auto f = any_cast<const for_stmt*>(node)) scan(f->VpiStmt());
+                    break;
+                case vpiCase:
+                    if (auto cs = any_cast<const case_stmt*>(node)) {
+                        scan(cs->VpiCondition());
+                        if (cs->Case_items())
+                            for (auto item : *cs->Case_items()) scan(item->Stmt());
+                    }
                     break;
                 case vpiAssignment: case vpiAssignStmt:
                     if (auto a = any_cast<const assignment*>(node)) {
@@ -3414,20 +3430,27 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                             }
                             return dflt;
                         };
+                        int array_low = 0;
                         if (first_range->Left_expr() && first_range->Right_expr()) {
                             int left = eval_bound(first_range->Left_expr(), 3);
                             int right = eval_bound(first_range->Right_expr(), 0);
                             array_size = std::abs(left - right) + 1;
+                            array_low = std::min(left, right);
                         }
-                        
+
                         // Get the packed width from the underlying variable
                         int element_width = 1;
                         if (array_var->Variables() && !array_var->Variables()->empty()) {
                             element_width = get_width(array_var->Variables()->at(0), uhdm_module);
                         }
-                        
-                        // Create individual wires for each array element
-                        for (int i = 0; i < array_size; i++) {
+
+                        // Create individual wires for each array element, named
+                        // by the DECLARED indices — a `[N:1]` array (CVA6
+                        // perf_counters `generic_counter_d[MHPMCounterNum:1]`)
+                        // must materialise `\arr[1..N]`; naming from 0 leaves
+                        // every `arr[i]` access one off (reads X, writes land
+                        // on a stray wire that then latches).
+                        for (int i = array_low; i < array_low + array_size; i++) {
                             std::string element_name = array_name + "[" + std::to_string(i) + "]";
                             RTLIL::IdString wire_id = RTLIL::escape_id(element_name);
                             if (!module->wire(wire_id)) {
@@ -4439,6 +4462,7 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                     
                     // Get the array dimensions
                     int array_size = 4; // Default for cases like M[3:0]
+                    int array_low = 0;
                     if (array->Ranges() && !array->Ranges()->empty()) {
                         auto first_range = (*array->Ranges())[0];
                         // Bounds may be literal constants or expressions
@@ -4455,9 +4479,10 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                             int left = eval_bound(first_range->Left_expr(), 3);
                             int right = eval_bound(first_range->Right_expr(), 0);
                             array_size = std::abs(left - right) + 1;
+                            array_low = std::min(left, right);
                         }
                     }
-                    
+
                     // Get the packed width and signedness from the underlying net
                     int element_width = 1;
                     bool element_signed = false;
@@ -4468,8 +4493,13 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                             element_signed = true;
                     }
 
-                    // Create individual wires for each array element
-                    for (int i = 0; i < array_size; i++) {
+                    // Create individual wires for each array element, named by
+                    // the DECLARED indices — a `[N:1]` array (CVA6
+                    // perf_counters `generic_counter_d[MHPMCounterNum:1]`) must
+                    // materialise `\arr[1..N]`; naming from 0 leaves every
+                    // `arr[i]` access dangling one off (reads X, writes make a
+                    // stray wire that then latches).
+                    for (int i = array_low; i < array_low + array_size; i++) {
                         std::string element_name = array_name + "[" + std::to_string(i) + "]";
                         RTLIL::IdString wire_id = RTLIL::escape_id(element_name);
                         if (!module->wire(wire_id)) {
@@ -4498,17 +4528,20 @@ void UhdmImporter::import_module(const module_inst* uhdm_module) {
                     int array_low = 0;
                     if (array->Ranges() && !array->Ranges()->empty()) {
                         auto first_range = (*array->Ranges())[0];
-                        if (first_range->Left_expr() && first_range->Right_expr() &&
-                            first_range->Left_expr()->VpiType() == vpiConstant &&
-                            first_range->Right_expr()->VpiType() == vpiConstant) {
-                            const constant* lc = any_cast<const constant*>(first_range->Left_expr());
-                            const constant* rc = any_cast<const constant*>(first_range->Right_expr());
-                            RTLIL::Const lv = extract_const_from_value(std::string(lc->VpiValue()));
-                            RTLIL::Const rv = extract_const_from_value(std::string(rc->VpiValue()));
-                            int left = lv.size() > 0 ? lv.as_int() : 0;
-                            int right = rv.size() > 0 ? rv.as_int() : 0;
-                            array_size = std::abs(left - right) + 1;
-                            array_low = std::min(left, right);
+                        // Bounds may be literal constants OR expressions
+                        // (`entry_t mem_q[N]` elaborates to `[0:N-1]` with an
+                        // operation bound) — fold either via import_expression;
+                        // the old literal-only path left array_size = 1 and the
+                        // array collapsed to a single element wire.
+                        if (first_range->Left_expr() && first_range->Right_expr()) {
+                            RTLIL::SigSpec ls = import_expression(first_range->Left_expr());
+                            RTLIL::SigSpec rs = import_expression(first_range->Right_expr());
+                            if (ls.is_fully_const() && rs.is_fully_const()) {
+                                int left = ls.as_int();
+                                int right = rs.as_int();
+                                array_size = std::abs(left - right) + 1;
+                                array_low = std::min(left, right);
+                            }
                         }
                     }
 

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -799,6 +799,13 @@ struct UhdmImporter {
         const UHDM::any* rhs_any,
         RTLIL::Process* proc,
         RTLIL::CaseRule* case_rule);
+    // `arr[idx].field = rhs` (dynamic element index) on an unpacked struct
+    // array represented as a flat wire — full-width mask/shift/or RMW.
+    bool emit_dynamic_array_elem_field_write(
+        const UHDM::hier_path* hp,
+        const UHDM::any* rhs_any,
+        RTLIL::Process* proc,
+        RTLIL::CaseRule* case_rule);
     bool emit_dynamic_unpacked_array_write(
         const UHDM::bit_select* bs,
         const UHDM::any* rhs_any,
@@ -903,6 +910,10 @@ struct UhdmImporter {
     // Evaluate an `if` condition to a compile-time constant WITHOUT creating
     // cells: 0 (false), 1 (true), or -1 (not a resolvable constant).
     int const_cond_value(const UHDM::any* cond);
+    // Lowest declared index of an expanded unpacked array (`\base[k]` element
+    // wires) — usually 0, but a `[N:1]` declaration starts at 1.  -1 when no
+    // element wire exists (not an expanded array).
+    int expanded_array_low(const std::string& base_name);
     void collect_dynamic_expanded_array_writes(const any* stmt, std::set<std::string>& names, RTLIL::Module* module);
     void extract_lhs_signals(const UHDM::expr* lhs_expr, std::vector<AssignedSignal>& signals);
     void extract_assigned_signal_names(const any* stmt, std::set<std::string>& signal_names);

--- a/test/latch_axi_adapter/dut.sv
+++ b/test/latch_axi_adapter/dut.sv
@@ -1,0 +1,38 @@
+// Repro of CVA6 wt_axi_adapter.sv:142 `p_axi_req` spurious latches on
+// IMPORTER-GENERATED wires ($auto$expression.cpp:...:import_expression /
+// import_bit_select): an always_comb writing constant-index elements of small
+// unpacked arrays (`axi_wr_data[0] = {...replication...}`) and reading them
+// back with dynamic indices.  The dynamic/const element access on the LHS must
+// not go through the READ path (a $shiftx output wire) — a read wire that ends
+// up as a process update target self-holds and proc_dlatch latches it.
+// slang: 0 latches.
+module latch_axi_adapter #(
+    parameter int unsigned W = 32,
+    parameter int unsigned N = 2
+) (
+    input  logic [W-1:0] data_i,
+    input  logic [W-1:0] user_i,
+    input  logic         sel_i,
+    input  logic [0:0]   idx_i,
+    output logic [W-1:0] wdata_o,
+    output logic [W-1:0] wuser_o
+);
+  logic [W-1:0] wr_data[N];
+  logic [W-1:0] wr_user[N];
+
+  always_comb begin : p_axi_req
+    wr_data[0] = {2{data_i[W/2-1:0]}};
+    wr_user[0] = user_i;
+    wr_data[1] = '0;
+    wr_user[1] = '0;
+
+    if (sel_i) begin
+      wr_user[0] = {user_i[W/2-1:0], {W / 2{1'b0}}};
+    end else begin
+      wr_user[0] = {{W / 2{1'b0}}, user_i[W-1:W/2]};
+    end
+
+    wdata_o = wr_data[idx_i];
+    wuser_o = wr_user[idx_i];
+  end
+endmodule

--- a/test/latch_axi_adapter/test_slang_equiv.ys
+++ b/test/latch_axi_adapter/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for latch_axi_adapter.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top latch_axi_adapter
+flatten; proc; opt -fast
+rename latch_axi_adapter gold
+design -stash gold
+
+read_slang dut.sv --top latch_axi_adapter
+hierarchy -check -top latch_axi_adapter
+flatten; proc; opt -fast
+rename latch_axi_adapter gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/latch_csr_armlocal/dut.sv
+++ b/test/latch_csr_armlocal/dut.sv
@@ -1,0 +1,36 @@
+// Repro of CVA6 csr_regfile.sv:968 arm-local latches (`index`, `DirVecOnly`,
+// `$unnamed_block$N.index`): a block-local variable DECLARED INSIDE A CASE ARM
+// and unconditionally assigned there before use.  Promoted to a module-level
+// wire, it is written only when its arm is selected -> self-hold default
+// survives on every other arm -> spurious latch (slang SSAs arm-locals; the
+// variable is never read outside its arm, so the latch is dead but noisy).
+module latch_csr_armlocal (
+    input  logic [1:0]  addr_i,
+    input  logic [11:0] waddr_i,
+    input  logic [63:0] wdata_i,
+    input  logic        dirveconly_cfg_i,
+    output logic [63:0] r_o
+);
+  always_comb begin : csr_update
+    r_o = '0;
+    unique case (addr_i)
+      2'd0: begin
+        automatic logic [3:0] index;
+        index = waddr_i[3:0] - 4'd2;
+        r_o   = wdata_i >> index;
+      end
+      2'd1: begin
+        automatic logic [11:0] index;
+        index = waddr_i - 12'd16;
+        r_o   = wdata_i << index[3:0];
+      end
+      2'd2: begin
+        logic DirVecOnly;
+        DirVecOnly = dirveconly_cfg_i ? 1'b0 : wdata_i[0];
+        r_o = {wdata_i[63:2], 1'b0, DirVecOnly};
+        if (DirVecOnly) r_o = {wdata_i[63:8], 7'b0, DirVecOnly};
+      end
+      default: r_o = wdata_i;
+    endcase
+  end
+endmodule

--- a/test/latch_csr_armlocal/test_slang_equiv.ys
+++ b/test/latch_csr_armlocal/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for latch_csr_armlocal.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top latch_csr_armlocal
+flatten; proc; opt -fast
+rename latch_csr_armlocal gold
+design -stash gold
+
+read_slang dut.sv --top latch_csr_armlocal
+hierarchy -check -top latch_csr_armlocal
+flatten; proc; opt -fast
+rename latch_csr_armlocal gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/latch_decoder_partial/dut.sv
+++ b/test/latch_decoder_partial/dut.sv
@@ -1,0 +1,71 @@
+// Repro of CVA6 decoder.sv:1840 `exception_handling` spurious latches on
+// SLICES of a struct output: the block writes SOME fields live
+// (`instruction_o.ex = ex_i;`) and OTHER fields only under compile-time-false
+// guards (`if (Cfg.RVH) instruction_o.ex.tval2 = ...`).  The per-bit
+// written-bits map / temp coverage must include LIVE writes only — bits from
+// dead-guarded field writes otherwise get an STa update whose only driver is
+// the self-hold default, and proc_dlatch latches those slices (slang: 0).
+package ldp_cfg_pkg;
+  typedef struct packed {
+    logic [31:0] XLEN;
+    logic        RVH;
+    logic        TvalEn;
+  } cfg_t;
+  localparam cfg_t CfgEmpty = cfg_t'(0);
+  function automatic cfg_t build_config();
+    cfg_t c;
+    c.XLEN   = 64;
+    c.RVH    = 1'b0;
+    c.TvalEn = 1'b1;
+    return c;
+  endfunction
+  localparam cfg_t CfgDefault = build_config();
+endpackage
+
+module ldp_leaf #(
+    parameter ldp_cfg_pkg::cfg_t Cfg = ldp_cfg_pkg::CfgEmpty
+) (
+    input  logic [63:0] cause_i,
+    input  logic [63:0] tval_i,
+    input  logic [63:0] tval2_i,
+    input  logic        valid_i,
+    input  logic        take_i,
+    output logic [255:0] instr_o
+);
+  typedef struct packed {
+    logic [63:0] cause;
+    logic [63:0] tval;
+    logic [63:0] tval2;   // RVH-only field
+    logic [62:0] tinst;   // RVH-only field
+    logic        valid;
+  } ex_t;
+
+  ex_t ex_d;
+
+  always_comb begin : exception_handling
+    ex_d.cause = cause_i;
+    ex_d.valid = valid_i;
+    if (Cfg.TvalEn) ex_d.tval = tval_i;
+    else ex_d.tval = '0;
+    if (Cfg.RVH) begin
+      ex_d.tval2 = tval2_i;      // DEAD: RVH == 0
+      ex_d.tinst = tval2_i[62:0];
+    end
+    if (take_i) begin
+      ex_d.cause = cause_i ^ 64'h8000000000000000;
+    end
+  end
+
+  assign instr_o = {ex_d};
+endmodule
+
+module latch_decoder_partial (
+    input  logic [63:0] cause_i,
+    input  logic [63:0] tval_i,
+    input  logic [63:0] tval2_i,
+    input  logic        valid_i,
+    input  logic        take_i,
+    output logic [255:0] instr_o
+);
+  ldp_leaf #(.Cfg(ldp_cfg_pkg::CfgDefault)) u_leaf (.*);
+endmodule

--- a/test/latch_decoder_partial/test_slang_equiv.ys
+++ b/test/latch_decoder_partial/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for latch_decoder_partial.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top latch_decoder_partial
+flatten; proc; opt -fast
+rename latch_decoder_partial gold
+design -stash gold
+
+read_slang dut.sv --top latch_decoder_partial
+hierarchy -check -top latch_decoder_partial
+flatten; proc; opt -fast
+rename latch_decoder_partial gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/latch_fifo_dynfield/dut.sv
+++ b/test/latch_fifo_dynfield/dut.sv
@@ -1,0 +1,54 @@
+// Repro of CVA6 cva6_fifo_v3.sv:75 / lsu_bypass.sv:67 / load_unit.sv:155
+// spurious latches on importer-generated $auto$...import_bit_select wires: a
+// DYNAMIC-index element (or element-field) write into a small unpacked array
+// (`mem_n[write_pointer_q] = data_i;`,
+// `mem_n[read_pointer_q].valid = 1'b0;`) inside an always_comb with a
+// whole-array default.  The dynamic LHS must go through the masked-write
+// path, not the READ path — a $shiftx read-output wire that ends up as a
+// process update target self-holds and latches (slang: 0 latches).
+module latch_fifo_dynfield #(
+    parameter int unsigned N = 4,
+    parameter int unsigned W = 8
+) (
+    input  logic [W-1:0]         data_i,
+    input  logic [1:0]           wptr_i,
+    input  logic [1:0]           rptr_i,
+    input  logic                 push_i,
+    input  logic                 pop_i,
+    output logic [N-1:0][W-1:0]  mem_o,
+    output logic [N-1:0]         valid_o
+);
+  typedef struct packed {
+    logic [W-1:0] data;
+    logic         valid;
+  } entry_t;
+
+  entry_t mem_q[N];
+  entry_t mem_n[N];
+
+  // feedback-free "registers" for a purely combinational miter
+  always_comb begin
+    for (int unsigned k = 0; k < N; k++) begin
+      mem_q[k].data  = data_i ^ W'(k);
+      mem_q[k].valid = pop_i;
+    end
+  end
+
+  always_comb begin : read_write_comb
+    mem_n = mem_q;
+    if (push_i) begin
+      mem_n[wptr_i].data  = data_i;
+      mem_n[wptr_i].valid = 1'b1;
+    end
+    if (pop_i) begin
+      mem_n[rptr_i].valid = 1'b0;
+    end
+  end
+
+  always_comb begin
+    for (int unsigned k = 0; k < N; k++) begin
+      mem_o[k]   = mem_n[k].data;
+      valid_o[k] = mem_n[k].valid;
+    end
+  end
+endmodule

--- a/test/latch_fifo_dynfield/test_slang_equiv.ys
+++ b/test/latch_fifo_dynfield/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for latch_fifo_dynfield.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top latch_fifo_dynfield
+flatten; proc; opt -fast
+rename latch_fifo_dynfield gold
+design -stash gold
+
+read_slang dut.sv --top latch_fifo_dynfield
+hierarchy -check -top latch_fifo_dynfield
+flatten; proc; opt -fast
+rename latch_fifo_dynfield gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/latch_perf_counters/dut.sv
+++ b/test/latch_perf_counters/dut.sv
@@ -1,0 +1,50 @@
+// Repro of CVA6 perf_counters.sv:141 `generic_counter` spurious per-element
+// latches: an unpacked array with a WHOLE-ARRAY default at the top of the
+// always_comb (`generic_counter_d = generic_counter_q;`) followed by
+// per-element writes from an unrolled for loop under runtime guards, plus a
+// dynamic-index read.  The whole-array default must reach every per-element
+// `$0\arr[k]` temp unconditionally — otherwise proc_dlatch infers a latch per
+// element (slang: 0 latches; CVA6 shows generic_counter_d[0..5] and
+// mhpmevent_d[0..5]).  Also models store_buffer.sv:161 commit_queue_n[0..3].
+module latch_perf_counters #(
+    parameter int unsigned N = 4
+) (
+    input  logic [63:0]      inc_i,
+    input  logic [N-1:0]     ev_i,
+    input  logic             we_i,
+    input  logic [2:0]       addr_i,
+    input  logic [63:0]      wdata_i,
+    output logic [63:0]      data_o,
+    output logic [63:0]      cnt_o
+);
+  logic [63:0] counter_d[N:1], counter_q[N:1];
+  logic clk_i = 1'b0;  // keep the test purely combinational via feedback regs
+
+  // simple registers so counter_q has drivers (comb-only miter still works)
+  always_comb begin
+    for (int unsigned k = 1; k <= N; k++) counter_q[k] = {16'h0, inc_i[47:0]} + 64'(k);
+  end
+
+  always_comb begin : generic_counter
+    counter_d = counter_q;
+    data_o    = 'b0;
+
+    for (int unsigned i = 1; i <= N; i++) begin
+      if (!we_i) begin
+        if (ev_i[i-1]) begin
+          counter_d[i] = counter_q[i] + 1'b1;
+        end
+      end
+    end
+
+    if (addr_i >= 3'd1 && addr_i <= 3'(N)) begin
+      data_o = counter_q[addr_i];
+    end
+
+    if (we_i && addr_i >= 3'd1 && addr_i <= 3'(N)) begin
+      counter_d[addr_i] = wdata_i;
+    end
+  end
+
+  assign cnt_o = counter_d[1] ^ counter_d[2] ^ counter_d[3] ^ counter_d[4];
+endmodule

--- a/test/latch_perf_counters/test_slang_equiv.ys
+++ b/test/latch_perf_counters/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for latch_perf_counters.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top latch_perf_counters
+flatten; proc; opt -fast
+rename latch_perf_counters gold
+design -stash gold
+
+read_slang dut.sv --top latch_perf_counters
+hierarchy -check -top latch_perf_counters
+flatten; proc; opt -fast
+rename latch_perf_counters gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/latch_tlb_napot/dut.sv
+++ b/test/latch_tlb_napot/dut.sv
@@ -1,0 +1,77 @@
+// Repro of CVA6 cva6_tlb.sv:298/:184 napot-guard latches: block temps
+// (temp_stored_vpn / flush_vpn_masked / stored_vpn_masked / patched_pte)
+// assigned ONLY under `if (runtime_bit && Cfg.SvnapotEn)` with SvnapotEn == 0.
+// The && guard mixes a RUNTIME first operand with a compile-time-FALSE struct
+// param field: const_cond_value must short-circuit on the constant 0 so the
+// dead-guard prune drops the temps (slang: 0 latches).  The struct-param field
+// (not a plain parameter) is the essential CVA6 ingredient.
+package ltn_cfg_pkg;
+  typedef struct packed {
+    logic [31:0] VpnLen;
+    logic        SvnapotEn;
+    logic        RVH;
+  } cfg_t;
+  localparam cfg_t CfgEmpty = cfg_t'(0);
+  function automatic cfg_t build_config();
+    cfg_t c;
+    c.VpnLen    = 27;
+    c.SvnapotEn = 1'b0;
+    c.RVH       = 1'b0;
+    return c;
+  endfunction
+  localparam cfg_t CfgDefault = build_config();
+endpackage
+
+module ltn_leaf #(
+    parameter ltn_cfg_pkg::cfg_t Cfg = ltn_cfg_pkg::CfgEmpty
+) (
+    input  logic [3:0]  napot_i,
+    input  logic [26:0] vpn0_i,
+    input  logic [26:0] vpn1_i,
+    input  logic [26:0] flush_vaddr_i,
+    input  logic [63:0] pte_i,
+    output logic [3:0]  match_o,
+    output logic [63:0] content_o
+);
+  logic [26:0] temp_stored_vpn;
+  logic [26:0] flush_vpn_masked;
+  logic [26:0] stored_vpn_masked;
+  logic        napot_match;
+  logic [63:0] patched_pte;
+
+  always_comb begin : translation
+    match_o   = '0;
+    content_o = '0;
+    for (int unsigned i = 0; i < 4; i++) begin
+      if (napot_i[i] && Cfg.SvnapotEn) begin
+        temp_stored_vpn   = vpn0_i;
+        flush_vpn_masked  = flush_vaddr_i & ~27'hF;
+        stored_vpn_masked = temp_stored_vpn & ~27'hF;
+        napot_match       = (flush_vpn_masked == stored_vpn_masked);
+      end else begin
+        napot_match = 1'b0;
+      end
+      match_o[i] = napot_match | vpn1_i[i];
+
+      if (napot_i[i] && Cfg.SvnapotEn) begin
+        patched_pte      = pte_i;
+        patched_pte[3:0] = flush_vaddr_i[3:0];
+        content_o        = patched_pte;
+      end else begin
+        content_o = pte_i ^ 64'(i);
+      end
+    end
+  end
+endmodule
+
+module latch_tlb_napot (
+    input  logic [3:0]  napot_i,
+    input  logic [26:0] vpn0_i,
+    input  logic [26:0] vpn1_i,
+    input  logic [26:0] flush_vaddr_i,
+    input  logic [63:0] pte_i,
+    output logic [3:0]  match_o,
+    output logic [63:0] content_o
+);
+  ltn_leaf #(.Cfg(ltn_cfg_pkg::CfgDefault)) u_leaf (.*);
+endmodule

--- a/test/latch_tlb_napot/test_slang_equiv.ys
+++ b/test/latch_tlb_napot/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for latch_tlb_napot.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top latch_tlb_napot
+flatten; proc; opt -fast
+rename latch_tlb_napot gold
+design -stash gold
+
+read_slang dut.sv --top latch_tlb_napot
+hierarchy -check -top latch_tlb_napot
+flatten; proc; opt -fast
+rename latch_tlb_napot gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter


### PR DESCRIPTION
## Summary

Continues the CVA6 latch-parity work (#579) with per-module triage of the remaining 79 latches against the read_slang reference (slang: **0 latches** design-wide). One repro test per failing module, each adjudicated by a **UHDM-vs-slang SAT miter** (read_verilog cannot parse most of the shapes). **Three real correctness bugs** found and fixed — two of the six repros initially FAILED their miter, i.e. wrong netlists, not just latch noise.

CVA6 `proc_dlatch` latches: **79 → 63** (perf_counters ×12 and store_buffer ×4 classes fully cleared).

### Real bugs fixed
1. **Struct-array whole-copy collapsed/dropped** (`latch_fifo_dynfield`): the whole-array-access pre-scan missed `mem_n = mem_q` inside **named** begin blocks (`any_cast<const begin*>` is null for `named_begin`), and the fallback materialization required literal range bounds so `entry_t mem_q[N]` collapsed to one element.
2. **Dynamic element-field writes dropped**: `mem_n[wptr_i].valid = 1'b1` fell through to the hier_path *read* path and emitted nothing. New `emit_dynamic_array_elem_field_write` (mask/shift/or RMW on the flat array wire), hooked in both `import_assignment_comb` variants **and** the CaseRule inline assignment handler (if-arm assignments bypass `import_assignment_comb`).
3. **`[N:1]` unpacked arrays off-by-one** (`latch_perf_counters`): element wires were named `[0..N-1]` ignoring the declared low bound (CVA6 `generic_counter_d[MHPMCounterNum:1]`) — every access dangled. New `expanded_array_low()` helper; fixed materialization, the dynamic read mux chain, the whole-array concat, and the dynamic write path.
4. **Self-hold in dynamic RMW**: the whole-array copy lowers to one concat action that never recorded per-element in-flight values, so the RMW mux read the raw element wire (self-hold → per-element latches). Both concat-LHS emit paths now record per-element values.

### Tests
6 new repros (`test/latch_*`), all proving UHDM == slang by SAT miter. `latch_csr_armlocal` keeps 2 *cosmetic dead* latches (case-arm locals; slang SSAs them) — functionally proven equal, tracked for a later pass.

### Validation
Full sweep: 808/814 functional, same 6 expected Induct-Formal failures, co-sim warning set = baseline **minus one** (`comb_array_next_state`'s pre-existing warning disappeared with the array fixes).

### Remaining (tracked)
decoder:1840 instruction_o slices (9), wt_axi_adapter importer temps (10), tlb napot (10, may be legit runtime-incomplete), csr arm-locals (9, cosmetic), fifo `data_ft_n` + mmu `final_fetch_ppn` (7, legit runtime-incomplete — slang's X-default is the outlier), import_bit_select temps (11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)