### PR TITLE
uhdm: CVA6 per-module equivalence round 2 — branch_unit proven, 4 fixes + 1 revert

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -240,18 +240,26 @@ void UhdmImporter::process_stmt_to_case(const any* stmt, RTLIL::CaseRule* case_r
                 // labels (multiple compares in one CaseRule are OR'd, the
                 // exact case-label semantics).
                 if (ci->VpiExprs() && !ci->VpiExprs()->empty()) {
+                    // `case … inside` items arrive as ONE vpiInsideOp whose
+                    // operands are per-label single-element vpiListOps
+                    // (ariane_pkg op_is_branch) — flatten both recursively.
                     std::vector<const any*> labels;
-                    for (auto le : *ci->VpiExprs()) {
-                        if (le->VpiType() == vpiOperation) {
-                            auto lop = any_cast<const operation*>(le);
-                            if (lop->VpiOpType() == vpiListOp && lop->Operands()) {
-                                for (auto o : *lop->Operands())
-                                    labels.push_back(o);
-                                continue;
+                    std::function<void(const any*)> add_label =
+                        [&](const any* le) {
+                            if (le->VpiType() == vpiOperation) {
+                                auto lop = any_cast<const operation*>(le);
+                                if ((lop->VpiOpType() == vpiListOp ||
+                                     lop->VpiOpType() == vpiInsideOp) &&
+                                    lop->Operands()) {
+                                    for (auto o : *lop->Operands())
+                                        add_label(o);
+                                    return;
+                                }
                             }
-                        }
-                        labels.push_back(le);
-                    }
+                            labels.push_back(le);
+                        };
+                    for (auto le : *ci->VpiExprs())
+                        add_label(le);
                     for (auto le : labels) {
                         RTLIL::SigSpec case_value = import_expression(
                             any_cast<const expr*>(le), &input_mapping);
@@ -9646,73 +9654,91 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                     base_ref_typespec = union_var_obj->Typespec();
                 }
 
+                // Walk a struct/union typespec's members for `member_name`.
+                auto find_member_slice = [&](const UHDM::typespec* ts,
+                                             int& bit_offset,
+                                             int& member_width) -> bool {
+                    if (!ts) return false;
+                    bool is_union = ts->UhdmType() == uhdmunion_typespec;
+                    if (!is_union && ts->UhdmType() != uhdmstruct_typespec)
+                        return false;
+                    const VectorOftypespec_member* members = is_union
+                        ? any_cast<const UHDM::union_typespec*>(ts)->Members()
+                        : any_cast<const UHDM::struct_typespec*>(ts)->Members();
+                    if (!members) return false;
+                    bit_offset = 0;
+                    // Iterate members in reverse (MSB to LSB for packed structs)
+                    for (int i = members->size() - 1; i >= 0; i--) {
+                        auto member_spec = (*members)[i];
+                        int w = 1;
+                        if (auto member_ts = member_spec->Typespec()) {
+                            if (auto actual_ts = member_ts->Actual_typespec())
+                                w = get_width_from_typespec(actual_ts, inst);
+                        } else {
+                            w = get_width(member_spec, inst);
+                        }
+                        if (std::string(member_spec->VpiName()) == member_name) {
+                            member_width = w;
+                            return true;
+                        }
+                        if (!is_union) bit_offset += w;
+                    }
+                    return false;
+                };
+
+                int mem_off = 0, mem_w = 0;
+                bool found_member = false;
                 if (base_ref_typespec) {
                     base_typespec = base_ref_typespec->Actual_typespec();
+                    found_member = find_member_slice(base_typespec, mem_off, mem_w);
+                    if (!found_member && mode_debug)
+                        log("    Base wire typespec is not a struct/union (UhdmType=%s)\n",
+                            base_typespec ? UhdmName(base_typespec->UhdmType()).c_str() : "null");
+                } else if (mode_debug) {
+                    log("    Base wire has no typespec\n");
+                }
 
-                    // Check if this is a packed struct or union typespec
-                    if (base_typespec && (base_typespec->UhdmType() == uhdmstruct_typespec ||
-                                         base_typespec->UhdmType() == uhdmunion_typespec)) {
-                        bool base_is_union = (base_typespec->UhdmType() == uhdmunion_typespec);
-                        const VectorOftypespec_member* members = nullptr;
-                        if (base_is_union) {
-                            auto u_ts = any_cast<const UHDM::union_typespec*>(base_typespec);
-                            members = u_ts->Members();
-                        } else {
-                            auto s_ts = any_cast<const UHDM::struct_typespec*>(base_typespec);
-                            members = s_ts->Members();
-                        }
-
-                        if (mode_debug)
-                            log("    Found %s typespec for base wire '%s'\n",
-                                base_is_union ? "union" : "struct", base_name.c_str());
-
-                        // Find the member
-                        if (members) {
-                            int bit_offset = 0;
-                            int member_width = 0;
-                            bool found_member = false;
-
-                            // Iterate through members in reverse order (MSB to LSB for packed structs)
-                            for (int i = members->size() - 1; i >= 0; i--) {
-                                auto member_spec = (*members)[i];
-                                std::string current_member_name = std::string(member_spec->VpiName());
-
-                                // Get width of this member
-                                int current_member_width = 1;
-                                if (auto member_ts = member_spec->Typespec()) {
-                                    if (auto actual_ts = member_ts->Actual_typespec()) {
-                                        current_member_width = get_width_from_typespec(actual_ts, inst);
-                                    }
-                                } else {
-                                    // Try to get width directly from the member
-                                    current_member_width = get_width(member_spec, inst);
-                                }
-
-                                if (current_member_name == member_name) {
-                                    member_width = current_member_width;
+                // `parameter type` port/net: the base's own typespec is the
+                // UNBOUND declaration default (`parameter type exception_t =
+                // logic` → a plain logic_typespec), so the member walk above
+                // fails even though the wire has its bound width.  Recover the
+                // BOUND struct from the elaborated instance's type parameters,
+                // disambiguated by total width == wire width (branch_unit's
+                // exception_t(203) and bp_resolve_t(134) both contain `valid`).
+                // Without this the whole struct-field write stream degraded to
+                // 1-bit-x actions and `update 1'x $0\<sig>` — 12 undriven
+                // struct outputs across CVA6 (branch_unit resolved_branch_o /
+                // branch_exception_o, decoder instruction_o, mmu icache_areq_o,
+                // wt_dcache_ctrl req_port_o, cvxif drivers, btb_d).
+                if (!found_member) {
+                    if (auto mi = dynamic_cast<const UHDM::module_inst*>(current_instance)) {
+                        if (mi->Parameters()) {
+                            for (auto p : *mi->Parameters()) {
+                                auto tp = dynamic_cast<const UHDM::type_parameter*>(p);
+                                if (!tp || !tp->Typespec()) continue;
+                                auto ats = tp->Typespec()->Actual_typespec();
+                                if (!ats) continue;
+                                if (ats->UhdmType() != uhdmstruct_typespec &&
+                                    ats->UhdmType() != uhdmunion_typespec) continue;
+                                int total = get_width_from_typespec(ats, inst);
+                                if (total != base_wire->width) continue;
+                                if (find_member_slice(ats, mem_off, mem_w)) {
+                                    if (mode_debug)
+                                        log("    Resolved '%s.%s' via type-parameter %s (bound struct, width %d)\n",
+                                            base_name.c_str(), member_name.c_str(),
+                                            std::string(tp->VpiName()).c_str(), total);
                                     found_member = true;
                                     break;
                                 }
-
-                                // Only accumulate offset for structs, not unions
-                                if (!base_is_union)
-                                    bit_offset += current_member_width;
-                            }
-                            
-                            if (found_member) {
-                                if (mode_debug)
-                                    log("    Found packed member: offset=%d, width=%d\n", bit_offset, member_width);
-
-                                // Return a bit slice of the base wire
-                                return RTLIL::SigSpec(base_wire, bit_offset, member_width);
                             }
                         }
-                    } else if (mode_debug) {
-                        log("    Base wire typespec is not a struct/union (UhdmType=%s)\n",
-                            base_typespec ? UhdmName(base_typespec->UhdmType()).c_str() : "null");
                     }
-                } else if (mode_debug) {
-                    log("    Base wire has no typespec\n");
+                }
+
+                if (found_member) {
+                    if (mode_debug)
+                        log("    Found packed member: offset=%d, width=%d\n", mem_off, mem_w);
+                    return RTLIL::SigSpec(base_wire, mem_off, mem_w);
                 }
             } else if (mode_debug) {
                 log("    Could not find UHDM object for base wire '%s'\n", base_name.c_str());
@@ -10179,6 +10205,33 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                                 log("    hier_path '%s' folded to constant %s via ExprEval\n",
                                     path_name.c_str(), cv.as_const().as_string().c_str());
                             return cv;
+                        }
+                    }
+                }
+            }
+            // Second chance: decodeHierPath (above) returned the field's
+            // VALUE EXPRESSION from the struct-value parameter's assignment
+            // pattern (INTERRUPTS.S_TIMER → `(XLEN'(1)<<(XLEN-1)) | 5`).
+            // reduceExpr can fail on the hier_path in a re-passed context,
+            // but the member expression itself folds under force_const_fold.
+            // Without this the field returned width-only X and CVA6 decoder's
+            // interrupt_cause lost every INTERRUPTS.* constant.
+            if (member) {
+                if (auto mex = dynamic_cast<const UHDM::expr*>(member)) {
+                    if (member->UhdmType() == uhdmoperation ||
+                        member->UhdmType() == uhdmconstant) {
+                        bool saved_fcf = force_const_fold;
+                        int saved_ctx = expression_context_width;
+                        force_const_fold = true;
+                        expression_context_width = 0;
+                        RTLIL::SigSpec v = import_expression(mex, input_mapping);
+                        expression_context_width = saved_ctx;
+                        force_const_fold = saved_fcf;
+                        if (!v.empty() && v.is_fully_const() && v.is_fully_def()) {
+                            if (mode_debug)
+                                log("    hier_path '%s' folded via member value expression\n",
+                                    path_name.c_str());
+                            return v;
                         }
                     }
                 }

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -940,36 +940,21 @@ void UhdmImporter::finalize_dead_selfhold_defaults()
         // sync action RHS.  Write targets (action/sync-update LHS) don't
         // count.
         dict<RTLIL::Wire*, int> uses;
-        // Threading-mux fallback legs (thread_comb_if / thread_comb_case
-        // cells) read the raw wire as "the held value when not yet written
-        // this activation".  For signals PROVEN write-before-read by the
-        // import-time prescan those legs are dead — track them separately so
-        // they don't count as uses and can be rewired to X.
-        std::vector<std::pair<RTLIL::Cell*, RTLIL::IdString>> thread_legs;
+        // NOTE: threading-mux fallback legs reading the raw wire COUNT as
+        // uses.  An earlier tier rewired prescan-safe signals' legs to X, but
+        // that is UNSOUND: a raw-wire leg exists precisely where the
+        // threading had no in-flight value recorded, and such a leg can be
+        // REACHABLE standing in for a defined value (CVA6 decoder
+        // interrupt_cause: `'0`-initialized, a cv-miss leg fed the interrupt
+        // arm — the X leaked into instruction_o.ex).  Only the zero-raw-use
+        // tier is sound.
         auto count = [&](const RTLIL::SigSpec& s) {
             for (auto& ch : s.chunks())
                 if (ch.wire) uses[ch.wire]++;
         };
-        const std::set<std::string>* ssa_safe =
-            comb_ssa_safe_.count(mod) ? &comb_ssa_safe_.at(mod) : nullptr;
-        auto wire_ssa_safe = [&](RTLIL::Wire* w) {
-            if (!ssa_safe) return false;
-            std::string n = w->name.str();
-            if (!n.empty() && n[0] == '\\') n = n.substr(1);
-            return ssa_safe->count(n) != 0;
-        };
-        for (auto* cell : mod->cells()) {
-            bool is_thread_cell =
-                cell->name.str().find(":thread_comb_") != std::string::npos;
-            for (auto& conn : cell->connections()) {
-                if (is_thread_cell && conn.second.is_wire() &&
-                    wire_ssa_safe(conn.second.as_wire())) {
-                    thread_legs.push_back({cell, conn.first});
-                    continue;
-                }
+        for (auto* cell : mod->cells())
+            for (auto& conn : cell->connections())
                 count(conn.second);
-            }
-        }
         for (auto& conn : mod->connections()) { count(conn.first); count(conn.second); }
         for (auto& pit : mod->processes) {
             RTLIL::Process* p = pit.second;
@@ -999,7 +984,6 @@ void UhdmImporter::finalize_dead_selfhold_defaults()
                 if (!skipped.count(c.act)) uses[c.sig]--;
         }
 
-        pool<RTLIL::Wire*> converted;
         for (auto& c : cands) {
             if (cand_count[c.sig] > 1) continue;          // multi-writer
             if (c.sig->port_input || c.sig->port_output) continue;
@@ -1007,17 +991,9 @@ void UhdmImporter::finalize_dead_selfhold_defaults()
             if (c.sig->attributes.count(RTLIL::ID::init)) continue;
             if (uses.count(c.sig) && uses.at(c.sig) > 0) continue;
             c.act->second = RTLIL::SigSpec(RTLIL::State::Sx, c.sig->width);
-            converted.insert(c.sig);
             log("UHDM: %s.%s: self-hold default replaced with X (held value "
                 "never observed — write-before-read comb temp)\n",
                 log_id(mod->name), log_id(c.sig->name));
-        }
-        // Rewire the (dead) threading fallback legs of converted signals to X
-        // so their muxes stop referencing the raw wire.
-        for (auto& [cell, port] : thread_legs) {
-            RTLIL::SigSpec s = cell->getPort(port);
-            if (s.is_wire() && converted.count(s.as_wire()))
-                cell->setPort(port, RTLIL::SigSpec(RTLIL::State::Sx, s.size()));
         }
     }
 }
@@ -7072,6 +7048,40 @@ void UhdmImporter::import_statement_sync(const any* uhdm_stmt, RTLIL::SyncRule* 
     log_flush();
 }
 
+// Record a PARTIAL (bit/part-select) blocking write into current_comb_values
+// by splicing the written slice into the base's in-flight value.  Without
+// this a later same-block read observed the PRE-write value via the threaded
+// map: branch_unit's JALR `target_address[0] = 1'b0` never reached the
+// following `resolved_branch_o.target_address = comp ? target_address : …`
+// (UHDM kept the uncleared adder LSB; slang clears it).  The enclosing
+// if/case threading (ccv snapshots) then muxes the spliced value with the
+// pre-branch value automatically.
+void UhdmImporter::record_comb_partial_write(const RTLIL::SigSpec& lhs,
+                                             const RTLIL::SigSpec& rhs) {
+    if (in_always_ff_body_mode || in_always_ff_context) return;
+    if (lhs.empty() || lhs.chunks().size() != 1) return;
+    const RTLIL::SigChunk fc = *lhs.chunks().begin();
+    if (!fc.wire || fc.width >= fc.wire->width) return;   // full writes handled elsewhere
+    std::string bn = fc.wire->name.str();
+    if (!bn.empty() && bn[0] == '\\') bn = bn.substr(1);
+    // Only splice when the base ALREADY has an in-flight value (a prior
+    // full write, like branch_unit's `target_address = base + imm`).
+    // CREATING a new entry here is hazardous: LHS imports that consult
+    // comb_read_map would redirect a later partial write's TARGET to the
+    // value (multi-driver on the thread-mux wire — latch_tlb_napot).
+    auto cit = current_comb_values.find(bn);
+    if (cit == current_comb_values.end() ||
+        cit->second.size() != fc.wire->width) return;
+    RTLIL::SigSpec cur = cit->second;
+    RTLIL::SigSpec rv = rhs;
+    if (rv.size() < fc.width) rv.extend_u0(fc.width);
+    else if (rv.size() > fc.width) rv = rv.extract(0, fc.width);
+    cur.replace(fc.offset, rv);
+    current_comb_values[bn] = cur;
+    auto ai = comb_value_aliases.find(bn);
+    if (ai != comb_value_aliases.end()) current_comb_values[ai->second] = cur;
+}
+
 // Emit an assignment in a comb process, mapping LHS to its $0\ temp wire
 void UhdmImporter::emit_comb_assign(RTLIL::SigSpec lhs, RTLIL::SigSpec rhs, RTLIL::Process* proc) {
     // Size match
@@ -7115,6 +7125,8 @@ void UhdmImporter::emit_comb_assign(RTLIL::SigSpec lhs, RTLIL::SigSpec rhs, RTLI
             }
             off += chunk.width;
         }
+        // Single-chunk PARTIAL write: splice into the in-flight value.
+        record_comb_partial_write(lhs, rhs);
     }
 }
 
