### PR TITLE
uhdm: eq-fold width, fill-in-ternary, expr-width cast, loop break, dynamic packed reads (CVA6 round 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ report **0 Miter-Formal escapes** — no real UHDM≠Verilog difference slips th
 Run via `make test-all --all` (the internal SystemVerilog suite **plus** the
 upstream Yosys test suite under `third_party/yosys/tests/`):
 
-- **Total Tests**: 1374 (829 internal SystemVerilog + 545 upstream Yosys)
-- **Success Rate**: 96% (1330/1374 tests functional), 1 crash, **0 Miter-Formal
+- **Total Tests**: 1382 (837 internal SystemVerilog + 545 upstream Yosys)
+- **Success Rate**: 97% (1337/1382 tests functional), 1 crash, **0 Miter-Formal
   escapes** (no UHDM≠Verilog diff slips past `equiv_induct`)
-- **Passing**: 910 tests with formal equivalence verified between the UHDM and Verilog frontends
-- **UHDM-Only Success**: 420 tests verified end-to-end against Verilator (the UHDM frontend handles SystemVerilog the Verilog frontend can't, so formal equivalence isn't possible — see below)
+- **Passing**: 912 tests with formal equivalence verified between the UHDM and Verilog frontends
+- **UHDM-Only Success**: 425 tests verified end-to-end against Verilator (the UHDM frontend handles SystemVerilog the Verilog frontend can't, so formal equivalence isn't possible — see below)
 - **Equivalence failures**: 10 — all caught by `equiv_induct` (0 Miter-Formal
   escapes): internal `CastStructArray` and `packed_array_elem_select` (both
   cases where the *Verilog-frontend reference* is wrong — a SAT miter / slang
@@ -80,7 +80,7 @@ upstream Yosys test suite under `third_party/yosys/tests/`):
   don't-care divergences (e.g. `rp32_r5p_alu/wbu/mdu`, where the Verilog frontend
   can't synthesize the SV so no miter is possible)
 
-> The **internal** SystemVerilog suite alone is **829 tests, 0 crashes, 0 true
+> The **internal** SystemVerilog suite alone is **837 tests, 0 crashes, 0 true
 > failures** — every internal design reads and produces output, including the
 > complete Ibex core (all modules + `ibex_top`) and the rp32 cores/SoCs. The only
 > internal equivalence failures are `CastStructArray` and

--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -1778,17 +1778,98 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                             int leaf_w = 1;
                             for (size_t d = K; d < pdims.size(); d++) leaf_w *= pdims[d].first;
                             long off = 0; bool ok = true;
+                            bool any_dyn_idx = false;
+                            int sel_w = leaf_w;
                             for (size_t k = 0; k < K; k++) {
-                                RTLIL::SigSpec is = import_expression((*exprs)[k], input_mapping);
-                                if (!is.is_fully_const()) { ok = false; break; }
                                 int inner = 1;
                                 for (size_t d = k + 1; d < pdims.size(); d++) inner *= pdims[d].first;
+                                // Trailing RANGE select of a dim
+                                // (`vaddr_vpn_match[i][z][PtLevels-1:x]`, CVA6
+                                // cva6_tlb): the last Exprs entry is a
+                                // part_select node windowing dim K-1 — the
+                                // const-index import below returned non-const
+                                // and the read collapsed to a single wrong bit.
+                                if (k == K - 1 &&
+                                    (*exprs)[k]->UhdmType() == uhdmpart_select) {
+                                    auto psx = any_cast<const UHDM::part_select*>((*exprs)[k]);
+                                    RTLIL::SigSpec l = import_expression(psx->Left_range(), input_mapping);
+                                    RTLIL::SigSpec rr = import_expression(psx->Right_range(), input_mapping);
+                                    if (!l.is_fully_const() || !rr.is_fully_const()) { ok = false; break; }
+                                    int lo = std::min(l.as_const().as_int(), rr.as_const().as_int());
+                                    int w = std::abs(l.as_const().as_int() -
+                                                     rr.as_const().as_int()) + 1;
+                                    int rel = lo - pdims[k].second;
+                                    if (rel < 0 || rel + w > pdims[k].first) { ok = false; break; }
+                                    off += (long)rel * inner;
+                                    sel_w = w * inner;
+                                    continue;
+                                }
+                                RTLIL::SigSpec is = import_expression((*exprs)[k], input_mapping);
+                                if (!is.is_fully_const()) {
+                                    ok = false;
+                                    any_dyn_idx = true;
+                                    break;
+                                }
                                 off += (long)(is.as_const().as_int() - pdims[k].second) * inner;
                             }
-                            if (ok && off >= 0 && off + leaf_w <= base_sig.size()) {
+                            if (ok && off >= 0 && off + sel_w <= base_sig.size()) {
                                 log("  vpiVarSelect: packed %dD %s[...] → [%d+:%d]\n",
-                                    (int)pdims.size(), base_name.c_str(), (int)off, leaf_w);
-                                return base_sig.extract((int)off, leaf_w);
+                                    (int)pdims.size(), base_name.c_str(), (int)off, sel_w);
+                                return base_sig.extract((int)off, sel_w);
+                            }
+                            // DYNAMIC index into a multi-dim PACKED array
+                            // (`vaddr_lvl[0][ptw_lvl_q[0]]` on
+                            // `logic [A:0][B:0][8:0]`, CVA6 cva6_ptw): the
+                            // const path above bails, and without this the read
+                            // fell through to a plain 1-BIT bit_select —
+                            // ptw_pptr_n lost 8 of the element's 9 bits.  Shift
+                            // the element out of the flat value at
+                            // Σ (idx_k − low_k)·stride_k.
+                            if (any_dyn_idx && pdims.size() >= K) {
+                                int leaf_w = 1;
+                                for (size_t d = K; d < pdims.size(); d++)
+                                    leaf_w *= pdims[d].first;
+                                int shamt_w = 32;
+                                RTLIL::SigSpec acc(RTLIL::Const(0, shamt_w));
+                                bool dyn_ok = leaf_w > 1;
+                                for (size_t k = 0; k < K && dyn_ok; k++) {
+                                    int inner = 1;
+                                    for (size_t d = k + 1; d < pdims.size(); d++)
+                                        inner *= pdims[d].first;
+                                    RTLIL::SigSpec ix =
+                                        import_expression((*exprs)[k], input_mapping);
+                                    if (ix.empty()) { dyn_ok = false; break; }
+                                    ix.extend_u0(shamt_w, false);
+                                    if (pdims[k].second != 0) {
+                                        RTLIL::Wire* sw = module->addWire(NEW_ID, shamt_w);
+                                        module->addSub(NEW_ID, ix,
+                                            RTLIL::SigSpec(RTLIL::Const(pdims[k].second, shamt_w)),
+                                            sw, true);
+                                        ix = RTLIL::SigSpec(sw);
+                                    }
+                                    RTLIL::Wire* mw = module->addWire(NEW_ID, shamt_w);
+                                    module->addMul(NEW_ID, ix,
+                                        RTLIL::SigSpec(RTLIL::Const(inner, shamt_w)), mw, true);
+                                    RTLIL::Wire* aw = module->addWire(NEW_ID, shamt_w);
+                                    module->addAdd(NEW_ID, acc, RTLIL::SigSpec(mw), aw, true);
+                                    acc = RTLIL::SigSpec(aw);
+                                }
+                                if (dyn_ok) {
+                                    RTLIL::Wire* out = module->addWire(NEW_ID, leaf_w);
+                                    RTLIL::Cell* sx = module->addCell(NEW_ID, ID($shiftx));
+                                    sx->setParam(ID::A_SIGNED, 0);
+                                    sx->setParam(ID::B_SIGNED, 0);
+                                    sx->setParam(ID::A_WIDTH, base_sig.size());
+                                    sx->setParam(ID::B_WIDTH, shamt_w);
+                                    sx->setParam(ID::Y_WIDTH, leaf_w);
+                                    sx->setPort(ID::A, base_sig);
+                                    sx->setPort(ID::B, acc);
+                                    sx->setPort(ID::Y, out);
+                                    log("  vpiVarSelect: DYNAMIC packed %dD %s[...] → "
+                                        "shiftx (w=%d)\n",
+                                        (int)pdims.size(), base_name.c_str(), leaf_w);
+                                    return RTLIL::SigSpec(out);
+                                }
                             }
                         }
                     }
@@ -3592,6 +3673,51 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 if (result.size() > 0)
                     return result;
             }
+
+            // `'{default: V}` on a PACKED VECTOR / packed array target
+            // (`logic [TLB_ENTRIES-1:0] m = RVH ? '{default: 0} : '{default: 1}`,
+            // CVA6 cva6_tlb match_vmid): every ELEMENT gets V — for a plain
+            // vector the elements are single bits, so `'{default: 1}` is
+            // all-ones, NOT the literal 1 the generic loop below produced.
+            if (deftp && !members && deftp->Pattern()) {
+                int ew = 1, tw = 0;
+                if (ats) {
+                    tw = get_width_from_typespec(ats, inst);
+                    if (auto pt = dynamic_cast<const UHDM::packed_array_typespec*>(ats)) {
+                        if (pt->Elem_typespec() && pt->Elem_typespec()->Actual_typespec()) {
+                            int w = get_width_from_typespec(
+                                pt->Elem_typespec()->Actual_typespec(), inst);
+                            if (w > 0) ew = w;
+                        }
+                    } else if (auto lt = dynamic_cast<const UHDM::logic_typespec*>(ats)) {
+                        // Multi-range vector `logic [A][B]`: element = product of
+                        // the inner ranges; single range → 1-bit elements.
+                        if (lt->Ranges() && lt->Ranges()->size() >= 2) {
+                            int iw = 1;
+                            for (size_t ri = 1; ri < lt->Ranges()->size(); ri++) {
+                                auto rn = (*lt->Ranges())[ri];
+                                RTLIL::SigSpec il = import_expression(rn->Left_expr(), input_mapping);
+                                RTLIL::SigSpec ir = import_expression(rn->Right_expr(), input_mapping);
+                                if (il.is_fully_const() && ir.is_fully_const())
+                                    iw *= std::abs(il.as_const().as_int() -
+                                                   ir.as_const().as_int()) + 1;
+                            }
+                            if (iw > 0) ew = iw;
+                        }
+                    }
+                }
+                if (tw <= 0) tw = expression_context_width;
+                if (tw > 0 && ew > 0 && tw % ew == 0) {
+                    RTLIL::SigSpec defval = import_expression(
+                        any_cast<const expr*>(deftp->Pattern()), input_mapping);
+                    if (defval.size() < ew) defval.extend_u0(ew);
+                    else if (defval.size() > ew) defval = defval.extract(0, ew);
+                    RTLIL::SigSpec result;
+                    for (int i = 0; i < tw / ew; i++) result.append(defval);
+                    if (result.size() > 0)
+                        return result;
+                }
+            }
         }
 
         // Struct/array aggregate: '{field: val, field: val, ...}
