### PR TITLE
test: size-align latch_packed_dyn_write's dynamic +: offsets (fix Miter-Formal)

### DIFF
--- a/test/latch_packed_dyn_write/dut.sv
+++ b/test/latch_packed_dyn_write/dut.sv
@@ -35,11 +35,16 @@ module latch_packed_dyn_write #(
       mem_n[wptr_i] = data_i;
     end
 
+    // Size-aligned dynamic bit offsets, like wt_axi_adapter's byte enables.
+    // The +: base MUST stay in range: for a partially out-of-range packed
+    // part-select write, UHDM and slang clamp to the element (LRM 11.5.1)
+    // while read_verilog / Verilator / iverilog spill into the flat vector —
+    // OOB stimulus makes the miter fail on a tool divergence, not a bug.
     wr_be = '0;
     unique case (size_i)
       2'b00:   wr_be[0][bit_i] = 1'b1;
-      2'b01:   wr_be[0][bit_i+:2] = '1;
-      2'b10:   wr_be[0][bit_i+:4] = '1;
+      2'b01:   wr_be[0][{bit_i[2:1], 1'b0}+:2] = '1;
+      2'b10:   wr_be[0][{bit_i[2], 2'b00}+:4] = '1;
       default: wr_be[0] = '1;
     endcase
   end

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -670,14 +670,15 @@ Test: rp32_r5p_mouse
     (see sim_equiv_classification.txt) and is tracked in failing_tests.txt.
 
 Test: latch_packed_dyn_write
-    Verilator-vs-LRM divergence on an out-of-range indexed part-select
-    WRITE within a packed-array element: `wr_be[0][bit_i+:2] = '1` with
-    bit_i == 7 addresses bits [8:7] of the 8-bit element wr_be[0].  Per
-    IEEE 1800 11.5.1 the write to the non-existent bit 8 is IGNORED —
-    read_slang and the UHDM frontend both truncate at the element
-    boundary (UHDM == slang PROVEN by the SAT miter in
-    test_slang_equiv.ys), while Verilator flattens the select and spills
-    the write into bit 0 of the NEXT element (rtl=0x180 vs nl=0x80).
-    CONFIRMED ARTIFACT (Verilator semantics deviation, not a frontend
-    bug).  The real CVA6 usage (wt_axi_adapter byte enables) never
-    overruns because addresses are size-aligned.
+    RESOLVED — the DUT's `+:` bit offsets are now size-aligned (like the
+    real CVA6 wt_axi_adapter byte enables), so no select overruns its
+    packed-array element and the co-sim, equiv_induct, UHDM-vs-Verilog
+    miter AND UHDM-vs-slang miter all pass.  The original entry
+    documented an out-of-range `wr_be[0][7+:2] = '1` where the LRM
+    (11.5.1) ignores the write to the non-existent bit — UHDM and slang
+    clamp at the element boundary, while Verilator, iverilog AND
+    read_verilog all flatten the select and spill into the next element,
+    so the UHDM-vs-Verilog Miter-Formal check failed on stimulus no real
+    design produces.  Kept as a note: out-of-range dynamic packed-element
+    part-select writes are implementation-divergent territory — keep
+    repro stimulus in range.


### PR DESCRIPTION
## Summary

Fixes the `latch_packed_dyn_write` Miter-Formal failure from PR #582's CI run. The frontend was correct — the repro's stimulus was out of range.

The test drove `wr_be[0][bit_i+:2/4] = '1` with `bit_i` up to 7, overrunning the 8-bit packed-array element. Out-of-range packed-element part-select **writes** are implementation-divergent:

- **UHDM frontend + slang**: clamp at the element boundary (IEEE 1800 §11.5.1 — writes to non-existent bits are ignored)
- **yosys read_verilog + Verilator + iverilog**: flatten the select and spill into the next element

So the sound UHDM-vs-Verilog miter could never pass on OOB stimulus even with a correct frontend. This PR size-aligns the dynamic bit offsets exactly like the real CVA6 `wt_axi_adapter` byte enables (`{bit_i[2:1],1'b0}+:2`, `{bit_i[2],2'b0}+:4`), keeping the selects dynamic while staying in range.

## Verification

- Verilator co-sim: PASS, 200 cycles, 0 mismatches, full output activity
- equiv_induct: PASS
- SAT-from-reset miter UHDM vs Verilog: EQUIVALENT
- SAT miter UHDM vs slang (`test_slang_equiv.ys`): SUCCESS
- `sim_equiv_analyzed.txt` entry rewritten as RESOLVED, with the tool divergence kept as a note for future repros

🤖 Generated with [Claude Code](https://claude.com/claude-code)