### PR TITLE
uhdm: CVA6 per-module equivalence round 1 — 5 correctness fixes

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -231,17 +231,38 @@ void UhdmImporter::process_stmt_to_case(const any* stmt, RTLIL::CaseRule* case_r
                 // Add source location attribute for the case item
                 add_src_attribute(item_case->attributes, ci);
                 
-                // Get the case value
+                // Get the case value(s).  A multi-label arm
+                // (`EQ, NE, LTS: …`) has SEVERAL VpiExprs — taking only
+                // at(0) matched just the first label (ariane_pkg
+                // op_is_branch mis-classified NE/LTS/… as non-branches).
+                // `case … inside` additionally wraps a label list in ONE
+                // vpiListOp operation — expand its operands to individual
+                // labels (multiple compares in one CaseRule are OR'd, the
+                // exact case-label semantics).
                 if (ci->VpiExprs() && !ci->VpiExprs()->empty()) {
-                    // Regular case item
-                    RTLIL::SigSpec case_value = import_expression(any_cast<const expr*>(ci->VpiExprs()->at(0)), &input_mapping);
-                    // Ensure case value has same width as case expression
-                    if (case_value.size() < case_expr.size()) {
-                        case_value.extend_u0(case_expr.size());
-                    } else if (case_value.size() > case_expr.size()) {
-                        case_value = case_value.extract(0, case_expr.size());
+                    std::vector<const any*> labels;
+                    for (auto le : *ci->VpiExprs()) {
+                        if (le->VpiType() == vpiOperation) {
+                            auto lop = any_cast<const operation*>(le);
+                            if (lop->VpiOpType() == vpiListOp && lop->Operands()) {
+                                for (auto o : *lop->Operands())
+                                    labels.push_back(o);
+                                continue;
+                            }
+                        }
+                        labels.push_back(le);
                     }
-                    item_case->compare.push_back(case_value);
+                    for (auto le : labels) {
+                        RTLIL::SigSpec case_value = import_expression(
+                            any_cast<const expr*>(le), &input_mapping);
+                        // Ensure case value has same width as case expression
+                        if (case_value.size() < case_expr.size()) {
+                            case_value.extend_u0(case_expr.size());
+                        } else if (case_value.size() > case_expr.size()) {
+                            case_value = case_value.extract(0, case_expr.size());
+                        }
+                        item_case->compare.push_back(case_value);
+                    }
                 } // else default case (empty compare list)
                 
                 // For nested case statements, create intermediate wires and chaining assignments
@@ -3786,7 +3807,29 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 ? any_cast<const operation*>(operand)->VpiOpType() : -1;
             operand_is_unsigned.push_back(
                 oty == vpiConcatOp || oty == vpiMultiConcatOp);
+            // The ternary CONDITION (operand 0) is SELF-DETERMINED per LRM
+            // 11.4.11 — importing it under the assignment's wide LHS context
+            // widened `~less` to 64 bits BEFORE the inversion, making the
+            // condition nonzero for BOTH values of `less` (CVA6 alu MIN/MINU
+            // always returned operand_b).
+            // A replication COUNT (operand 0 of `{count{expr}}`) is a
+            // compile-time constant expression — force const folding so a
+            // struct-param arithmetic count (`{{53+CVA6Cfg.VLEN-64{sign}}}`,
+            // CVA6 instr_scan rvc_imm_o) folds instead of emitting cells and
+            // zero-filling the replication.
+            int cond_saved_ctx = expression_context_width;
+            bool cond_saved_fcf = force_const_fold;
+            if ((op_type == vpiConditionOp || op_type == vpiMultiConcatOp) &&
+                operands.empty()) {
+                expression_context_width = 0;
+                if (op_type == vpiMultiConcatOp)
+                    force_const_fold = true;
+            }
             RTLIL::SigSpec op_sig = import_expression(any_cast<const expr*>(operand), input_mapping);
+            if (op_type == vpiConditionOp || op_type == vpiMultiConcatOp) {
+                expression_context_width = cond_saved_ctx;
+                force_const_fold = cond_saved_fcf;
+            }
             if (op_type == vpiConditionOp) {
                 log("UHDM: ConditionOp operand %d has size %d\n", (int)operands.size(), op_sig.size());
             }
@@ -4701,6 +4744,13 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 if (is_signed) mark_result_signed(result);
                 return result;
             }
+            break;
+        case vpiListOp:
+            // `case … inside` wraps each label in a ListOp (Surelog emits a
+            // SINGLE-element list per label) — transparently its value.
+            // Multi-element lists are expanded at the case-label sites.
+            if (operands.size() == 1)
+                return operands[0];
             break;
         case vpiConcatOp:
             // Concatenation operation {a, b, c}

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -2944,7 +2944,16 @@ void UhdmImporter::import_always_ff(const process_stmt* uhdm_process, RTLIL::Pro
                         if (sig.lhs_expr) {
                             lhs_spec = import_expression(sig.lhs_expr);
                         } else {
-                            RTLIL::Wire* wire = module->wire(RTLIL::escape_id(sig.name));
+                            // May be generate-scoped (`\gen_x.sig`) — same
+                            // resolution as the always_comb variant.
+                            RTLIL::Wire* wire = name_map.count(sig.name)
+                                                    ? name_map[sig.name] : nullptr;
+                            if (!wire) wire = module->wire(RTLIL::escape_id(sig.name));
+                            if (!wire) {
+                                std::string gs = get_current_gen_scope();
+                                if (!gs.empty())
+                                    wire = module->wire(RTLIL::escape_id(gs + "." + sig.name));
+                            }
                             if (!wire) {
                                 log_warning("import_always_ff: cannot find wire '%s' for for-loop signal\n",
                                             sig.name.c_str());
@@ -3269,7 +3278,18 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
             } else {
                 // Signal extracted from a for-loop with dynamic index (lhs_expr is null).
                 // Use the full wire width so we can create a proper temp wire for it.
-                RTLIL::Wire* wire = module->wire(RTLIL::escape_id(sig.name));
+                // The wire may be GENERATE-SCOPED: `logic in_tmp;` declared
+                // inside `if (WIDTH > 1) begin : gen_lzc` lives as
+                // `\gen_lzc.in_tmp` (common_cells lzc flip_vector — the bare
+                // lookup dropped the whole loop's writes in every CVA6 lzc).
+                RTLIL::Wire* wire = name_map.count(sig.name)
+                                        ? name_map[sig.name] : nullptr;
+                if (!wire) wire = module->wire(RTLIL::escape_id(sig.name));
+                if (!wire) {
+                    std::string gs = get_current_gen_scope();
+                    if (!gs.empty())
+                        wire = module->wire(RTLIL::escape_id(gs + "." + sig.name));
+                }
                 if (!wire) {
                     log_warning("import_always_comb: cannot find wire '%s' for for-loop signal\n",
                                 sig.name.c_str());
@@ -11497,11 +11517,21 @@ static std::string comb_blocking_base(const RTLIL::SigSpec& target) {
 // `!found` must observe this iteration's update (and the minimal `t=0;
 // if(c) t=x; o=t+1`).  Operates on current_comb_values, which is what
 // import_ref_obj reads for a blocking scalar; the structural switch is
-// untouched.  Only top-level branch actions are threaded (a value assigned
-// inside a nested switch is left as-is, the prior behaviour).
+// untouched.  Direct branch actions are always threaded; when the caller
+// passes pre/then/else current_comb_values SNAPSHOTS, writes made ANYWHERE
+// inside a branch — including inside a nested if/case, whose own threading
+// recorded them into current_comb_values during the branch import — are
+// threaded too (same mechanism as thread_comb_case's arm_ccv).  Without the
+// snapshots a value assigned only under a nested if inside a branch was
+// dropped by the caller's ccv restore: CVA6 compressed_decoder's C.JR
+// `illegal_instr_o = (rs1 != '0) ? 0 : 1` two ifs deep in a case arm never
+// reached the trailing `if (illegal_instr_o) instr_o = instr_i;`.
 void UhdmImporter::thread_comb_if(RTLIL::SigSpec cond,
                                   RTLIL::CaseRule* then_case,
-                                  RTLIL::CaseRule* else_case) {
+                                  RTLIL::CaseRule* else_case,
+                                  const std::map<std::string, RTLIL::SigSpec>* pre_ccv,
+                                  const std::map<std::string, RTLIL::SigSpec>* then_ccv,
+                                  const std::map<std::string, RTLIL::SigSpec>* else_ccv) {
     if (in_always_ff_body_mode) return;
     // Last write wins within each branch.
     std::map<std::string, RTLIL::SigSpec> then_vals, else_vals;
@@ -11515,6 +11545,21 @@ void UhdmImporter::thread_comb_if(RTLIL::SigSpec cond,
             std::string b = comb_blocking_base(a.first);
             if (!b.empty()) else_vals[b] = a.second;
         }
+    // Snapshot-diff capture: any name whose in-flight value CHANGED during a
+    // branch import (vs the pre-branch snapshot) was written in that branch —
+    // possibly deep inside nested constructs.  Overrides the action scan
+    // (the ccv value is the branch's final merged value).
+    auto ccv_diff = [&](const std::map<std::string, RTLIL::SigSpec>* post,
+                        std::map<std::string, RTLIL::SigSpec>& vals) {
+        if (!pre_ccv || !post) return;
+        for (auto& kv : *post) {
+            auto p = pre_ccv->find(kv.first);
+            if (p == pre_ccv->end() || p->second != kv.second)
+                vals[kv.first] = kv.second;
+        }
+    };
+    ccv_diff(then_ccv, then_vals);
+    ccv_diff(else_ccv, else_vals);
     std::set<std::string> names;
     for (auto& kv : then_vals) names.insert(kv.first);
     for (auto& kv : else_vals) names.insert(kv.first);
@@ -11717,6 +11762,9 @@ void UhdmImporter::import_if_else_comb(const UHDM::if_else* uhdm_if_else, RTLIL:
                 log("    Importing then statement\n");
             import_statement_comb(then_stmt, true_case);
         }
+        // Capture the branch's final in-flight values (incl. nested-construct
+        // writes threaded during the import) BEFORE restoring.
+        auto then_ccv = current_comb_values;
         current_comb_values = saved_ccv;
 
         sw->cases.push_back(true_case);
@@ -11733,16 +11781,19 @@ void UhdmImporter::import_if_else_comb(const UHDM::if_else* uhdm_if_else, RTLIL:
             import_statement_comb(else_stmt, else_case);
             log("    Else case has %d actions after import\n", (int)else_case->actions.size());
             log("    Else case has %d switches after import\n", (int)else_case->switches.size());
+            auto else_ccv = current_comb_values;
             current_comb_values = saved_ccv;
 
             sw->cases.push_back(else_case);
-            thread_comb_if(condition_sig, true_case, else_case);
+            thread_comb_if(condition_sig, true_case, else_case,
+                           &saved_ccv, &then_ccv, &else_ccv);
         } else {
             // Create empty default case
             RTLIL::CaseRule* default_case = new RTLIL::CaseRule;
             add_src_attribute(default_case->attributes, uhdm_if_else);
             sw->cases.push_back(default_case);
-            thread_comb_if(condition_sig, true_case, nullptr);
+            thread_comb_if(condition_sig, true_case, nullptr,
+                           &saved_ccv, &then_ccv, nullptr);
         }
 
         // Add the switch to the current case
@@ -11840,25 +11891,27 @@ void UhdmImporter::import_if_stmt_comb(const UHDM::if_stmt* uhdm_if, RTLIL::Proc
                 log("    Importing then statement\n");
             import_statement_comb(then_stmt, true_case);
         }
+        auto then_ccv = current_comb_values;
         current_comb_values = saved_ccv;
 
         sw->cases.push_back(true_case);
-        
+
         // For simple if statements (not if_else), create empty default case
         RTLIL::CaseRule* default_case = new RTLIL::CaseRule;
         add_src_attribute(default_case->attributes, uhdm_if);
         sw->cases.push_back(default_case);
-        
+
         if (mode_debug) {
             log("    If statement import complete. Switch has %d cases\n", (int)sw->cases.size());
             for (size_t i = 0; i < sw->cases.size(); i++) {
                 log("      Case %d: %d actions\n", (int)i, (int)sw->cases[i]->actions.size());
             }
         }
-        
+
         // Add the switch to the current case
         proc->root_case.switches.push_back(sw);
-        thread_comb_if(condition_sig, true_case, nullptr);
+        thread_comb_if(condition_sig, true_case, nullptr,
+                       &saved_ccv, &then_ccv, nullptr);
     } else {
         log_warning("If statement has no condition\n");
     }
@@ -13334,6 +13387,7 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                         log("        Importing then statement in case\n");
                     import_statement_comb(then_stmt, true_case);
                 }
+                auto then_ccv = current_comb_values;
                 current_comb_values = saved_ccv;
 
                 sw->cases.push_back(true_case);
@@ -13354,7 +13408,10 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                 // under a nested `if` in a case arm (CVA6 compressed_decoder's
                 // `if (instr_i[12:5]==0) illegal_instr_o = 1'b1;`) reverted to
                 // its pre value and the later `if (illegal) …` never saw it.
-                thread_comb_if(condition_sig, true_case, nullptr);
+                // The ccv snapshots additionally capture writes NESTED inside
+                // this branch (C.JR's ternary two ifs deep).
+                thread_comb_if(condition_sig, true_case, nullptr,
+                               &saved_ccv, &then_ccv, nullptr);
             }
             current_if_qualifier = saved_qualifier;
             break;
@@ -13416,10 +13473,12 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                 }
 
                 sw->cases.push_back(true_case);
+                auto then_ccv = current_comb_values;
                 current_comb_values = saved_ccv;
 
                 // Handle else branch
                 RTLIL::CaseRule* else_case = nullptr;
+                auto else_ccv = saved_ccv;
                 if (auto else_stmt = if_else_stmt->VpiElseStmt()) {
                     else_case = new RTLIL::CaseRule;
                     // Empty compare means default case
@@ -13429,6 +13488,7 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                         log("        Importing else statement in case (type=%s)\n",
                             UhdmName(else_stmt->UhdmType()).c_str());
                     import_statement_comb(else_stmt, else_case);
+                    else_ccv = current_comb_values;
                     current_comb_values = saved_ccv;
 
                     sw->cases.push_back(else_case);
@@ -13443,8 +13503,10 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                 case_rule->switches.push_back(sw);
 
                 // Thread both branches' blocking writes so a later read sees
-                // `cond ? then_value : else_value` (see the vpiIf case above).
-                thread_comb_if(condition_sig, true_case, else_case);
+                // `cond ? then_value : else_value` (see the vpiIf case above);
+                // ccv snapshots capture writes nested deeper in each branch.
+                thread_comb_if(condition_sig, true_case, else_case,
+                               &saved_ccv, &then_ccv, &else_ccv);
             }
             current_if_qualifier = saved_qualifier;
             break;

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -751,7 +751,10 @@ struct UhdmImporter {
     void import_for_stmt(const UHDM::for_stmt* uhdm_for, RTLIL::Process* proc);
     void import_while_stmt(const UHDM::while_stmt* uhdm_while, RTLIL::Process* proc);
     void import_if_else_comb(const UHDM::if_else* uhdm_if_else, RTLIL::Process* proc);
-    void thread_comb_if(RTLIL::SigSpec cond, RTLIL::CaseRule* then_case, RTLIL::CaseRule* else_case);
+    void thread_comb_if(RTLIL::SigSpec cond, RTLIL::CaseRule* then_case, RTLIL::CaseRule* else_case,
+                        const std::map<std::string, RTLIL::SigSpec>* pre_ccv = nullptr,
+                        const std::map<std::string, RTLIL::SigSpec>* then_ccv = nullptr,
+                        const std::map<std::string, RTLIL::SigSpec>* else_ccv = nullptr);
     void thread_comb_case(const RTLIL::SigSpec& case_sig, RTLIL::SwitchRule* sw,
                           const std::map<std::string, RTLIL::SigSpec>& pre_ccv,
                           const std::vector<std::map<std::string, RTLIL::SigSpec>>& arm_ccv);

--- a/test/comb_flag_after_case/dut.sv
+++ b/test/comb_flag_after_case/dut.sv
@@ -1,0 +1,36 @@
+// Repro of CVA6 compressed_decoder illegal-passthrough bug: a blocking flag
+// defaulted at block top, conditionally set inside NESTED case/if arms, then
+// read by a TRAILING if in the same always_comb.  The trailing read must see
+// the in-flight (post-case) value; UHDM read a stale value so
+// `if (illegal) instr_o = instr_i` never fired (slang/LRM: it fires).
+module comb_flag_after_case (
+    input  logic [7:0] instr_i,
+    output logic [7:0] instr_o,
+    output logic       illegal_o
+);
+  always_comb begin
+    illegal_o = 1'b0;
+    instr_o   = 8'h00;
+    unique case (instr_i[1:0])
+      2'b00: begin
+        unique case (instr_i[3:2])
+          2'b00:   instr_o = 8'h11;
+          2'b01: begin
+            if (instr_i[7:4] == '0) illegal_o = 1'b1;
+            else instr_o = 8'h22;
+          end
+          default: illegal_o = 1'b1;
+        endcase
+      end
+      2'b01: instr_o = 8'h33;
+      default: begin
+        if (instr_i[7]) illegal_o = 1'b1;
+        else instr_o = 8'h44;
+      end
+    endcase
+
+    if (illegal_o) begin
+      instr_o = instr_i;
+    end
+  end
+endmodule

--- a/test/struct_param_repl_count/dut.sv
+++ b/test/struct_param_repl_count/dut.sv
@@ -1,0 +1,24 @@
+// Repro of CVA6 instr_scan rvc_imm_o bug: a replication whose COUNT is an
+// arithmetic expression over a struct-parameter field
+// (`{{53+CVA6Cfg.VLEN-64{instr_i[12]}}, ...}`).  UHDM zero-filled instead of
+// replicating the sign bit (only visible when the replicated bit is 1).
+package cfg_pkg;
+  typedef struct packed {
+    int unsigned VLEN;
+    int unsigned XLEN;
+  } cfg_t;
+  localparam cfg_t Cfg = '{VLEN: 64, XLEN: 64};
+endpackage
+
+module struct_param_repl_count
+  import cfg_pkg::*;
+#(
+    parameter cfg_t CVA6Cfg = cfg_pkg::Cfg
+) (
+    input  logic [31:0]             instr_i,
+    output logic [CVA6Cfg.VLEN-1:0] imm_o
+);
+  assign imm_o = (instr_i[14])
+      ? {{56 + CVA6Cfg.VLEN - 64 {instr_i[12]}}, instr_i[6:5], instr_i[2], instr_i[11:10], instr_i[4:3], 1'b0}
+      : {{53 + CVA6Cfg.VLEN - 64 {instr_i[12]}}, instr_i[8], instr_i[10:9], instr_i[6], instr_i[7], instr_i[2], instr_i[11], instr_i[5:3], 1'b0};
+endmodule

--- a/test/ternary_not_cond/dut.sv
+++ b/test/ternary_not_cond/dut.sv
@@ -1,0 +1,28 @@
+// Repro of CVA6 alu.sv MIN/MINU bug: `result_o = ~less ? operand_b :
+// operand_a;` — a `~cond` ternary condition inside a wide-LHS case-arm
+// assignment.  The condition is SELF-DETERMINED per LRM; importing it under
+// the 64-bit LHS context widens `less` before the `~`, so `~less` is nonzero
+// for BOTH values and the mux always picks operand_b (UHDM MIN == MAX).
+module ternary_not_cond (
+    input  logic [7:0] op_i,
+    input  logic [7:0] a_i,
+    input  logic [7:0] b_i,
+    output logic [7:0] y_o,
+    output logic [7:0] z_o
+);
+  logic less;
+  assign less = a_i < b_i;
+
+  // continuous-assign shape
+  assign z_o = ~less ? b_i : a_i;
+
+  // case-arm shape (the CVA6 alu context)
+  always_comb begin
+    y_o = '0;
+    unique case (op_i)
+      8'd170:  y_o = less ? b_i : a_i;   // MAX
+      8'd172:  y_o = ~less ? b_i : a_i;  // MIN
+      default: y_o = a_i;
+    endcase
+  end
+endmodule


### PR DESCRIPTION
## Summary

First round of the CVA6 **per-module formal equivalence campaign** (the follow-on to latch parity): each CVA6 module gets a wrapper that reproduces the real hierarchy's parameterization (cva6.sv's own `CVA6Cfg = build_config(...)` parameter block + shared type params), then a SAT miter proves UHDM == read_slang (read_verilog cannot parse CVA6, so slang is the reference).

**Modules proven equivalent so far:** `alu`, `csr_buffer`, `compressed_decoder`, `instr_scan`.

Getting those four green flushed out **five real correctness bugs** — none of them visible to latch counting or the whole-core smoke flow:

1. **lzc dropped driver** — `in_tmp` is declared inside the `gen_lzc` generate block (`\gen_lzc.in_tmp`), but the for-loop-signal wire lookup only tried the bare name; the flip_vector loop was silently dropped in **every CVA6 lzc instance** (wrong clz/ctz core-wide). Both always_comb and always_ff variants fixed.
2. **MIN/MINU returned the max** — ternary conditions are self-determined (LRM §11.4.11), but `~less ? b : a` imported under the 64-bit LHS context widened `less` before the `~`, making the condition always true. Repro `test/ternary_not_cond` (sound miter NON-EQUIVALENT before, EQUIVALENT + co-sim PASS after).
3. **RVC immediates lost sign extension** — `{{53+CVA6Cfg.VLEN-64{sign}}}` replication counts over struct-param arithmetic didn't const-fold outside loop/gen/function contexts, so the multiconcat zero-filled (instr_scan `rvc_imm_o`). Counts now import under `force_const_fold`. Guard test `test/struct_param_repl_count`.
4. **Multi-label case arms matched only their first label** — `process_stmt_to_case` compared `VpiExprs()->at(0)` only, so `ariane_pkg::op_is_branch`'s `EQ, NE, LTS, GES, LTU, GEU:` arm classified NE/LTS/… as non-branches when function-inlined; `case…inside` additionally wraps each label in a single-element `vpiListOp`. All labels now iterate with ListOp expansion, plus a transparent single-element ListOp unwrap in `import_operation`.
5. **Nested-branch value threading** — `thread_comb_if` only threaded *direct* branch actions; a write nested deeper (compressed_decoder's C.JR `illegal_instr_o = (rs1 != '0) ? 0 : 1`, two ifs deep in a case arm) was discarded by the ccv restore and never reached the trailing `if (illegal_instr_o) instr_o = instr_i;`. It now takes pre/then/else `current_comb_values` snapshots — the same mechanism `thread_comb_case` already uses — at all five call sites. Repro `test/comb_flag_after_case`.

## Verification

- Per-module SAT miters vs slang: `alu`, `csr_buffer`, `compressed_decoder`, `instr_scan` all EQUIVALENT (seq=4, from reset)
- `test/ternary_not_cond`: sound miter + both co-sims adjudicated (real bug before, equivalent after)
- Full sweep (`run_all_tests.sh --all`, 1366 tests): **0 unexpected failures, 0 unexpected successes, Miter-Formal 0**, warning set byte-identical to baseline; 907 passing / 415 UHDM-only (all 3 new tests green)

Campaign harness lives in `~/cva6/cva6_build/module_equiv/` (wrapper generator + runner + sweep driver). Next up: `branch_unit` and `decoder` divergences, then the remaining ~60 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)