@@ -3838,7 +3964,19 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
     // final widen — losing the explicit `signed'`/`unsigned'` cast and
     // producing the wrong bits (static_cast_simple).  Our own cast
     // handler below tracks signedness through the chain correctly.
-    if (op_type != vpiCastOp) {
+    // An UNBASED UNSIZED fill literal (`'1`/`'0`/`'x`/`'z`, VpiSize()==-1) in a
+    // context-determined position must REPLICATE to the context width, but
+    // reduceExpr collapses it to a single bit and we then zero-extend — CVA6
+    // cva6_ptw's `assign req_port_o.data_be = CVA6Cfg.IS_XLEN32 ? be_gen_32(…)
+    // : '1;` folded to 8'h01 instead of 8'hff.  Let the operand-wise path below
+    // handle those (it sizes fill branches to the context).
+    bool has_unsized_fill_operand = false;
+    if (op_type == vpiConditionOp && uhdm_op->Operands())
+        for (auto o : *uhdm_op->Operands())
+            if (auto c = dynamic_cast<const UHDM::constant*>(o))
+                if (c->VpiSize() == -1) { has_unsized_fill_operand = true; break; }
+
+    if (op_type != vpiCastOp && !has_unsized_fill_operand) {
         ExprEval eval;
         bool invalidValue = false;
         expr* res = eval.reduceExpr(uhdm_op, invalidValue, inst, uhdm_op->VpiParent(), true);
@@ -4101,13 +4239,24 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                 }
                 break;
             case vpiEqOp:
+                // VALUE comparison, not bit-vector identity: RTLIL::Const's
+                // operator== also compares the WIDTH, so a 32-bit 0 (what an
+                // unrolled loop variable folds to) compared against a 64-bit
+                // literal 0 came out FALSE.  `y == 0` inside an unrolled
+                // `for (int unsigned y …)` therefore always folded to 0 —
+                // CVA6 cva6_ptw's `shared_tlb_update_o.is_page[x][y] =
+                // y == 0 ? … : 1'b0` lost every y==0 term.  const_eq extends
+                // both operands to a common width first, like the const_lt /
+                // const_gt cases below already did.
                 if (operands.size() == 2) {
-                    result = operands[0].as_const() == operands[1].as_const() ? RTLIL::Const(1, 1) : RTLIL::Const(0, 1);
+                    result = RTLIL::const_eq(operands[0].as_const(), operands[1].as_const(),
+                                             false, false, 1);
                 }
                 break;
             case vpiNeqOp:
                 if (operands.size() == 2) {
-                    result = operands[0].as_const() != operands[1].as_const() ? RTLIL::Const(1, 1) : RTLIL::Const(0, 1);
+                    result = RTLIL::const_ne(operands[0].as_const(), operands[1].as_const(),
+                                             false, false, 1);
                 }
                 break;
             case vpiLtOp:
@@ -4841,8 +4990,41 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
 
                 // Match operand widths for the mux output
                 int max_width = std::max(operands[1].size(), operands[2].size());
+                // An UNBASED UNSIZED fill literal branch (`'1`, `'0`, `'x`,
+                // `'z` — VpiSize()==-1) is 1 bit as imported but must
+                // REPLICATE to the result width, not zero-extend.  CVA6
+                // cva6_ptw's `assign req_port_o.data_be = CVA6Cfg.IS_XLEN32 ?
+                // be_gen_32(…) : '1;` produced data_be = 8'h01 instead of
+                // 8'hff.  The assignment sites already handle a bare fill RHS;
+                // inside a ternary the branch never reached them.  Take the
+                // width from the other branch, else the surrounding context.
+                auto fill_state_of = [&](size_t i) -> std::pair<bool, RTLIL::State> {
+                    if (!uhdm_op->Operands() || uhdm_op->Operands()->size() < 3)
+                        return {false, RTLIL::State::S0};
+                    auto c = dynamic_cast<const UHDM::constant*>(
+                        (*uhdm_op->Operands())[i]);
+                    if (!c || c->VpiSize() != -1) return {false, RTLIL::State::S0};
+                    std::string v(c->VpiValue());
+                    if (v == "BIN:1") return {true, RTLIL::State::S1};
+                    if (v == "BIN:0") return {true, RTLIL::State::S0};
+                    if (v == "BIN:x" || v == "BIN:X") return {true, RTLIL::State::Sx};
+                    if (v == "BIN:z" || v == "BIN:Z") return {true, RTLIL::State::Sz};
+                    return {false, RTLIL::State::S0};
+                };
+                auto tf = fill_state_of(1), ff = fill_state_of(2);
+                // A `?:` is context-determined (LRM 11.4.11): the surrounding
+                // assignment width wins over the sibling branch's own width —
+                // `data_be = cond ? be_gen_32(…4 bits…) : '1` must fill all 8
+                // LHS bits, not 4.  Fall back to the sibling branch when there
+                // is no context.
+                int fill_w = expression_context_width > 0
+                                 ? expression_context_width
+                                 : max_width;
+                if ((tf.first || ff.first) && fill_w > max_width) max_width = fill_w;
                 RTLIL::SigSpec true_val = operands[1];
                 RTLIL::SigSpec false_val = operands[2];
+                if (tf.first && fill_w > 0) true_val = RTLIL::SigSpec(tf.second, fill_w);
+                if (ff.first && fill_w > 0) false_val = RTLIL::SigSpec(ff.second, fill_w);
 
                 // Extend operands to match widths if needed
                 // Use sign-extension when operands are signed
@@ -5035,6 +5217,24 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                                 RTLIL::Const width_const = extract_const_from_value(val_str);
                                 if (width_const.size() > 0) {
                                     target_width = width_const.as_int();
+                                    is_size_cast = true;
+                                }
+                            }
+                            // EXPRESSION-width size cast — `((CVA6Cfg.PtLevels +
+                            // HYP_EXT) * (CVA6Cfg.VpnLen / CVA6Cfg.PtLevels))'
+                            // (vpn_to_store)` (CVA6 cva6_tlb tag update):
+                            // VpiValue is EMPTY and the width lives in the
+                            // integer_typespec's Expr().  Without this the
+                            // fallthrough defaulted to 32 and the oversized
+                            // cast STOLE bits from the enclosing concat (the
+                            // stored TLB asid lost its top 5 bits).
+                            if (target_width <= 0 && its->Expr()) {
+                                bool saved = force_const_fold;
+                                force_const_fold = true;
+                                RTLIL::SigSpec ws = import_expression(its->Expr());
+                                force_const_fold = saved;
+                                if (ws.is_fully_const() && ws.as_const().as_int() > 0) {
+                                    target_width = ws.as_const().as_int();
                                     is_size_cast = true;
                                 }
                             }
@@ -5915,11 +6115,21 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
             int bw = w ? w->width : 32;
             base = RTLIL::SigSpec(RTLIL::Const(lv, bw));
             log("      PartSelect: substituting loop var '%s' = %d\n", base_signal_name.c_str(), lv);
-        } else if (input_mapping && input_mapping->count(base_signal_name)) {
+        } else if (input_mapping && input_mapping->count(base_signal_name) &&
+                   (!comb_lhs_keep_base ||
+                    !module->wire(RTLIL::escape_id(base_signal_name)))) {
             // Function-inline (legacy) path: a part-select of a function param
             // or local (e.g. op[6:2] in rp32's dec32) — the base signal lives in
             // input_mapping, not as a module wire.  Without this it resolves to
             // the wrong wire / 0 (bit-selects and full refs already work).
+            // Skipped for a WRITE TARGET (comb_lhs_keep_base) whose base IS a
+            // real module wire: the base must stay the target wire —
+            // substituting the in-flight comb VALUE here turned
+            // `endian_data[31:0] = …` after `endian_data = ctrl.data` into a
+            // write at ctrl.data's struct offset (CVA6 store_unit corrupted
+            // bit 39 of the AMO operand).  Function LOCALS have no module
+            // wire, so they still resolve through input_mapping
+            // (function_mixed's `result[2*i] = x[i]`).
             base = input_mapping->at(base_signal_name);
             log("      PartSelect: base '%s' from input_mapping (width=%d)\n",
                 base_signal_name.c_str(), base.size());
@@ -5961,10 +6171,14 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
                     base_signal_name.c_str(), vs.c_str(), bw);
             }
         }
