### PR TITLE
uhdm: struct-member packed-dim geometry + internal-cell-type instantiation (CI triage)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7716,9 +7716,17 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 // 4) indexes the part-select in ELEMENT units, so scale the
                 // offset/width by the element width and by the array's declared
                 // low bound.  A plain vector member (`logic [2:0] fn3`) has no
-                // Elem_typespec → element width 1 (plain bit indices), which
-                // reduces to the previous behaviour.
-                int elem_w = 1, decl_low = 0;
+                // inner dimensions → element width 1 (plain bit indices), which
+                // reduces to the previous behaviour.  The member's packed dims
+                // come in three shapes: multi-range (`bit [5:0][7:0]` — logic OR
+                // bit typespec), Elem_typespec (`logic4 [2:0]`), or a
+                // packed_array_typespec (`bit3l_t [0:7][1:0]`) — element width =
+                // product of the inner ranges times the Elem_typespec width.
+                // An ASCENDING outer range (`bit [0:7][7:0]`) puts the LEFT
+                // index at the MSB, so the bit offset counts down from the
+                // declared high index instead of up from the low one.
+                int elem_w = 1, decl_low = 0, decl_high = 0;
+                bool decl_asc = false;
                 if (ats->UhdmType() == uhdmstruct_typespec) {
                     auto st = any_cast<const UHDM::struct_typespec*>(ats);
                     if (st->Members())
@@ -7726,19 +7734,51 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                             if (std::string(m->VpiName()) != field) continue;
                             const UHDM::typespec* mat = nullptr;
                             if (auto mts = m->Typespec()) mat = mts->Actual_typespec();
-                            if (mat && mat->UhdmType() == uhdmlogic_typespec) {
-                                auto lt = any_cast<const UHDM::logic_typespec*>(mat);
-                                if (lt->Ranges() && !lt->Ranges()->empty()) {
-                                    auto r0 = (*lt->Ranges())[0];
-                                    RTLIL::SigSpec rl = import_expression(r0->Left_expr(), input_mapping);
-                                    RTLIL::SigSpec rr = import_expression(r0->Right_expr(), input_mapping);
-                                    if (rl.is_fully_const() && rr.is_fully_const())
-                                        decl_low = std::min(rl.as_const().as_int(),
-                                                            rr.as_const().as_int());
+                            const UHDM::VectorOfrange* mranges = nullptr;
+                            const UHDM::ref_typespec* elem_rts = nullptr;
+                            if (mat) {
+                                if (auto lt = dynamic_cast<const UHDM::logic_typespec*>(mat)) {
+                                    mranges = lt->Ranges();
+                                    elem_rts = lt->Elem_typespec();
+                                } else if (auto bt = dynamic_cast<const UHDM::bit_typespec*>(mat)) {
+                                    mranges = bt->Ranges();
+                                } else if (auto pt = dynamic_cast<const UHDM::packed_array_typespec*>(mat)) {
+                                    mranges = pt->Ranges();
+                                    elem_rts = pt->Elem_typespec();
+                                } else if (auto at = dynamic_cast<const UHDM::array_typespec*>(mat)) {
+                                    // Unpacked array member inside a packed
+                                    // struct (`bit [7:0] a [7:0]`) — Yosys
+                                    // packs it, indexed like a packed dim.
+                                    mranges = at->Ranges();
+                                    elem_rts = at->Elem_typespec();
                                 }
-                                if (lt->Elem_typespec() && lt->Elem_typespec()->Actual_typespec())
-                                    elem_w = get_width_from_typespec(
-                                        lt->Elem_typespec()->Actual_typespec(), inst);
+                            }
+                            if (mranges && !mranges->empty()) {
+                                auto r0 = (*mranges)[0];
+                                RTLIL::SigSpec rl = import_expression(r0->Left_expr(), input_mapping);
+                                RTLIL::SigSpec rr = import_expression(r0->Right_expr(), input_mapping);
+                                if (rl.is_fully_const() && rr.is_fully_const()) {
+                                    int rli = rl.as_const().as_int();
+                                    int rri = rr.as_const().as_int();
+                                    decl_low = std::min(rli, rri);
+                                    decl_high = std::max(rli, rri);
+                                    decl_asc = rli < rri;
+                                }
+                                int inner_w = 1;
+                                for (size_t ri = 1; ri < mranges->size(); ri++) {
+                                    auto rn = (*mranges)[ri];
+                                    RTLIL::SigSpec il = import_expression(rn->Left_expr(), input_mapping);
+                                    RTLIL::SigSpec ir = import_expression(rn->Right_expr(), input_mapping);
+                                    if (il.is_fully_const() && ir.is_fully_const())
+                                        inner_w *= std::abs(il.as_const().as_int() -
+                                                            ir.as_const().as_int()) + 1;
+                                }
+                                elem_w = inner_w;
+                                if (elem_rts && elem_rts->Actual_typespec()) {
+                                    int ew = get_width_from_typespec(
+                                        elem_rts->Actual_typespec(), inst);
+                                    if (ew > 0) elem_w *= ew;
+                                }
                             }
                             break;
                         }
@@ -7747,8 +7787,10 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 if (okoff &&
                     w > 0 && ls.is_fully_const() && rs.is_fully_const()) {
                     int l = ls.as_const().as_int(), r = rs.as_const().as_int();
-                    int lo = std::min(l, r), cnt = std::abs(l - r) + 1;
-                    int bit_lo = (lo - decl_low) * elem_w, sw = cnt * elem_w;
+                    int lo = std::min(l, r), hi = std::max(l, r), cnt = hi - lo + 1;
+                    int bit_lo = decl_asc ? (decl_high - hi) * elem_w
+                                          : (lo - decl_low) * elem_w;
+                    int sw = cnt * elem_w;
                     if (bit_lo >= 0 && bit_lo + sw <= w &&
                         off + bit_lo + sw <= base_wire->width) {
                         log("    hier_path: packed-struct %s.%s[%d:%d] (elem_w=%d) -> %s[%d+:%d]\n",

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1852,7 +1852,47 @@ void UhdmImporter::import_instance(const module_inst* uhdm_inst) {
     if (base_module_name.find("work@") == 0) {
         base_module_name = base_module_name.substr(5);
     }
-    
+
+    // Direct instantiation of a Yosys internal cell type (escaped `\$lcu`,
+    // `\$add`, … module names in the source — yosys tests
+    // techmap/lcu_refined.v).  read_verilog emits a cell of the PUBLIC type
+    // `\$lcu` with the parameters on the cell and named connections, mapped
+    // later by `techmap`; deriving a $paramod module here instead produces an
+    // unknown internal-style cell type that write_rtlil's checker rejects.
+    if (!base_module_name.empty() && base_module_name[0] == '$') {
+        RTLIL::Cell* cell = module->addCell(new_id(inst_name),
+                                            RTLIL::escape_id(base_module_name));
+        add_src_attribute(cell->attributes, uhdm_inst);
+        cell->set_bool_attribute(ID::module_not_derived);
+        if (uhdm_inst->Param_assigns()) {
+            for (auto pa : *uhdm_inst->Param_assigns()) {
+                auto lhs = pa->Lhs();
+                if (!lhs || !pa->Rhs()) continue;
+                RTLIL::SigSpec v =
+                    import_expression(dynamic_cast<const expr*>(pa->Rhs()));
+                if (!v.empty() && v.is_fully_const()) {
+                    RTLIL::Const pc = v.as_const();
+                    pc.flags |= RTLIL::CONST_FLAG_SIGNED;
+                    cell->setParam(
+                        RTLIL::escape_id(std::string(lhs->VpiName())), pc);
+                }
+            }
+        }
+        if (uhdm_inst->Ports()) {
+            for (auto p : *uhdm_inst->Ports()) {
+                std::string pname = std::string(p->VpiName());
+                if (pname.empty()) continue;
+                RTLIL::SigSpec conn;
+                if (auto hc = p->High_conn())
+                    conn = import_expression(dynamic_cast<const expr*>(hc));
+                cell->setPort(RTLIL::escape_id(pname), conn);
+            }
+        }
+        log("UHDM: Created internal-cell-type instance '%s' of '%s'\n",
+            inst_name.c_str(), base_module_name.c_str());
+        return;
+    }
+
     // Build parameterized module name using VpiValue format (matching import_module naming)
     std::string module_name = base_module_name;
     bool has_params = false;

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -2018,7 +2018,75 @@ void UhdmImporter::import_module_hierarchy(const module_inst* uhdm_module, bool 
             if (parent_rtlil_module) {
                 // Create the cell in the parent module
                 std::string inst_name = std::string(uhdm_module->VpiName());
-                
+
+                // Direct instantiation of a Yosys internal cell type (escaped
+                // `\$lcu`, `\$add`, … module names in the source — yosys tests
+                // techmap/lcu_refined.v; Surelog scopes the def as
+                // "parent::$lcu").  read_verilog emits a cell of the PUBLIC
+                // type `\$lcu` with the parameters on the cell and NAMED
+                // connections, mapped later by `techmap`; deriving a $paramod
+                // module here instead produces an unknown internal-style cell
+                // type that write_rtlil's checker rejects (and the
+                // undefined-cell heuristic below would rewrite the named
+                // connections to positional `$1..$N`).
+                std::string def_base = module_name;
+                {
+                    size_t ns_pos = def_base.rfind("::");
+                    if (ns_pos != std::string::npos)
+                        def_base = def_base.substr(ns_pos + 2);
+                }
+                if (!def_base.empty() && def_base[0] == '$') {
+                    RTLIL::IdString icell_id = RTLIL::escape_id(inst_name);
+                    if (!parent_rtlil_module->cell(icell_id)) {
+                        RTLIL::Module* saved_module = this->module;
+                        auto saved_name_map = this->name_map;
+                        auto saved_wire_map = this->wire_map;
+                        this->module = parent_rtlil_module;
+                        this->name_map.clear();
+                        for (auto &wp : parent_rtlil_module->wires_) {
+                            std::string wn = wp.first.str();
+                            if (wn[0] == '\\') wn = wn.substr(1);
+                            this->name_map[wn] = wp.second;
+                        }
+                        RTLIL::Cell* cell = parent_rtlil_module->addCell(
+                            icell_id, RTLIL::escape_id(def_base));
+                        add_src_attribute(cell->attributes, uhdm_module);
+                        cell->set_bool_attribute(ID::module_not_derived);
+                        if (uhdm_module->Param_assigns()) {
+                            for (auto pa : *uhdm_module->Param_assigns()) {
+                                if (!pa->Lhs() || !pa->Rhs()) continue;
+                                RTLIL::SigSpec v = import_expression(
+                                    any_cast<const expr*>(pa->Rhs()));
+                                if (!v.empty() && v.is_fully_const()) {
+                                    RTLIL::Const pc = v.as_const();
+                                    pc.flags |= RTLIL::CONST_FLAG_SIGNED;
+                                    cell->setParam(
+                                        RTLIL::escape_id(
+                                            std::string(pa->Lhs()->VpiName())),
+                                        pc);
+                                }
+                            }
+                        }
+                        if (uhdm_module->Ports()) {
+                            for (auto port : *uhdm_module->Ports()) {
+                                std::string port_name =
+                                    std::string(port->VpiName());
+                                if (port_name.empty() || !port->High_conn())
+                                    continue;
+                                RTLIL::SigSpec conn = import_expression(
+                                    any_cast<const expr*>(port->High_conn()));
+                                cell->setPort(RTLIL::escape_id(port_name), conn);
+                            }
+                        }
+                        log("UHDM: Created internal-cell-type instance '%s' of '%s'\n",
+                            inst_name.c_str(), def_base.c_str());
+                        this->module = saved_module;
+                        this->name_map = saved_name_map;
+                        this->wire_map = saved_wire_map;
+                    }
+                    return;
+                }
+
                 // Generate parameterized module name
                 std::string cell_type = module_name;
                 // A `parameter type` instance is imported under a uniquified

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -68,20 +68,8 @@ arch/nanoxplore/meminit.v
 # not meaningful under read_uhdm -> synth -> equiv.
 verilog/mem_bounds.sv
 
-# --- equiv_induct inductively incomplete (UHDM proven equivalent otherwise) ---
-# Not UHDM bugs: the UHDM netlist is functionally equal to the Verilog frontend's,
-# but the harness's equiv_induct can't close the proof.
-#   sat/alu        - the flat equiv_induct AND the sound SAT-from-reset miter both
-#                    prove UHDM == Verilog; only the harness's write_verilog
-#                    round-trip equiv flow fails to converge.
-#   sat/ram_memory - a 4096x8 RAM with an `initial` individual-element ROM init.
-#                    The ROM init (`store[i] <= const`) is now emitted as $meminit
-#                    and a directed sim matches the Verilog frontend exactly
-#                    (store[2]=0x54, store[258]=0x7e, write/read OK); equiv_induct
-#                    is impractical once the 4096-entry memory is mapped to ~32k
-#                    FFs.  (was a real bug: the init was missing entirely — fixed.)
-sat/alu.v
-sat/ram_memory.v
+# (sat/alu / sat/ram_memory removed: both now pass the harness end-to-end —
+# the earlier equiv_induct-convergence limitation no longer reproduces.)
 
 # --- techmap rule files (not standalone DUTs, not a UHDM feature gap) ---
 # These define techmap MAPPING RULES, not synthesizable top designs: they use
@@ -98,8 +86,10 @@ arch/fabulous/arith_map.v
 arch/fabulous/ff_map.v
 arch/fabulous/io_map.v
 arch/fabulous/regfile_map.v
-techmap/mem_simple_4x1_map.v
-techmap/recursive_map.v
+# (techmap/mem_simple_4x1_map removed: its `module \$mem` built-in cell
+# template now imports via the internal-cell-type instantiation path and the
+# UHDM flow completes synth where read_verilog's errors — counted as a pass.)
+# (techmap/recursive_map removed: passes the full harness now.)
 
 # --- Yosys-internal-cell netlist (not SystemVerilog) ---
 # opt_rmdff.v is `read_verilog -icells` of Yosys built-in cells ($dffe,
@@ -109,33 +99,16 @@ techmap/recursive_map.v
 # UHDM frontend (same class as the techmap rule files above).
 opt/opt_rmdff.v
 
-# --- REAL UHDM-frontend bug: block-local blocking temps in `always @*` ---
-# loops.v (a combinational AES fragment) declares block-local regs inside its
-# `always @*` (`data_var`, `round_key_var`) and uses them blocking:
-#   data_var = addroundkey_data_i; round_key_var = key_i;
-#   round_data_var = round_key_var ^ data_var;
-# The UHDM frontend computes round_data_var with the WRONG operand values for
-# those block-local temps, so next_addroundkey_data_reg diverges (UHDM nl=0xf vs
-# RTL/Verilog rtl=0xb at cycle 17).  Two-co-sim adjudicated (UHDM-vs-RTL FAIL,
-# Verilog-vs-RTL PASS).  (The earlier "spurious latch" diagnosis was wrong —
-# post-synth latch count is now 0 for both frontends.)  Fix: thread the blocking
-# value of an always-@* block-local var into its later same-block reads.
-simple/loops.v
+# (simple/loops removed: the always-@* block-local blocking-temp bug was fixed
+# by the comb branch-value threading work — equiv_induct AND co-sim now pass.)
 
 # --- multi-file / external-tool tests ---
 # setup_yosys_test now loads SIBLING source files a test's .ys reads together
 # (e.g. sat/grom.ys: `read_verilog grom_computer.v grom_cpu.v alu.v
 # ram_memory.v`), so a cross-file submodule is no longer an undefined blackbox.
 #
-#   sat/grom_computer / sat/grom_cpu - now load all four grom sources and run
-#       the FULL UHDM flow.  The sound SAT-from-reset miter proves UHDM ==
-#       Verilog (triage_cosim.py: EQUIVALENT), i.e. the UHDM netlist is CORRECT.
-#       They remain expected-fail only because equiv_induct cannot inductively
-#       prove a CPU-with-memory and the self-checking design has no co-sim-
-#       observable outputs (co-sim build/skip) — the same equiv_induct
-#       inductive-invariant limitation as the dual-clock RAMs, NOT a frontend
-#       bug.  The harness uses the bounded miter for classification only, never
-#       as a pass-gate, so there is no green path for them yet.
+# (sat/grom_computer / sat/grom_cpu removed: the full harness now passes them
+# end-to-end — the earlier equiv_induct inductive limitation no longer bites.)
 #
 # These still cannot complete in the single-DUT flow (no .ys file list / external
 # tool), so they stay listed:
@@ -146,8 +119,6 @@ simple/loops.v
 #   rpc/design              - Yosys RPC frontend (python_inv over a unix socket)
 #   verific/mixed_flist     - Verific-only (`verific -f -sv ...flist`)
 functional/picorv32_tb.v
-sat/grom_computer.v
-sat/grom_cpu.v
 hana/test_simulation_vlib.v
 rpc/design.v
 verific/mixed_flist.sv
@@ -172,18 +143,10 @@ verific/mixed_flist.sv
 #   netlist — UHDM is correct.  (verified UHDM == Verilator via co-sim.)
 CastStructArray
 
-# --- Yosys v0.67 equiv_induct incompleteness on packed struct-arrays (NOT UHDM
-# bugs) ---
-# The v0.67 bump made equiv_induct inductively weaker on three packed
-# struct-array designs: it can no longer close the proof, but the sound
-# SAT-from-reset miter proves UHDM == Verilog (triage_cosim.py: EQUIVALENT), so
-# the netlists are functionally identical — 0 Miter-Formal escapes.  Same class
-# as sat/alu and the dual-clock RAMs below.  (The genuine struct-array bug the
-# v0.67 reference exposed, multidim_hier_path8, was fixed in the frontend, not
-# listed here.)
-struct_array_indexed_write
-struct_little_endian_bit_array
-svtypes_struct_array
+# (struct_array_indexed_write / struct_little_endian_bit_array /
+# svtypes_struct_array removed: all three pass equiv_induct again after the
+# struct-member packed-dim geometry fix — bit/array_typespec members and
+# ascending ([0:N]) outer ranges now element-index correctly.)
 
 # --- read_verilog mis-sizes a packed array of a struct (NOT a UHDM bug) ---
 # The Yosys read_verilog reference lowers `struct_t [N:0] arr` to a SINGLE

--- a/test/skipped_tests.txt
+++ b/test/skipped_tests.txt
@@ -29,3 +29,11 @@ various/shregmap.v        # `module $__SHREG_DFF_P_` and `module $__XILINX_SHREG
 # via test/rand_const/dut.sv.
 various/rand_const.sv     # `rand` modifier at module scope (non-LRM)
 
+
+# Recursive self-instantiation (`module top; top top_i(...); endmodule`).
+# Yosys v0.68's `stat` (and the shared harness synth flow) segfaults on the
+# resulting self-referential hierarchy through BOTH read_verilog and
+# read_uhdm (`read_verilog dut.v; hierarchy -auto-top; stat` alone dumps
+# core) — an upstream yosys crash, not a UHDM-frontend bug.  The upstream
+# test only checks that `hierarchy` reports the recursion error.
+various/hierarchy_recursive.v  # upstream yosys stat segfault on recursion


### PR DESCRIPTION
## Summary

Triage of the standing CI unexpected failures (all pre-date #582 — main CI has been red on these for a while), plus the baseline updates for the newly-passing tests CI keeps flagging.

### 1. `run/svtypes/struct_array` — real frontend bug, fixed (`expression.cpp`)

The `[ref_obj, part_select]` hier_path branch (struct member `s.a[hi:lo]`, both reads and LHS writes) computed the member's element width only from `logic_typespec`'s `Elem_typespec`:

- `bit [5:0][7:0] a` (**bit_typespec**: has `Ranges()` but no `Elem_typespec()`) got `elem_w=1` — `s.a[2:1] = 16'h1234` wrote 2 bits at `[18:17]` instead of 16 bits at `[39:24]`, silently corrupting constant struct writes
- **packed_array_typespec** (`bit3l_t [0:7][1:0]`) and **array_typespec** members (unpacked `bit [7:0] a [7:0]` inside a packed struct — yosys packs them) weren't recognized at all
- **ascending outer ranges** (`bit [0:7][…]`) were offset from the wrong end: the left index is the MSB, so the bit offset is `(decl_high - hi) * elem_w`, not `(lo - decl_low) * elem_w`

`elem_w` is now the product of the inner packed ranges times the `Elem_typespec` width, across all four member typespec shapes. Also fixes internal tests `svtypes_struct_array`, `struct_little_endian_bit_array`, `struct_array_indexed_write` (removed from `failing_tests.txt`).

### 2. `run/techmap/lcu_refined` — fixed (`module.cpp` + `uhdm2rtlil.cpp`)

Direct instantiation of a yosys internal cell by escaped name (`\$lcu #(.WIDTH(2)) impl (.P(P), …)`) was imported as a paramod-style type `$lcu\WIDTH=s32'…` with positional `$1..$4` connects, which `write_rtlil`'s internal-cell checker rejects. Both instance-creation paths (`import_instance`, and `import_module_hierarchy` where Surelog scopes the def as `parent::$lcu`) now emit what read_verilog emits: a public-typed `\$lcu` cell with parameters on the cell, named connections, and `module_not_derived`. This also un-blocks `techmap/mem_simple_4x1_map`'s `module \$mem` template (removed from `failing_tests.txt`).

### 3. `run/various/hierarchy_recursive` — upstream yosys crash, skipped

Not a UHDM bug: yosys v0.68's `stat` segfaults on the self-instantiating module through **both** frontends (`read_verilog dut.v; hierarchy -auto-top; stat` alone dumps core). Added to `skipped_tests.txt`.

### Baseline: 6 newly-passing tests removed from `failing_tests.txt`

`sat/alu`, `sat/ram_memory`, `sat/grom_computer`, `sat/grom_cpu`, `simple/loops`, `techmap/recursive_map` — CI has been reporting these as unexpected successes; `simple/loops` and `recursive_map` re-verified locally with full equiv + co-sim.

## Verification

Full sweep (`run_all_tests.sh --all`, 1360 tests): **0 unexpected failures, 0 unexpected successes, Miter-Formal 0**, no new crashes (the single crash is the pre-existing expected `memories/wide_all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)