@@ -9074,8 +9086,31 @@ void UhdmImporter::inline_func_body_comb(const any* stmt, RTLIL::Process* proc,
                     Arm arm;
                     arm.is_default = (!ci->VpiExprs() || ci->VpiExprs()->empty());
                     // Build match = OR of (sel == cmpval) over this item's labels.
+                    // `case … inside` wraps the label set in ONE bare vpiInsideOp
+                    // (no left operand — the selector is implicit) whose members
+                    // are single-element vpiListOps; importing that as an
+                    // expression mangles it into one nonsense compare (ariane_pkg
+                    // op_is_branch classified only garbage as branches).  Flatten
+                    // InsideOp/ListOp wrappers to the individual label values.
                     if (!arm.is_default && ci->VpiExprs()) {
-                        for (auto e : *ci->VpiExprs()) {
+                        std::vector<const any*> labels;
+                        std::function<void(const any*)> add_label =
+                            [&](const any* le) {
+                                if (le->VpiType() == vpiOperation) {
+                                    auto lop = any_cast<const operation*>(le);
+                                    if ((lop->VpiOpType() == vpiListOp ||
+                                         lop->VpiOpType() == vpiInsideOp) &&
+                                        lop->Operands()) {
+                                        for (auto o : *lop->Operands())
+                                            add_label(o);
+                                        return;
+                                    }
+                                }
+                                labels.push_back(le);
+                            };
+                        for (auto e : *ci->VpiExprs())
+                            add_label(e);
+                        for (auto e : labels) {
                             RTLIL::SigSpec cmp = import_expression(any_cast<const expr*>(e), &func_mapping);
                             int w = std::max(sel.size(), cmp.size());
                             RTLIL::SigSpec s2 = sel, c2 = cmp;
@@ -12986,6 +13021,12 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                             // otherwise (Ibex ibex_compressed_decoder cm_rlist_d:
                             // `cm_rlist_d = cm_rlist_init(..); if (cm_rlist_d<=3)…
                             // else cm_rlist_d -= 1`).
+                            if (current_comb_process && !in_always_ff_body_mode &&
+                                    !in_always_ff_context && !lhs_sig.is_wire()) {
+                                // Partial blocking write inside a branch: splice
+                                // into the in-flight value (see helper).
+                                record_comb_partial_write(lhs_sig, rhs_sig);
+                            }
                             if (current_comb_process && !in_always_ff_body_mode &&
                                     !in_always_ff_context && lhs_sig.is_wire()) {
                                 std::string bn = lhs_sig.as_wire()->name.str();

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -517,6 +517,7 @@ struct UhdmImporter {
     // find_own_temp_wire().
     std::map<std::string, RTLIL::Wire*> comb_signal_temp_map;
     RTLIL::Wire* find_own_temp_wire(const std::string& signal_name);
+    void record_comb_partial_write(const RTLIL::SigSpec& lhs, const RTLIL::SigSpec& rhs);
     
     // Memory write handling for synchronous processes
     struct MemoryWriteInfo {


### PR DESCRIPTION
## Summary

Round 2 of the CVA6 per-module formal equivalence campaign. **branch_unit is now SAT-proven UHDM == slang** with hierarchy-representative parameters; `alu`, `csr_buffer`, `compressed_decoder`, `instr_scan` all re-verified with the final code.

### Fixes (found by peeling branch_unit/decoder counterexamples)

1. **`case…inside` labels via bare `vpiInsideOp`** — Surelog emits a case-inside item as one selector-less `vpiInsideOp` wrapping single-element ListOps; the function-inline path imported it as an expression → one garbage compare (`ariane_pkg::op_is_branch` misclassified branch ops). Flattened recursively in both inline paths.
2. **`parameter type` struct-member recovery** — a type-param port's net/port typespec is the *unbound* `= logic` default, so struct-field writes failed to resolve and whole processes degraded to `update 1'x $0\<sig>` — **12 silently undriven struct outputs across CVA6** (branch_unit both outputs, decoder `instruction_o` ×3, mmu `icache_areq_o`, `wt_dcache_ctrl.req_port_o`, cvxif drivers ×3, `btb_d`; July builds had 70). The bound struct is now recovered from the elaborated instance's type parameters, width-disambiguated.
3. **Partial-write in-flight splicing** — branch_unit's JALR `target_address[0] = 1'b0` never reached the following `resolved_branch_o.target_address` mux (wrong LSB + wrong `is_mispredict`). Bit/part-select writes now splice into the base's existing in-flight value; guarded to bases with a prior full write after the first gate run caught a write-target redirection hazard (`latch_tlb_napot`).
4. **Struct-value-parameter member folding** — `INTERRUPTS.S_TIMER` (assignment-pattern field `(1<<63)|5`) resolved to width-only X; the decoded member value-expression now folds under `force_const_fold`. Decoder's interrupt causes match slang exactly.
5. **Revert of #585's tier-2 X-leg rewiring** — proven unsound by decoder's `interrupt_cause` (a raw-wire threading fallback leg can be *reachable*, standing in for a defined value). Only the provably-safe zero-use tier remains; csr_regfile's 4 cosmetic write-before-read latches return — correctness over latch count.

## Verification

- branch_unit: SAT miter vs slang EQUIVALENT (seq=4, from reset); previously-proven modules re-verified
- `latch_tlb_napot`: import clean again (0 errors), slang miter SUCCESS
- Full sweep (`run_all_tests.sh --all`, 1366 tests): **0 unexpected failures, 0 unexpected successes, Miter-Formal 0**, warning set byte-identical to baseline

Campaign scoreboard: **5 modules proven** (`alu`, `csr_buffer`, `compressed_decoder`, `instr_scan`, `branch_unit`); decoder is one divergence away (interrupt-enable gating), then the remaining ~60 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)