-        if (base.empty() && input_mapping && input_mapping->count(base_signal_name)) {
+        if (base.empty() && input_mapping &&
+            input_mapping->count(base_signal_name) &&
+            (!comb_lhs_keep_base ||
+             !module->wire(RTLIL::escape_id(base_signal_name)))) {
             // Function argument sliced inside the function body (`data[hi:lo]`
             // in repData64) — the base is the call argument in input_mapping,
-            // not a module wire.
+            // not a module wire.  (Write targets keep a real wire base — see
+            // the comb_lhs_keep_base rule above.)
             base = input_mapping->at(base_signal_name);
         }
         if (base.empty()) {
@@ -6059,7 +6273,8 @@ RTLIL::SigSpec UhdmImporter::import_part_select(const part_select* uhdm_part, co
     // import_ref_obj's whole-signal substitution.  PR #291 redirected
     // whole-signal blocking-temp reads but missed part/bit-selects, so the
     // consumer read the registered wire and got an extra cycle of delay.
-    if (input_mapping && !base_signal_name.empty()) {
+    if (input_mapping && !base_signal_name.empty() &&
+        !(comb_lhs_keep_base && base.is_wire())) {
         auto im = input_mapping->find(base_signal_name);
         if (im != input_mapping->end() && im->second.size() == base.size())
             base = im->second;
@@ -6685,6 +6900,36 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                 }
             }
         }
+        // Packed array of an (anonymous) struct on a plain net:
+        // `struct packed {...} [N-1:0] tags_n;` — the net's typespec is a
+        // packed_array_typespec whose Elem_typespec is the struct.  Without
+        // this, `tags_n[i] = {…}` wrote a SINGLE BIT instead of the 62-bit
+        // element (CVA6 cva6_tlb's update path never stored an entry).
+        if (packed_elem_w <= 1 && rt && rt->Actual_typespec() &&
+            rt->Actual_typespec()->UhdmType() == uhdmpacked_array_typespec) {
+            auto pat = any_cast<const UHDM::packed_array_typespec*>(rt->Actual_typespec());
+            int ew = 0;
+            if (pat->Elem_typespec() && pat->Elem_typespec()->Actual_typespec())
+                ew = get_width_from_typespec(
+                    pat->Elem_typespec()->Actual_typespec(), inst);
+            if (ew > 1 && pat->Ranges() && !pat->Ranges()->empty()) {
+                auto r0 = (*pat->Ranges())[0];
+                RTLIL::SigSpec ls = import_expression(r0->Left_expr());
+                RTLIL::SigSpec rs = import_expression(r0->Right_expr());
+                // Only DESCENDING declarations (`[N-1:0]`, what CVA6 uses):
+                // the shared const/dynamic slot math below is
+                // `idx - min(l,r)`, which is only correct when element 0 sits
+                // at the LSB.  An ASCENDING `[0:1]` puts element 0 at the MSB
+                // (typedef_packed_enum_array), so leave those to the existing
+                // paths rather than mis-scaling them here.
+                if (ls.is_fully_const() && rs.is_fully_const() &&
+                    ls.as_int() >= rs.as_int() && base.size() % ew == 0) {
+                    packed_elem_w = ew;
+                    packed_outer_l = ls.as_int();
+                    packed_outer_r = rs.as_int();
+                }
+            }
+        }
     }
 
     // Flattened interface unpacked-ARRAY signal (`req_t req_dly [0:DLY]`,
@@ -7019,7 +7264,12 @@ RTLIL::SigSpec UhdmImporter::import_indexed_part_select(const indexed_part_selec
         // `data[offset*8+:16]`): the base is passed via input_mapping, not a
         // module wire (CVA6 wt_dcache_wbuffer repData64 — else "Base signal
         // 'data' not found").  Prefer it so the slice reads the call argument.
-        if (input_mapping && input_mapping->count(base_signal_name)) {
+        // Skipped for a WRITE TARGET (comb_lhs_keep_base) with a real module
+        // wire — same rule as import_part_select: the base must stay the
+        // target wire; function locals (no wire) still use input_mapping.
+        if (input_mapping && input_mapping->count(base_signal_name) &&
+            (!comb_lhs_keep_base ||
+             !module->wire(RTLIL::escape_id(base_signal_name)))) {
             base = input_mapping->at(base_signal_name);
         } else
         // If this is a for-loop variable, substitute its current constant value
@@ -8420,7 +8670,8 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                        (nsel == peN.size() - 1 &&
                         (peN[nsel]->UhdmType() == uhdmref_obj ||
                          peN[nsel]->UhdmType() == uhdmpart_select ||
-                         peN[nsel]->UhdmType() == uhdmbit_select));
+                         peN[nsel]->UhdmType() == uhdmbit_select ||
+                         peN[nsel]->UhdmType() == uhdmvar_select));
         if (mode_debug)
             log("    Nidx probe: nsel=%zu total=%zu tail_ok=%d run_base='%s'\n",
                 nsel, peN.size(), tail_ok ? 1 : 0, run_base.c_str());
@@ -8434,6 +8685,13 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                                          ? any_cast<const part_select*>(peN[nsel]) : nullptr;
             if (nsel < peN.size() && peN[nsel]->UhdmType() == uhdmbit_select)
                 fbs2 = any_cast<const bit_select*>(peN[nsel]);
+            // Multi-index field select (`tags_q[i].is_page[2-x][0:0]`,
+            // CVA6 cva6_tlb page_match): the field is a var_select whose
+            // Indexes() carry per-dim selects; the LAST one may be a
+            // part_select node.
+            const UHDM::var_select* fvs =
+                (nsel < peN.size() && peN[nsel]->UhdmType() == uhdmvar_select)
+                    ? any_cast<const UHDM::var_select*>(peN[nsel]) : nullptr;
             std::string base_name = bs0 ? std::string(bs0->VpiName()) : std::string();
             RTLIL::Wire* base_flat = (!base_name.empty() && name_map.count(base_name))
                                          ? name_map[base_name]
@@ -8471,20 +8729,26 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 // all dims are consumed).
                 int field_offset = 0, field_width = level_w;
                 bool field_ok = true;
-                if ((fr || fps || fbs2) && st && st->Members() && nsel == dims.size()) {
+                const UHDM::typespec* field_ts = nullptr;
+                if ((fr || fps || fbs2 || fvs) && st && st->Members() && nsel == dims.size()) {
                     std::string field_name = fr ? std::string(fr->VpiName())
                                               : fps ? std::string(fps->VpiName())
-                                                    : std::string(fbs2->VpiName());
+                                              : fbs2 ? std::string(fbs2->VpiName())
+                                                     : std::string(fvs->VpiName());
                     field_offset = 0; field_width = 0;
                     bool found_field = false;
                     for (int i2 = (int)st->Members()->size() - 1; i2 >= 0; i2--) {
                         auto m = (*st->Members())[i2];
                         int mw = 0;
+                        const UHDM::typespec* ats_r = nullptr;
                         if (auto mts = m->Typespec())
-                            if (auto ats = mts->Actual_typespec())
-                                mw = get_width_from_typespec(ats, inst);
+                            if (auto ats = mts->Actual_typespec()) {
+                                ats_r = resolve_type_param_typespec(ats, inst);
+                                mw = get_width_from_typespec(ats_r, inst);
+                            }
                         if (std::string(m->VpiName()) == field_name) {
                             field_width = mw;
+                            field_ts = ats_r;
                             found_field = true;
                             break;
                         }
@@ -8515,7 +8779,89 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                             } else field_ok = false;
                         } else field_ok = false;
                     }
-                } else if (fr || fps || fbs2) {
+                    // Multi-index select of a MULTI-DIM PACKED field
+                    // (`.is_page[2-x][0:0]` — CVA6 cva6_tlb page_match, genvar
+                    // indices fold to constants).  Walk the field's declared
+                    // packed dims; each Indexes() entry consumes one dim
+                    // (stride = product of remaining dim widths), and a
+                    // trailing part_select entry windows the current dim.
+                    if (field_ok && fvs && fvs->Exprs()) {
+                        // Collect (size, low) per dim, outer→inner.
+                        std::vector<std::pair<int,int>> fdims;
+                        const UHDM::any* cur = field_ts;
+                        while (cur) {
+                            const UHDM::VectorOfrange* rgs = nullptr;
+                            const UHDM::any* next = nullptr;
+                            if (cur->UhdmType() == uhdmlogic_typespec) {
+                                auto lt2 = any_cast<const UHDM::logic_typespec*>(cur);
+                                rgs = lt2->Ranges();
+                                if (lt2->Elem_typespec())
+                                    next = lt2->Elem_typespec()->Actual_typespec();
+                            } else if (cur->UhdmType() == uhdmpacked_array_typespec) {
+                                auto pt2 = any_cast<const UHDM::packed_array_typespec*>(cur);
+                                rgs = pt2->Ranges();
+                                if (pt2->Elem_typespec())
+                                    next = pt2->Elem_typespec()->Actual_typespec();
+                            }
+                            if (rgs)
+                                for (auto r : *rgs) {
+                                    RTLIL::SigSpec l = import_expression(r->Left_expr(), input_mapping);
+                                    RTLIL::SigSpec rr = import_expression(r->Right_expr(), input_mapping);
+                                    if (l.is_fully_const() && rr.is_fully_const())
+                                        fdims.push_back({std::abs(l.as_const().as_int() -
+                                                                  rr.as_const().as_int()) + 1,
+                                                         std::min(l.as_const().as_int(),
+                                                                  rr.as_const().as_int())});
+                                    else { field_ok = false; break; }
+                                }
+                            cur = next;
+                            if (!field_ok) break;
+                        }
+                        // The walk is only bit-accurate when the collected dims
+                        // fully tile the field (innermost dim = bit range).
+                        {
+                            long prod = 1;
+                            for (auto& d : fdims) prod *= d.first;
+                            if (prod != field_width) field_ok = false;
+                        }
+                        size_t di = 0;
+                        for (auto sel : *fvs->Exprs()) {
+                            if (!field_ok) break;
+                            if (di >= fdims.size()) { field_ok = false; break; }
+                            // stride of dim di = product of inner dim widths
+                            // (in bits within the field)
+                            int stride = 1;
+                            for (size_t d2 = di + 1; d2 < fdims.size(); d2++)
+                                stride *= fdims[d2].first;
+                            if (sel->UhdmType() == uhdmpart_select) {
+                                auto ps2 = any_cast<const UHDM::part_select*>(sel);
+                                RTLIL::SigSpec l = import_expression(ps2->Left_range(), input_mapping);
+                                RTLIL::SigSpec rr = import_expression(ps2->Right_range(), input_mapping);
+                                if (l.is_fully_const() && rr.is_fully_const()) {
+                                    int lo = std::min(l.as_const().as_int(), rr.as_const().as_int());
+                                    int w = std::abs(l.as_const().as_int() -
+                                                     rr.as_const().as_int()) + 1;
+                                    int rel = lo - fdims[di].second;
+                                    if (rel >= 0 && rel + w <= fdims[di].first) {
+                                        field_offset += rel * stride;
+                                        field_width = w * stride;
+                                    } else field_ok = false;
+                                } else field_ok = false;
+                            } else {
+                                RTLIL::SigSpec ix = import_expression(
+                                    any_cast<const expr*>(sel), input_mapping);
+                                if (ix.is_fully_const()) {
+                                    int iv = ix.as_const().as_int() - fdims[di].second;
+                                    if (iv >= 0 && iv < fdims[di].first) {
+                                        field_offset += iv * stride;
+                                        field_width = stride;
+                                    } else field_ok = false;  // OOB → X fallback
+                                } else field_ok = false;      // dynamic — not yet
+                            }
+                            di++;
+                        }
+                    }
+                } else if (fr || fps || fbs2 || fvs) {
                     field_ok = false;  // field on a partial (row) slice — bail
                 }
                 if (idx_ok && field_ok && any_dyn) {
@@ -8558,7 +8904,8 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                         base_name.c_str(), nsel, field_width);
                     return RTLIL::SigSpec(out);
                 }
-                if (idx_ok && field_ok && !any_dyn && nsel == dims.size() && nsel >= 2) {
+                if (idx_ok && field_ok && !any_dyn && nsel == dims.size() &&
+                    (nsel >= 2 || fvs)) {
                     // All-constant MULTI-index element (or field) read: plain
                     // slice of the flat wire.
                     int off = field_offset;
@@ -9469,13 +9816,36 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                         rts = sv->Typespec();
                     else if (auto sn = dynamic_cast<const UHDM::struct_net*>(kv.first))
                         rts = sn->Typespec();
+                    else if (auto po = dynamic_cast<const UHDM::port*>(kv.first))
+                        rts = po->Typespec();
                     if (rts) {
                         if (auto ats = rts->Actual_typespec()) {
-                            if (ats->UhdmType() == uhdmstruct_typespec)
-                                st = any_cast<const UHDM::struct_typespec*>(ats);
+                            // A `parameter type` typed net keeps the
+                            // DECLARATION DEFAULT — substitute the instance
+                            // binding (CVA6 cva6_ptw shared_tlb_update_o:
+                            // tlb_update_cva6_t; without this the [x][y]
+                            // indices of .is_page[x][y] were DROPPED by the
+                            // string fallback and the write hit the whole
+                            // field).
+                            const UHDM::typespec* r =
+                                resolve_type_param_typespec(ats, inst);
+                            if (r && r->UhdmType() == uhdmstruct_typespec)
+                                st = any_cast<const UHDM::struct_typespec*>(r);
                         }
                     }
                     if (st) break;
+                }
+                // Base ref's own typespec as a fallback (the wire_map object
+                // may be a port with no typespec).
+                if (!st && base_ref->Actual_group()) {
+                    if (auto e = dynamic_cast<const UHDM::expr*>(base_ref->Actual_group())) {
+                        if (e->Typespec() && e->Typespec()->Actual_typespec()) {
+                            const UHDM::typespec* r = resolve_type_param_typespec(
+                                e->Typespec()->Actual_typespec(), inst);
+                            if (r && r->UhdmType() == uhdmstruct_typespec)
+                                st = any_cast<const UHDM::struct_typespec*>(r);
+                        }
+                    }
                 }
             }
 
@@ -9492,8 +9862,8 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                     const UHDM::typespec* mts_actual = nullptr;
                     if (auto mts = m->Typespec())
                         if (auto ats = mts->Actual_typespec()) {
-                            mts_actual = ats;
-                            mw = get_width_from_typespec(ats, inst);
+                            mts_actual = resolve_type_param_typespec(ats, inst);
+                            mw = get_width_from_typespec(mts_actual, inst);
                         }
                     if (std::string(m->VpiName()) == field_name) {
                         field_ts_actual = mts_actual;
@@ -11010,6 +11380,24 @@ bool UhdmImporter::flat_struct_array_geom(const std::string& base_name,
             if (pn->Elements() && !pn->Elements()->empty())
                 st = inner_struct((*pn->Elements())[0]);
             if (st) rngs = pn->Ranges();
+        } else if (auto e = dynamic_cast<const UHDM::expr*>(obj)) {
+            // Plain net/var whose OWN typespec is a packed_array_typespec of
+            // a struct — the shape an ANONYMOUS `struct packed {...} [N-1:0]`
+            // declaration produces (CVA6 cva6_tlb tags_q/content_q).
+            const UHDM::ref_typespec* rts = e->Typespec();
+            if (rts && rts->Actual_typespec() &&
+                rts->Actual_typespec()->UhdmType() == uhdmpacked_array_typespec) {
+                auto pat = any_cast<const UHDM::packed_array_typespec*>(
+                    rts->Actual_typespec());
+                if (pat->Elem_typespec() && pat->Elem_typespec()->Actual_typespec()) {
+                    const UHDM::typespec* ets = resolve_type_param_typespec(
+                        pat->Elem_typespec()->Actual_typespec(), inst);
+                    if (ets && ets->UhdmType() == uhdmstruct_typespec) {
+                        st = any_cast<const UHDM::struct_typespec*>(ets);
+                        rngs = pat->Ranges();
+                    }
+                }
+            }
         }
     };
     try_obj(actual_group);
@@ -11118,11 +11506,15 @@ bool UhdmImporter::calculate_struct_member_offset(const typespec* ts, const std:
             std::string current_member_name = std::string(member->VpiName());
 
             if (current_member_name == member_name) {
-                // Found the member
+                // Found the member.  Resolve a `parameter type` DECLARATION
+                // DEFAULT to the instance-bound type so the NEXT path level
+                // can descend into the bound struct's members (cva6_tlb's
+                // anonymous struct member `pte_cva6_t pte` defaults to a
+                // 1-bit logic — content_q[i].pte.g returned X).
                 if (auto ref_ts = member->Typespec()) {
                     if (auto actual_ts = ref_ts->Actual_typespec()) {
-                        found_member_ts = actual_ts;
-                        member_width = get_width_from_typespec(actual_ts, inst);
+                        found_member_ts = resolve_type_param_typespec(actual_ts, inst);
+                        member_width = get_width_from_typespec(found_member_ts, inst);
                     }
                 }
                 found = true;

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -2746,59 +2746,70 @@ int UhdmImporter::get_width(const any* uhdm_obj, const UHDM::scope* inst) {
     return 1;
 }
 
+// A struct member (or net) typed by a `parameter type` keeps the
+// DECLARATION DEFAULT typespec (`parameter type cbo_t = logic` → 1 bit)
+// in the elaborated model — Surelog doesn't propagate the binding into
+// shared typespec_members.  Detect it by matching against the DEF
+// module's type-parameter defaults (same object or same source location)
+// and substitute the INSTANCE's bound type (CVA6 store_buffer's queue
+// struct sized cbo_op at 1 bit instead of 8 — 532 vs 560-bit queues).
+// Returns the input unchanged when no binding applies, so callers can
+// use it unconditionally (also needed by calculate_struct_member_offset:
+// cva6_tlb's anonymous struct member `pte_cva6_t pte` must descend into
+// the BOUND struct's members, not the 1-bit default).
+const UHDM::typespec* UhdmImporter::resolve_type_param_typespec(
+        const UHDM::typespec* ts_c, const UHDM::scope* inst) {
+    if (!ts_c) return ts_c;
+    auto mi = dynamic_cast<const UHDM::module_inst*>(
+        current_instance ? (const UHDM::scope*)current_instance : inst);
+    if (!mi) return ts_c;
+    bool has_tp = false;
+    if (mi->Parameters())
+        for (auto p : *mi->Parameters())
+            if (p->UhdmType() == uhdmtype_parameter) { has_tp = true; break; }
+    if (!has_tp || !uhdm_design || !uhdm_design->AllModules()) return ts_c;
+    std::string dn = std::string(mi->VpiDefName());
+    const UHDM::module_inst* def = nullptr;
+    for (auto m : *uhdm_design->AllModules())
+        if (std::string(m->VpiDefName()) == dn) { def = m; break; }
+    if (!def || def == mi || !def->Parameters()) return ts_c;
+    for (auto dp : *def->Parameters()) {
+        if (dp->UhdmType() != uhdmtype_parameter) continue;
+        auto dtp = any_cast<const UHDM::type_parameter*>(dp);
+        const UHDM::typespec* d_at =
+            (dtp->Typespec() ? dtp->Typespec()->Actual_typespec() : nullptr);
+        if (!d_at) continue;
+        bool match = (d_at == ts_c) ||
+                     (d_at->UhdmType() == ts_c->UhdmType() &&
+                      d_at->VpiLineNo() == ts_c->VpiLineNo() &&
+                      d_at->VpiColumnNo() == ts_c->VpiColumnNo() &&
+                      d_at->VpiFile() == ts_c->VpiFile());
+        if (!match) continue;
+        for (auto ip : *mi->Parameters()) {
+            if (ip->UhdmType() != uhdmtype_parameter) continue;
+            if (ip->VpiName() != dp->VpiName()) continue;
+            auto itp = any_cast<const UHDM::type_parameter*>(ip);
+            if (itp->Typespec() && itp->Typespec()->Actual_typespec() &&
+                itp->Typespec()->Actual_typespec() != ts_c) {
+                log("UHDM: type-param member default '%s' -> instance-bound type\n",
+                    std::string(dp->VpiName()).c_str());
+                return itp->Typespec()->Actual_typespec();
+            }
+        }
+    }
+    return ts_c;
+}
+
 // Helper function to get width from typespec
 int UhdmImporter::get_width_from_typespec(const UHDM::any* typespec, const UHDM::scope* inst) {
     if (!typespec) return 1;
 
-    // A struct member (or net) typed by a `parameter type` keeps the
-    // DECLARATION DEFAULT typespec (`parameter type cbo_t = logic` → 1 bit)
-    // in the elaborated model — Surelog doesn't propagate the binding into
-    // shared typespec_members.  Detect it by matching against the DEF
-    // module's type-parameter defaults (same object or same source location)
-    // and substitute the INSTANCE's bound type (CVA6 store_buffer's queue
-    // struct sized cbo_op at 1 bit instead of 8 — 532 vs 560-bit queues).
-    if (auto mi = dynamic_cast<const UHDM::module_inst*>(
-            current_instance ? (const UHDM::scope*)current_instance : inst)) {
-        bool has_tp = false;
-        if (mi->Parameters())
-            for (auto p : *mi->Parameters())
-                if (p->UhdmType() == uhdmtype_parameter) { has_tp = true; break; }
-        if (has_tp && uhdm_design && uhdm_design->AllModules()) {
-            std::string dn = std::string(mi->VpiDefName());
-            const UHDM::module_inst* def = nullptr;
-            for (auto m : *uhdm_design->AllModules())
-                if (std::string(m->VpiDefName()) == dn) { def = m; break; }
-            if (def && def != mi && def->Parameters()) {
-                auto ts_c = dynamic_cast<const UHDM::typespec*>(typespec);
-                for (auto dp : *def->Parameters()) {
-                    if (dp->UhdmType() != uhdmtype_parameter) continue;
-                    auto dtp = any_cast<const UHDM::type_parameter*>(dp);
-                    const UHDM::typespec* d_at =
-                        (dtp->Typespec() ? dtp->Typespec()->Actual_typespec() : nullptr);
-                    if (!d_at || !ts_c) continue;
-                    bool match = (d_at == ts_c) ||
-                                 (d_at->UhdmType() == ts_c->UhdmType() &&
-                                  d_at->VpiLineNo() == ts_c->VpiLineNo() &&
-                                  d_at->VpiColumnNo() == ts_c->VpiColumnNo() &&
-                                  d_at->VpiFile() == ts_c->VpiFile());
-                    if (!match) continue;
-                    for (auto ip : *mi->Parameters()) {
-                        if (ip->UhdmType() != uhdmtype_parameter) continue;
-                        if (ip->VpiName() != dp->VpiName()) continue;
-                        auto itp = any_cast<const UHDM::type_parameter*>(ip);
-                        if (itp->Typespec() && itp->Typespec()->Actual_typespec() &&
-                            itp->Typespec()->Actual_typespec() != ts_c) {
-                            log("UHDM: type-param member default '%s' -> instance-bound type\n",
-                                std::string(dp->VpiName()).c_str());
-                            return get_width_from_typespec(
-                                itp->Typespec()->Actual_typespec(), inst);
-                        }
-                    }
-                }
-            }
-        }
+    if (auto ts_c = dynamic_cast<const UHDM::typespec*>(typespec)) {
+        const UHDM::typespec* bound = resolve_type_param_typespec(ts_c, inst);
+        if (bound != ts_c)
+            return get_width_from_typespec(bound, inst);
     }
-    
+
     try {
         log("UHDM: Analyzing typespec for width determination\n");
         log("UHDM: Typespec UhdmType = %d\n", typespec->UhdmType());

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -3462,16 +3462,36 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
     // and a full-width update would conflict with them ("Drivers conflicting
     // with a constant 1'0 driver").
     std::map<std::string, std::set<int>> comb_written_bits;
+    std::set<std::string> comb_written_unreliable;
     for (const auto& s : assigned_signals) {
-        if (!s.lhs_expr) continue;
+        if (!s.lhs_expr) {
+            // for-loop write with a dynamic/loop-var index — the touched bits
+            // are unknowable here; force the full-wire update for this base.
+            comb_written_unreliable.insert(s.name);
+            continue;
+        }
         RTLIL::SigSpec ls = import_expression(s.lhs_expr);
+        bool touches_base = false;
         for (const auto& ch : ls.chunks())
             if (ch.wire) {
                 std::string wn = ch.wire->name.str();
                 if (!wn.empty() && wn[0] == '\\') wn = wn.substr(1);
                 for (int b = 0; b < ch.width; b++)
                     comb_written_bits[wn].insert(ch.offset + b);
+                if (wn == s.name || wn.rfind(s.name + "[", 0) == 0)
+                    touches_base = true;
             }
+        // An indexed struct-field LHS whose indices are LOOP VARS
+        // (`upd.is_page[x][y]` — CVA6 cva6_ptw shared_tlb_update_o) can't
+        // resolve here (unrolling hasn't run), so its bits land on a scratch
+        // wire and the base bits are UNKNOWN — fall back to the full-wire
+        // update for that signal or the field writes never leave the process.
+        if (s.lhs_expr->VpiType() == vpiHierPath && !touches_base)
+            comb_written_unreliable.insert(s.name);
+        if (mode_debug)
+            log("    comb_written probe: name=%s type=%d ls=%s touches=%d\n",
+                s.name.c_str(), s.lhs_expr->VpiType(),
+                log_signal(ls), touches_base ? 1 : 0);
     }
 
     // Create sync always rule BEFORE statement import so task/function handlers can add entries
@@ -3486,6 +3506,7 @@ void UhdmImporter::import_always_comb(const process_stmt* uhdm_process, RTLIL::P
             auto wb = base_w ? comb_written_bits.find(sig_name)
                              : comb_written_bits.end();
             if (base_w && wb != comb_written_bits.end() &&
+                !comb_written_unreliable.count(sig_name) &&
                 (int)wb->second.size() < base_w->width &&
                 (int)temp_wire->width == base_w->width) {
                 // Partially-written base wire: drive only the written bit runs.
@@ -7730,12 +7751,27 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::Process* p
                 // iteration order flips that so the FIRST matching iteration's
                 // write is the one that survives.
                 bool has_break = body_has_break(fl_body);
+                // (index, break-flag) per iteration, for the post-loop value of
+                // the loop variable.
+                std::vector<std::pair<int, RTLIL::SigSpec>> brk_flags;
+                bool brk_idx_emitted = false;
                 if (has_break) {
                     log("    Comb for loop body has `break` — iterating in "
                         "reverse so first-match-wins semantics hold\n");
                     for (int64_t i = loop_end; i >= fl_start; i -= fl_inc_val) {
                         loop_values[fl_var] = (int)i;
+                        // Per-iteration break flag, defaulted to 0 in the root
+                        // case; the vpiBreak handler sets it to 1 under the
+                        // branch conditions that reach the break.
+                        RTLIL::Wire* bw = module->addWire(NEW_ID, 1);
+                        proc->root_case.actions.push_back(
+                            RTLIL::SigSig(RTLIL::SigSpec(bw),
+                                          RTLIL::SigSpec(RTLIL::State::S0)));
+                        RTLIL::SigSpec saved_bf = current_break_flag;
+                        current_break_flag = RTLIL::SigSpec(bw);
                         import_statement_comb(fl_body, proc);
+                        current_break_flag = saved_bf;
+                        brk_flags.push_back({(int)i, RTLIL::SigSpec(bw)});
                     }
                 } else {
                     for (int64_t i = fl_start; i <= loop_end; i += fl_inc_val) {
@@ -7747,6 +7783,37 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::Process* p
                 // (e.g. y = k - {a,b} should see k = final value after loop exits)
                 int64_t final_val = fl_inclusive ? fl_end + fl_inc_val : fl_end;
                 loop_values[fl_var] = (int)final_val;
+
+                // With a `break`, the post-loop value of the loop variable is
+                // NOT the static final value: it is the index of the FIRST
+                // iteration that broke, else N.  Code routinely tests exactly
+                // that (`if (i == NrPMPEntries)` = "nothing matched" — CVA6
+                // pmp.sv, whose allow_o was always taking the no-match
+                // fallback).  Build the priority mux and let post-loop reads
+                // resolve to it instead of the constant.
+                if (has_break && !brk_flags.empty()) {
+                    RTLIL::Wire* var_wire = name_map.count(fl_var)
+                                                ? name_map[fl_var] : nullptr;
+                    if (!var_wire)
+                        var_wire = module->wire(RTLIL::escape_id(fl_var));
+                    if (var_wire) {
+                        int w = var_wire->width;
+                        RTLIL::SigSpec sel = RTLIL::Const((int)final_val, w);
+                        // brk_flags is in DESCENDING index order, so folding in
+                        // order leaves the LOWEST index outermost = highest
+                        // priority (first break wins).
+                        for (auto& bf : brk_flags)
+                            sel = module->Mux(NEW_ID, sel,
+                                              RTLIL::SigSpec(RTLIL::Const(bf.first, w)),
+                                              bf.second);
+                        loop_values.erase(fl_var);
+                        emit_comb_assign(RTLIL::SigSpec(var_wire), sel, proc);
+                        brk_idx_emitted = true;
+                        log("    Comb for loop `break`: %s = first-break index "
+                            "priority mux (%zu iterations)\n",
+                            fl_var.c_str(), brk_flags.size());
+                    }
+                }
                 // Also drive the actual `\<fl_var>` wire with that final
                 // value via the standard comb temp-wire path.  Without
                 // this the post-loop wire stays undriven, so when ANOTHER
@@ -7757,8 +7824,9 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::Process* p
                 // if the variable corresponds to a module wire (skip
                 // locally-declared `for (int i = ...)` loop vars, which
                 // are loop_values-only).
-                if (RTLIL::Wire* var_wire = name_map.count(fl_var)
-                        ? name_map[fl_var] : nullptr) {
+                if (RTLIL::Wire* var_wire = brk_idx_emitted
+                        ? nullptr
+                        : (name_map.count(fl_var) ? name_map[fl_var] : nullptr)) {
                     int w = var_wire->width;
                     emit_comb_assign(RTLIL::SigSpec(var_wire),
                                      RTLIL::Const((int)final_val, w),
@@ -7770,6 +7838,17 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::Process* p
             }
             break;
         }
+        case vpiBreak:
+            // `break` inside an unrolled comb for-loop: record that THIS
+            // iteration terminated the loop, so the post-loop value of the
+            // loop variable can be built as a priority mux (CVA6 pmp.sv).
+            // Unconditional here means the branch reaching it always breaks.
+            if (!current_break_flag.empty())
+                proc->root_case.actions.push_back(
+                    RTLIL::SigSig(current_break_flag, RTLIL::SigSpec(RTLIL::State::S1)));
+            break;
+        case vpiContinue:
+            break;
         default:
             log_warning("Unsupported statement type in comb context: %d\n", stmt_type);
             break;
@@ -8837,6 +8916,32 @@ RTLIL::SigSpec UhdmImporter::import_func_call_comb(const func_call* fc, RTLIL::P
         }
     }
 
+    // Seed function-local DECLARATION INITIALIZERS (`logic [2:0] addr_tmp =
+    // {(addr[2] && Cfg.IS_XLEN64), addr[1:0]}`) — the Variables() loop above
+    // mapped every local to Sx, but a local whose only "assignment" is its
+    // initializer must start at that value, not X.  Evaluate against
+    // func_mapping so references to the bound call arguments resolve (CVA6
+    // store_unit data_align: addr_tmp stayed X, the case selector became 3'x
+    // and the byte-rotation collapsed to a passthrough).  Done after the
+    // current_comb_values merge so inits can also read module signals.
+    if (func_def->Variables()) {
+        for (auto var : *func_def->Variables()) {
+            std::string var_name = std::string(var->VpiName());
+            if (var_name == func_name) continue;
+            auto v = dynamic_cast<const UHDM::variables*>(var);
+            if (!v || !v->Expr()) continue;
+            auto init_expr = dynamic_cast<const expr*>(v->Expr());
+            if (!init_expr) continue;
+            RTLIL::SigSpec init = import_expression(init_expr, &func_mapping);
+            if (init.empty()) continue;
+            int width = get_width(var, current_instance);
+            if (width <= 0) width = init.size();
+            if (init.size() < width) init.extend_u0(width);
+            else if (init.size() > width) init = init.extract(0, width);
+            func_mapping[var_name] = init;
+        }
+    }
+
     // Inline function body
     if (auto func_stmt = func_def->Stmt()) {
         inline_func_body_comb(func_stmt, proc, func_mapping, func_name, context, "", process_src);
@@ -8945,6 +9050,23 @@ void UhdmImporter::inline_func_body_comb(const any* stmt, RTLIL::Process* proc,
 
                     // Map to initial undefined - will be updated by assignments
                     func_mapping[var_name] = RTLIL::SigSpec(RTLIL::State::Sx, width);
+
+                    // Block-local declaration initializer (`logic [2:0] t =
+                    // f(arg);`) — same rule as the function-level Variables()
+                    // seeding in import_func_call_comb: without it the local
+                    // reads X until an explicit body assignment.
+                    if (auto v = dynamic_cast<const UHDM::variables*>(var)) {
+                        if (auto init_expr = dynamic_cast<const expr*>(v->Expr())) {
+                            RTLIL::SigSpec init =
+                                import_expression(init_expr, &func_mapping);
+                            if (!init.empty()) {
+                                if (init.size() < width) init.extend_u0(width);
+                                else if (init.size() > width)
+                                    init = init.extract(0, width);
+                                func_mapping[var_name] = init;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -9031,6 +9153,69 @@ void UhdmImporter::inline_func_body_comb(const any* stmt, RTLIL::Process* proc,
                 if (lhs_expr->VpiType() == vpiRefObj) {
                     const ref_obj* lhs_ref = any_cast<const ref_obj*>(lhs_expr);
                     lhs_name = std::string(lhs_ref->VpiName());
+                } else if (auto lhs_var =
+                               dynamic_cast<const UHDM::variables*>(lhs_expr)) {
+                    // A DECLARATION INITIALIZER (`logic [2:0] addr_tmp =
+                    // {(addr[2] && …), addr[1:0]};`) — Surelog emits it as an
+                    // assignment statement whose LHS is the logic_var itself,
+                    // not a ref_obj.  Without this the init was skipped and the
+                    // local stayed X (CVA6 store_unit data_align: the case
+                    // selector addr_tmp read 3'x, so the byte rotation
+                    // collapsed to a passthrough).
+                    lhs_name = std::string(lhs_var->VpiName());
+                } else if (lhs_expr->VpiType() == vpiPartSelect ||
+                           lhs_expr->VpiType() == vpiBitSelect) {
+                    // Part/bit-select write to a function LOCAL
+                    // (`data_tmp[CVA6Cfg.XLEN-1:0] = {…}` in CVA6 store_unit's
+                    // data_align — the range survives as a part_select when its
+                    // bounds come from an elaborated module parameter).  With a
+                    // constant range, splice the RHS into the tracked in-flight
+                    // value.  Previously lhs_name stayed empty and the write
+                    // was DROPPED silently (d_tmp kept its all-zero init).
+                    std::string base;
+                    int sel_off = -1, sel_w = -1;
+                    if (lhs_expr->VpiType() == vpiPartSelect) {
+                        auto ps = any_cast<const part_select*>(lhs_expr);
+                        base = std::string(!ps->VpiName().empty()
+                                               ? ps->VpiName() : ps->VpiDefName());
+                        RTLIL::SigSpec l = import_expression(
+                            any_cast<const expr*>(ps->Left_range()), &func_mapping);
+                        RTLIL::SigSpec r = import_expression(
+                            any_cast<const expr*>(ps->Right_range()), &func_mapping);
+                        if (l.is_fully_const() && r.is_fully_const()) {
+                            int li = l.as_const().as_int(), ri = r.as_const().as_int();
+                            sel_off = std::min(li, ri);
+                            sel_w = std::abs(li - ri) + 1;
+                        }
+                    } else {
+                        auto bs = any_cast<const bit_select*>(lhs_expr);
+                        base = std::string(bs->VpiName());
+                        RTLIL::SigSpec ix =
+                            import_expression(bs->VpiIndex(), &func_mapping);
+                        if (ix.is_fully_const()) {
+                            sel_off = ix.as_const().as_int();
+                            sel_w = 1;
+                        }
+                    }
+                    auto fit = base.empty() ? func_mapping.end()
+                                            : func_mapping.find(base);
+                    if (fit != func_mapping.end() && sel_off >= 0 &&
+                        sel_off + sel_w <= fit->second.size()) {
+                        RTLIL::SigSpec cur = fit->second;
+                        RTLIL::SigSpec r2 = rhs;
+                        if (r2.size() < sel_w) r2.extend_u0(sel_w);
+                        else if (r2.size() > sel_w) r2 = r2.extract(0, sel_w);
+                        cur.replace(sel_off, r2);
+                        func_mapping[base] = cur;
+                        log("      inline_func_body_comb: %s[%d+:%d] = %s\n",
+                            base.c_str(), sel_off, sel_w, log_signal(r2).c_str());
+                    } else if (!base.empty()) {
+                        log_warning(
+                            "inline_func_body_comb: dropped part/bit-select "
+                            "write to '%s' (dynamic or out-of-range select)\n",
+                            base.c_str());
+                    }
+                    break;
                 }
             }
 
@@ -10722,9 +10907,12 @@ bool UhdmImporter::emit_dynamic_packed_select_write(
     // still element-indexes; only a genuinely 1-bit-element single entry is a
     // plain vector left to the bit-write paths.
     if (outer_size <= 1 && elem_w <= 1) return false;
-    if (elem_w <= 1 && !idx1_e) return false;      // 1-bit "elements" = plain
-                                                   // vector bit write; existing
-                                                   // paths handle that
+    // NOTE: elem_w == 1 (plain vector dynamic BIT write,
+    // `ldbuf_valid_d[windex] = 1'b1` in CVA6 load_unit's CaseRule context)
+    // is handled HERE too — the old defer-to-"existing paths" left the write
+    // to the generic assignment fallback, which imported the LHS as a READ
+    // (shiftx aux wire) and silently dropped the store: the load buffer's
+    // valid bits never set and req_port_o.data_id stuck at 0.
 
     // Two-level decomposition: an ELEMENT shift (element offset in the flat
     // wire) and an INNER shift (bit offset within the element).  The inner
@@ -14092,6 +14280,15 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
             break;
         }
 
+        case vpiBreak:
+            // See the Process* overload: drive this iteration's break flag
+            // under the enclosing branch conditions.
+            if (!current_break_flag.empty())
+                case_rule->actions.push_back(
+                    RTLIL::SigSig(current_break_flag, RTLIL::SigSpec(RTLIL::State::S1)));
+            break;
+        case vpiContinue:
+            break;
         default:
             if (mode_debug)
                 log("        Unsupported statement type in case: %s (vpiType=%d)\n",

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -938,8 +938,21 @@ void UhdmImporter::extract_assigned_signals(const any* stmt, std::vector<Assigne
                     sig.is_part_select = false;
                     sig.lhs_expr = nullptr;
                 }
-                for (const auto& existing : signals)
-                    if (existing.name == sig.name) return;
+                for (auto& existing : signals)
+                    if (existing.name == sig.name) {
+                        // A loop-body write with UNKNOWABLE bits (indexed by
+                        // the loop var — lhs_expr was nulled above) must widen
+                        // the surviving entry to the FULL wire, or the
+                        // written-bits scan misses the loop's bits and the
+                        // STa update drops them (CVA6 cva6_ptw
+                        // `shared_tlb_update_o.is_page[x][y]` after the
+                        // top-level `.valid`/`.pad` field writes).
+                        if (!sig.lhs_expr && existing.lhs_expr) {
+                            existing.is_part_select = false;
+                            existing.lhs_expr = nullptr;
+                        }
+                        return;
+                    }
                 signals.push_back(sig);
             };
             // A LOCALLY-declared loop var (`for (int i = ...)`) is

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -413,6 +413,12 @@ struct UhdmImporter {
     // is only correct for a RHS read; on an LHS it would make the write target a
     // constant and drop the write).
     bool comb_lhs_keep_base = false;
+    // While unrolling a comb for-loop whose body contains `break`, the 1-bit
+    // flag wire for the CURRENT iteration; the vpiBreak handler drives it to 1
+    // under the branch conditions that reach the break, so the post-loop value
+    // of the loop variable can be built as a priority mux (CVA6 pmp.sv
+    // `for (i…) … break;  if (i == NrPMPEntries) …`).
+    RTLIL::SigSpec current_break_flag;
 
     // When true, suppress current_comb_values read/write so that
     // always_ff body processing uses original register values (NB semantics)
@@ -1043,6 +1049,10 @@ struct UhdmImporter {
 
     // Width extraction helpers
     int get_width_from_typespec(const UHDM::any* typespec, const UHDM::scope* inst = nullptr);
+    // Substitute a `parameter type` DECLARATION-DEFAULT typespec with the
+    // instance-bound type (returns input unchanged when no binding applies).
+    const UHDM::typespec* resolve_type_param_typespec(const UHDM::typespec* ts,
+                                                      const UHDM::scope* inst = nullptr);
     // Materialize a whole-accessed / multi-dim unpacked array as ONE flat
     // canonical wire (product of all dims × element width) plus per-ROW
     // alias wires `name[k]` connected to its slices, stamping the

--- a/test/anon_struct_packed_dim/dut.sv
+++ b/test/anon_struct_packed_dim/dut.sv
@@ -1,0 +1,87 @@
+// CVA6 cva6_tlb tags_q/content_q repros (anonymous packed struct array):
+// 1. SURELOG: `struct packed { a; b; } [N-1:0] x;` LOST the outer [N-1:0]
+//    whenever the struct has MORE THAN ONE member — compileTypespec skipped
+//    only a single Struct_union_member sibling before looking for the
+//    Packed_dimension, so the net collapsed to ONE element (cva6_tlb's
+//    4-entry TLB became 1 entry; entries 1-3 read X → no hits).
+// 2. Element WRITE `q_n[i] = {…}` wrote a SINGLE BIT instead of the full
+//    element: import_bit_select's element-width detection had no branch for
+//    a packed_array_typespec on a plain net (cva6_tlb's update path never
+//    stored a TLB entry).
+// 3. Multi-index field READ `tags_q[i].is_page[2-x][0:0]` (2D packed member
+//    of the anonymous-struct element, genvar indices): the N-index hier_path
+//    branch had no var_select tail and flat_struct_array_geom no
+//    packed_array_typespec-on-net shape (cva6_tlb page_match read X).
+// 4. Range select of the LAST dim of a plain 3D packed vector
+//    `vvm[i][0][2:x]` (var_select whose last index is a part_select node):
+//    the packed multi-dim branch bailed on the non-const import and the
+//    read collapsed to one wrong bit (cva6_tlb vaddr_level_match).
+typedef struct packed {
+  logic [7:0] ppn;
+  logic       g;
+  logic       v;
+} pte_t;
+
+module anon_struct_packed_dim (
+  input  logic [39:0] din,
+  input  logic [3:0]  en,
+  output logic [3:0]  o_g,
+  output logic [7:0]  o_ppn,
+  output logic [39:0] o_all,
+  output logic [39:0] o_q,
+  output logic [3:0]  o_pm,
+  output logic [11:0] o_lvl
+);
+  struct packed {
+    pte_t pte;
+    pte_t gpte;
+  } [1:0] content_q, q_n;
+
+  assign content_q = din;
+  assign o_all = content_q;
+
+  always_comb begin
+    o_g = '0;
+    for (int unsigned i = 0; i < 2; i++) begin
+      o_g[i] = content_q[i].pte.g;
+    end
+    o_ppn = content_q[0].gpte.ppn;
+  end
+
+  // element write (cva6_tlb tags_n[i] = {...}) + per-field else write
+  always_comb begin
+    q_n = '0;
+    for (int unsigned i = 0; i < 2; i++) begin
+      if (en[i]) begin
+        q_n[i] = {din[19:12], din[11], din[10], din[9:2], din[1], din[0]};
+      end else begin
+        q_n[i].pte.v = 1'b0;
+      end
+    end
+  end
+  assign o_q = q_n;
+
+  // 2D packed member + genvar indices + [0:0] part-select (page_match shape);
+  // reuses the pte fields: ppn[7:0] read as ppn[x][0:0] windows via 2 dims
+  struct packed {
+    logic [15:0]     vpn;
+    logic [1:0][0:0] is_page;
+    logic            valid;
+    logic            pad;
+  } [1:0] tq;
+  assign tq = din;
+  for (genvar gi = 0; gi < 2; gi++) begin : g_i
+    for (genvar gx = 1; gx < 3; gx++) begin : g_x
+      assign o_pm[gi*2+gx-1] = &(tq[gi].is_page[2-gx][0:0] | (~en[0]));
+    end
+  end
+
+  // plain 3D packed vector, range select of the last dim by genvar
+  logic [3:0][0:0][2:0] vvm;
+  assign vvm = din[11:0];
+  for (genvar li = 0; li < 4; li++) begin : l_i
+    for (genvar lx = 0; lx < 3; lx++) begin : l_x
+      assign o_lvl[li*3+lx] = &vvm[li][0][2:lx];
+    end
+  end
+endmodule

--- a/test/anon_struct_packed_dim/test_slang_equiv.ys
+++ b/test/anon_struct_packed_dim/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top anon_struct_packed_dim
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename anon_struct_packed_dim gold
+design -stash gold
+read_slang dut.sv --top anon_struct_packed_dim
+hierarchy -check -top anon_struct_packed_dim
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename anon_struct_packed_dim gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/comb_partsel_after_struct_assign/dut.sv
+++ b/test/comb_partsel_after_struct_assign/dut.sv
@@ -1,0 +1,45 @@
+// CVA6 store_unit endian_data repro: a part-select write inside an if/case
+// arm, AFTER a whole-signal assign whose RHS is a struct FIELD, must target
+// the signal's own bits — not the struct field's offset.  The LHS import
+// received current_comb_values as input_mapping and substituted the base
+// (\ctrl slice / constant) for the write target, shifting the write by the
+// field offset (bit 39 of the AMO operand corrupted in CVA6 store_unit).
+typedef enum logic [7:0] {
+  OP_B = 8'd10, OP_H = 8'd20, OP_W = 8'd73
+} op_e;
+
+typedef struct packed {
+  logic        valid;
+  logic [63:0] data;
+  logic [7:0]  be;
+  op_e         op;
+} ctrl_t;
+
+module comb_partsel_after_struct_assign (
+  input  logic        mbe,
+  input  ctrl_t       ctrl,
+  input  logic [63:0] raw,
+  output logic [63:0] endian_data,
+  output logic [63:0] o_const_init
+);
+  // store_unit shape: struct-field init + byte-swap part-select arms
+  always_comb begin
+    endian_data = ctrl.data;
+    if (mbe) begin
+      case (ctrl.op)
+        OP_B: endian_data[7:0]  = ctrl.data[7:0];
+        OP_H: endian_data[15:0] = {ctrl.data[7:0], ctrl.data[15:8]};
+        OP_W: endian_data[31:0] = {ctrl.data[7:0], ctrl.data[15:8],
+                                   ctrl.data[23:16], ctrl.data[31:24]};
+        default: endian_data[63:0] = raw;
+      endcase
+    end
+  end
+
+  // constant-init variant: the write target collapsed to a CONSTANT LHS
+  // (the assignment was silently dropped)
+  always_comb begin
+    o_const_init = 64'd0;
+    if (mbe) o_const_init[7:0] = raw[7:0];
+  end
+endmodule

--- a/test/comb_partsel_after_struct_assign/test_slang_equiv.ys
+++ b/test/comb_partsel_after_struct_assign/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top comb_partsel_after_struct_assign
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename comb_partsel_after_struct_assign gold
+design -stash gold
+read_slang dut.sv --top comb_partsel_after_struct_assign
+hierarchy -check -top comb_partsel_after_struct_assign
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename comb_partsel_after_struct_assign gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/dyn_packed_multidim/dut.sv
+++ b/test/dyn_packed_multidim/dut.sv
@@ -1,0 +1,23 @@
+// CVA6 cva6_ptw repro (adjudicated against the behavioural RTL under
+// iverilog): a DYNAMIC index into a multi-dimensional PACKED array —
+// `vaddr_lvl[0][ptw_lvl_q[0]]` on `logic [A:0][B:0][8:0] vaddr_lvl`.
+// The packed multi-dim var_select path required ALL indices to be constant
+// and bailed otherwise, so the read fell through to a plain 1-BIT
+// bit_select: `ptw_pptr_n = {pte.ppn, vaddr_lvl[0][lvl], 3'b0}` lost 8 of
+// the element's 9 bits and every page-table pointer was mis-formed.
+// Fix: chained shiftx at Sigma (idx_k - low_k) * stride_k when any index is
+// dynamic, mirroring the unpacked/struct-array dynamic read paths.
+module dyn_packed_multidim (
+  input  logic [17:0] flat,
+  input  logic        lvl,
+  input  logic [1:0]  sel2,
+  output logic [8:0]  o_dyn,
+  output logic [8:0]  o_const,
+  output logic [8:0]  o_dyn_both
+);
+  logic [0:0][1:0][8:0] vaddr_lvl;
+  assign vaddr_lvl  = flat;
+  assign o_dyn      = vaddr_lvl[0][lvl];        // dynamic inner index
+  assign o_const    = vaddr_lvl[0][1];          // constant control
+  assign o_dyn_both = vaddr_lvl[sel2[1]][sel2[0]];  // both indices dynamic
+endmodule

--- a/test/dyn_packed_multidim/test_slang_equiv.ys
+++ b/test/dyn_packed_multidim/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dyn_packed_multidim
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dyn_packed_multidim gold
+design -stash gold
+read_slang dut.sv --top dyn_packed_multidim
+hierarchy -check -top dyn_packed_multidim
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dyn_packed_multidim gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/expr_width_cast/dut.sv
+++ b/test/expr_width_cast/dut.sv
@@ -1,0 +1,30 @@
+// CVA6 cva6_tlb tag-update repro: an EXPRESSION-width size cast
+// `((Cfg.PtLevels + HYP_EXT) * (Cfg.VpnLen / Cfg.PtLevels))'(vpn)` leaves an
+// integer_typespec with EMPTY VpiValue and the width in its Expr(); the
+// importer defaulted the cast to 32 bits, and inside the enclosing concat
+// the oversized cast STOLE the top 5 bits of the stored asid (TLB lookups
+// mismatched on asid).
+package ewc_pkg;
+  typedef struct packed {
+    int unsigned PtLevels;
+    int unsigned VpnLen;
+  } cfg_t;
+endpackage
+
+module expr_width_cast #(
+  parameter ewc_pkg::cfg_t Cfg = '{PtLevels: 3, VpnLen: 27},
+  parameter int unsigned HYP_EXT = 0
+)(
+  input  logic [26:0] vpn,
+  input  logic [15:0] asid,
+  output logic [44:0] tag
+);
+  always_comb begin
+    tag = {
+      asid,
+      ((Cfg.PtLevels + HYP_EXT) * (Cfg.VpnLen / Cfg.PtLevels))'(vpn),
+      1'b1,
+      1'b0
+    };
+  end
+endmodule

--- a/test/expr_width_cast/test_slang_equiv.ys
+++ b/test/expr_width_cast/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top expr_width_cast
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename expr_width_cast gold
+design -stash gold
+read_slang dut.sv --top expr_width_cast
+hierarchy -check -top expr_width_cast
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename expr_width_cast gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/failing_tests.txt
+++ b/test/failing_tests.txt
@@ -256,3 +256,17 @@ sva/extnets.sv
 # now re-resolves from a representative elaborated instance (elab_inst_by_def).
 # def_ctx_struct_param  (PASSES: runner classifies "UHDM succeeds where Verilog fails" as pass;
 #   kept documented here for the slang-miter verification pointer)
+
+# --- simple/mem2reg_bounds_tern: read_verilog is the WRONG side ---
+# `for (i=0;i<4;i++) mem[i] <= i == 0 ? base : mem[i-1]+1;` on `reg mem[0:2]`
+# (i==3 is an out-of-bounds write, i==0 an out-of-bounds read of mem[-1]).
+# Fixing the width-sensitive `==` constant fold (a 32-bit genvar value never
+# compared equal to a 64-bit literal, so `i == 0` folded FALSE on every
+# iteration) made the UHDM output match the behavioural RTL EXACTLY, which is
+# what newly exposes the disagreement with Yosys's own Verilog frontend.
+# ADJUDICATED with iverilog (UHDM netlist + read_verilog netlist + the
+# behavioural dut.v instantiated side by side, 40 clocked random vectors):
+#   UHDM-vs-RTL mismatches = 0     read_verilog-vs-RTL mismatches = 10
+# So this is an upstream read_verilog OOB bug, not a UHDM regression;
+# Miter-Formal stays 0 and only equiv_induct flags it.
+simple/mem2reg_bounds_tern.v

--- a/test/func_local_decl_init/dut.sv
+++ b/test/func_local_decl_init/dut.sv
@@ -1,0 +1,41 @@
+// CVA6 store_unit data_align repros (dynamic SSA function inline):
+// 1. A function-local whose ONLY assignment is its DECLARATION INITIALIZER
+//    (`logic [2:0] a_tmp = {a[2], a[1:0]};`) — Surelog emits it as a body
+//    assignment whose LHS is the logic_var itself (not a ref_obj); the
+//    inliner skipped it and the local stayed X.
+// 2. A PART/BIT-SELECT write to a function local (`d_tmp[62:0] = …`) — the
+//    inliner resolved no LHS name and dropped the write silently.
+typedef struct packed {
+  logic        valid;
+  logic [63:0] vaddr;
+  logic [63:0] data;
+} lsu_t;
+
+module func_local_decl_init (
+  input  logic        amo,
+  input  lsu_t        lsu,
+  output logic [63:0] st_data_n
+);
+  logic [63:0] endian_data;
+  assign endian_data = lsu.data;
+
+  function automatic [63:0] data_align(logic [2:0] a, logic [63:0] d);
+    logic [2:0]  a_tmp = {a[2], a[1:0]};
+    logic [63:0] d_tmp = {64{1'b0}};
+    case (a_tmp)
+      3'b000: d_tmp = d;
+      3'b010: d_tmp = {d[47:0], d[63:48]};
+      3'b011: begin
+        d_tmp[62:0] = {d[38:0], d[63:40]};
+        d_tmp[63]   = d[39];
+      end
+      default: d_tmp = {d[7:0], d[63:8]};
+    endcase
+    data_align = d_tmp;
+  endfunction
+
+  always_comb begin
+    st_data_n = (amo ? endian_data[63:0]
+                     : data_align(lsu.vaddr[2:0], {endian_data}));
+  end
+endmodule

--- a/test/func_local_decl_init/test_slang_equiv.ys
+++ b/test/func_local_decl_init/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top func_local_decl_init
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename func_local_decl_init gold
+design -stash gold
+read_slang dut.sv --top func_local_decl_init
+hierarchy -check -top func_local_decl_init
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename func_local_decl_init gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/loop_break_index/dut.sv
+++ b/test/loop_break_index/dut.sv
@@ -1,0 +1,31 @@
+// CVA6 pmp.sv repro (adjudicated against a hand-written break-free reference
+// under iverilog — iverilog itself cannot parse `break`):
+// a comb `for` loop with `break`, followed by a test on the LOOP VARIABLE
+// (`if (i == N)` = "no iteration matched").  The importer unrolled the loop
+// but drove the loop variable to the STATIC final value N, so the post-loop
+// "nothing matched" fallback fired unconditionally — CVA6 pmp's allow_o was
+// always the no-match value, which flipped cva6_ptw's allow_access.
+// Fix: a per-iteration break flag (set by the vpiBreak handler under the
+// branch conditions reaching it) feeding a first-break-index priority mux.
+module loop_break_index #(
+  parameter int N = 4
+)(
+  input  logic [N-1:0] match,
+  input  logic [N-1:0] allow,
+  input  logic         is_m,
+  output logic         allow_o,
+  output logic [31:0]  idx_o
+);
+  always_comb begin
+    int i;
+    allow_o = 1'b0;
+    for (i = 0; i < N; i++) begin
+      if (match[i]) begin
+        allow_o = allow[i];
+        break;
+      end
+    end
+    idx_o = i;              // first-break index, or N when nothing matched
+    if (i == N) allow_o = is_m;
+  end
+endmodule

--- a/test/loop_break_index/test_slang_equiv.ys
+++ b/test/loop_break_index/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top loop_break_index
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename loop_break_index gold
+design -stash gold
+read_slang dut.sv --top loop_break_index
+hierarchy -check -top loop_break_index
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename loop_break_index gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/loopvar_eq_fold/dut.sv
+++ b/test/loopvar_eq_fold/dut.sv
@@ -1,0 +1,28 @@
+// CVA6 cva6_ptw repro (adjudicated against iverilog, NOT just the miter):
+// constant folding of `==` / `!=` used RTLIL::Const::operator==, which
+// compares the bit-vector INCLUDING ITS WIDTH.  An unrolled loop variable
+// folds to a 32-bit constant while an integer literal arrives 64-bit, so
+// `y == 0` inside `for (int unsigned y …)` was FALSE on every iteration —
+// silently dropping the y==0 arm.  `<` was unaffected (it already used the
+// value-semantics const_lt helper), which is what made this so quiet.
+// In cva6_ptw: `shared_tlb_update_o.is_page[x][y] = y == 0 ? (…) : 1'b0;`
+module loopvar_eq_fold (
+  input  logic       a,
+  output logic [1:0] o_eq,     // (y == 0)
+  output logic [1:0] o_neq,    // (y != 0)
+  output logic [1:0] o_tern,   // y == 0 ? a : 1'b0
+  output logic [1:0] o_int,    // signed int loop var
+  output logic [1:0] o_lt      // (y < 1) — the control that always worked
+);
+  always_comb begin
+    o_eq = '0; o_neq = '0; o_tern = '0; o_int = '0; o_lt = '0;
+    for (int unsigned y = 0; y < 2; y++) begin
+      o_eq[y]   = (y == 0);
+      o_neq[y]  = (y != 0);
+      o_tern[y] = y == 0 ? a : 1'b0;
+      o_lt[y]   = (y < 1);
+    end
+    for (int y2 = 0; y2 < 2; y2++)
+      o_int[y2] = (y2 == 0);
+  end
+endmodule

--- a/test/loopvar_eq_fold/test_slang_equiv.ys
+++ b/test/loopvar_eq_fold/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top loopvar_eq_fold
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename loopvar_eq_fold gold
+design -stash gold
+read_slang dut.sv --top loopvar_eq_fold
+hierarchy -check -top loopvar_eq_fold
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename loopvar_eq_fold gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/pattern_default_packed/dut.sv
+++ b/test/pattern_default_packed/dut.sv
@@ -1,0 +1,21 @@
+// CVA6 cva6_tlb match_vmid repro: `'{default: V}` assigned to a PACKED
+// VECTOR replicates V into EVERY element (1-bit elements for a plain
+// vector) — `logic [3:0] m = '{default: 1}` is 4'b1111, not 4'b0001.
+// The importer's default-pattern handler only filled struct/union members;
+// vector targets fell through to the generic loop and got the literal value
+// (match_vmid = RVH ? '{default:0} : '{default:1} came out 4'b0001, so
+// 3 of 4 TLB ways could never match).
+module pattern_default_packed #(
+  parameter bit RVH = 1'b0
+)(
+  input  logic       sel,
+  output logic [3:0] m_param,
+  output logic [3:0] m_dyn,
+  output logic [3:0] m_plain
+);
+  always_comb begin
+    m_param = RVH ? '{default: 0} : '{default: 1};
+    m_dyn   = sel ? '{default: 0} : '{default: 1};
+    m_plain = '{default: 1};
+  end
+endmodule

--- a/test/pattern_default_packed/test_slang_equiv.ys
+++ b/test/pattern_default_packed/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top pattern_default_packed
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename pattern_default_packed gold
+design -stash gold
+read_slang dut.sv --top pattern_default_packed
+hierarchy -check -top pattern_default_packed
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename pattern_default_packed gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter

--- a/test/tern_fill_literal/dut.sv
+++ b/test/tern_fill_literal/dut.sv
@@ -1,0 +1,30 @@
+// CVA6 cva6_ptw repro (adjudicated with iverilog, not just the miter):
+// an UNBASED UNSIZED fill literal (`'1`) as a ternary branch must REPLICATE
+// to the context width.  Two separate bugs made `assign wide = cond ? f(x)
+// : '1;` produce 1 (or the narrow branch's width) instead of all-ones:
+//   1. SURELOG ExprEval::reduceExpr's vpiConditionOp fold pushed the picked
+//      branch through get_value(), turning `'1` into INT:1 — so with a
+//      CONSTANT condition the fill identity was destroyed before import.
+//   2. The importer's own ternary path zero-extended the 1-bit fill instead
+//      of replicating it to the (context-determined, LRM 11.4.11) width.
+// In cva6_ptw: `req_port_o.data_be = CVA6Cfg.IS_XLEN32 ? be_gen_32(…) : '1;`
+// yielded data_be = 8'h01 instead of 8'hff.
+function automatic logic [3:0] narrow(logic [1:0] a);
+  narrow = {2'b0, a};
+endfunction
+
+module tern_fill_literal #(
+  parameter bit IS32 = 1'b0
+)(
+  input  logic       sel,
+  input  logic [1:0] a,
+  output logic [7:0] o_constcond,  // constant condition (the Surelog half)
+  output logic [7:0] o_dyncond,    // dynamic condition (the importer half)
+  output logic [7:0] o_fill_true,  // fill in the TRUE branch
+  output logic [7:0] o_zero_fill   // '0 fill
+);
+  assign o_constcond = IS32 ? narrow(a) : '1;
+  assign o_dyncond   = sel  ? narrow(a) : '1;
+  assign o_fill_true = sel  ? '1 : 8'h5a;
+  assign o_zero_fill = sel  ? narrow(a) : '0;
+endmodule

--- a/test/tern_fill_literal/test_slang_equiv.ys
+++ b/test/tern_fill_literal/test_slang_equiv.ys
@@ -1,0 +1,14 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top tern_fill_literal
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename tern_fill_literal gold
+design -stash gold
+read_slang dut.sv --top tern_fill_literal
+hierarchy -check -top tern_fill_literal
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename tern_fill_literal gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+sat -verify -prove-asserts -seq 8 -set-init-zero -show-inputs -show-outputs miter


### PR DESCRIPTION
Five importer fixes from the CVA6 per-module equivalence sweep. Each is reduced
to a repro test, and — where the shape is parseable by an independent simulator
— **adjudicated against `iverilog`** rather than against `read_slang` alone,
after a check that the reference side itself was trustworthy.

## Fixes

1. **`==`/`!=` constant fold was width-sensitive.** It used
   `RTLIL::Const::operator==`, which compares the bit-vector *including its
   width*, so a 32-bit unrolled loop value never compared equal to a 64-bit
   literal: `y == 0` inside `for (int unsigned y ...)` folded FALSE on every
   iteration. `<`/`>` were unaffected — they already used the value-semantics
   `const_lt`/`const_gt` helpers — which is what kept this hidden. Now uses
   `const_eq`/`const_ne`. `test/loopvar_eq_fold`.

2. **Unsized fill `'1` as a ternary branch** zero-extended instead of
   replicating to the context-determined width (LRM 11.4.11), so
   `assign wide = cond ? f(x) : '1;` produced `1` rather than all-ones.
   `test/tern_fill_literal`.

3. **Expression-width size cast defaulted to 32 bits.** The width of
   `((A + B) * (C / D))'(x)` lives in the `integer_typespec`'s `Expr()`, not its
   `VpiValue`; the oversized cast then stole bits from the enclosing concat.
   `test/expr_width_cast`.

4. **`break` in a comb for-loop had no handler at all** — it fell through to
   "Unsupported statement type" — so the post-loop value of the loop variable
   was the static final `N`, and a following `if (i == N)` ("nothing matched")
   fired unconditionally. Each iteration now gets a break flag, set under the
   branch conditions that reach the break, feeding a first-break-index priority
   mux. `test/loop_break_index`.

5. **Dynamic index into a multi-dim packed array collapsed to a single bit**:
   the packed multi-dim `var_select` path required every index to be constant
   and otherwise fell through to a plain `bit_select`. Now emits a chained
   `$shiftx` at Σ (idx_k − low_k)·stride_k. `test/dyn_packed_multidim`.

Also included from the same sweep: comb LHS part-selects no longer take the
in-flight blocking value as their write target; function-local declaration
initializers and part-select writes to function locals are honoured by the SSA
inliner; `'{default: V}` fills every element of a packed vector; and struct
member/geometry resolution substitutes `parameter type` bindings.

## Upstream dependencies

Two of the new tests also need the companion upstream fixes:

- chipsalliance/Surelog#4139 — anonymous-struct packed dimension
  (`test/anon_struct_packed_dim`)
- chipsalliance/UHDM#1139 — constant-condition half of the fill-literal fix
  (`test/tern_fill_literal`)

Merge order: UHDM → Surelog → submodule bump here.

## `simple/mem2reg_bounds_tern`

Now differs between the two frontends because fix 1 made the UHDM output match
the behavioural RTL **exactly**. Adjudicated with `iverilog` over 40 clocked
random vectors, all three instantiated side by side:

| comparison | mismatches |
|---|---|
| UHDM netlist vs behavioural RTL | **0 / 40** |
| `read_verilog` netlist vs behavioural RTL | **10 / 40** |

So this is an upstream `read_verilog` out-of-bounds bug, not a regression here;
recorded in `test/failing_tests.txt` with the evidence. `Miter-Formal` stays 0.

## Gates

| suite | result |
|---|---|
| internal (837 tests) | `ALL RESULTS AS EXPECTED`, **Miter-Formal 0** |
| upstream Yosys (545 tests) | `ALL RESULTS AS EXPECTED`, **Miter-Formal 0** |
| 25 previously-proven CVA6 modules | all re-verified equivalent vs `read_slang`, with regenerated UHDM |
| Surelog own regression | 0 FAIL / 0 SEGFLT; only statistics-only golden drift, see the UHDM PR |

README counts refreshed to the measured numbers (1382 tests, 1337 functional,
912 formally verified, 425 UHDM-only).