### PR TITLE
test/cva6: inherit the target's package imports; find vendored modules (elabfail 32 → 25)

### DIFF
--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -41,7 +41,7 @@ bht                                    4   900   proven
 bht2lvl                                4   180   cex
 branch_unit                            4   900   proven
 btb                                    4   900   proven
-cache_ctrl                             4   180   elabfail
+cache_ctrl                             4   180   cex
 commit_stage                           4   900   proven
 compressed_decoder                     4   900   proven
 compressed_instr_decoder               4   180   elabfail
@@ -68,7 +68,7 @@ cvxif_example_coprocessor              4   180   elabfail
 cvxif_fu                               4   900   proven
 cvxif_issue_register_commit_if_driver  4   900   proven
 decoder                                4   900   proven
-div_sqrt_top_mvp                       4   180   elabfail
+div_sqrt_top_mvp                       4   180   timeout
 ex_stage                               4   180   cex
 fpnew_cast_multi                       4   180   timeout
 fpnew_classifier                       4   180   cex
@@ -87,8 +87,8 @@ fpu_wrap                               4   180   cex
 frontend                               4   180   cex
 hpdcache                               4   180   crash
 hpdcache_1hot_to_binary                4   180   crash
-hpdcache_amo                           4   180   elabfail
-hpdcache_cbuf                          4   180   elabfail
+hpdcache_amo                           4   900   proven
+hpdcache_cbuf                          4   180   cex
 hpdcache_cmo                           4   180   elabfail
 hpdcache_core_arbiter                  4   180   timeout
 hpdcache_ctrl                          4   180   crash
@@ -148,13 +148,13 @@ macro_decoder                          4   180   cex
 miss_handler                           4   180   crash
 mult                                   4   180   timeout
 multiplier                             4   180   timeout
-norm_div_sqrt_mvp                      4   180   elabfail
-nrbd_nrsc_mvp                          4   180   elabfail
+norm_div_sqrt_mvp                      4   900   proven
+nrbd_nrsc_mvp                          4   900   proven
 perf_counters                          4   900   proven
 pmp                                    4   180   timeout
 pmp_data_if                            4   180   cex
 pmp_entry                              4   900   proven
-popcount                               4   180   elabfail
+popcount                               4   900   proven
 preprocess_mvp                         4   180   elabfail
 ras                                    4   900   proven
 raw_checker                            4   900   proven

--- a/test/cva6_equiv/scripts/gen_wrapper.py
+++ b/test/cva6_equiv/scripts/gen_wrapper.py
@@ -136,6 +136,11 @@ def gen(target, out_path, extra_binds=None, import_pkgs=None):
         # search
         import glob
         cands = glob.glob(f"{CORE}/**/{target}.sv", recursive=True)
+        if not cands:
+            # Vendored common_cells / axi live outside core/ (popcount, lzc, …)
+            # but are part of the design and worth proving too.
+            rtl_root = os.path.dirname(CORE)
+            cands = glob.glob(f"{rtl_root}/**/{target}.sv", recursive=True)
         if not cands: raise SystemExit(f"{target}.sv not found under {CORE}")
         tgt_file = cands[0]
     tgt_txt = open(tgt_file).read()
@@ -257,7 +262,18 @@ def gen(target, out_path, extra_binds=None, import_pkgs=None):
         else:
             unbound.append(p)
 
-    pkgs = import_pkgs or ["ariane_pkg"]
+    # Inherit the target's OWN package imports.  A module that says
+    # `import hpdcache_pkg::*;` uses that package's types in its port list, and
+    # the wrapper copies that port list verbatim — without the same import
+    # slang stops at "use of undeclared identifier 'hpdcache_cfg_t'".  This is
+    # the single biggest remaining cause of wrappers that will not elaborate.
+    tgt_pkgs = []
+    for pm in re.finditer(r"\bimport\s+([A-Za-z_]\w*)\s*::", tgt_txt):
+        if pm.group(1) not in tgt_pkgs:
+            tgt_pkgs.append(pm.group(1))
+    pkgs = import_pkgs or (["ariane_pkg"] + [q for q in tgt_pkgs if q != "ariane_pkg"])
+    if tgt_pkgs:
+        print(f"  inherited target imports: {', '.join(tgt_pkgs)}")
     imports = "\n".join(f"  import {p}::*;" for p in pkgs)
     wtop = f"{target}_equiv"
     out = f"""// AUTO-GENERATED per-module equivalence wrapper for {target}

--- a/test/cva6_equiv/wrappers/wrapper_cache_ctrl.sv
+++ b/test/cva6_equiv/wrappers/wrapper_cache_ctrl.sv
@@ -6,6 +6,7 @@
 
 module cache_ctrl_equiv
   import ariane_pkg::*;
+  import std_cache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_control_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_control_mvp.sv
@@ -6,6 +6,7 @@
 
 module control_mvp_equiv
   import ariane_pkg::*;
+  import defs_div_sqrt_mvp::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_copro_alu.sv
+++ b/test/cva6_equiv/wrappers/wrapper_copro_alu.sv
@@ -6,6 +6,7 @@
 
 module copro_alu_equiv
   import ariane_pkg::*;
+  import cvxif_instr_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_cva6_icache_axi_wrapper.sv
+++ b/test/cva6_equiv/wrappers/wrapper_cva6_icache_axi_wrapper.sv
@@ -6,6 +6,7 @@
 
 module cva6_icache_axi_wrapper_equiv
   import ariane_pkg::*;
+  import wt_cache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_cvxif_example_coprocessor.sv
+++ b/test/cva6_equiv/wrappers/wrapper_cvxif_example_coprocessor.sv
@@ -6,6 +6,7 @@
 
 module cvxif_example_coprocessor_equiv
   import ariane_pkg::*;
+  import cvxif_instr_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_div_sqrt_top_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_div_sqrt_top_mvp.sv
@@ -6,6 +6,7 @@
 
 module div_sqrt_top_mvp_equiv
   import ariane_pkg::*;
+  import defs_div_sqrt_mvp::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_amo.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_amo.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_amo_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_cbuf.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_cbuf.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_cbuf_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_cmo.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_cmo.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_cmo_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_data_downsize.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_data_downsize.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_data_downsize_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_read.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_read.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_mem_to_axi_read_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_write.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_write.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_mem_to_axi_write_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_mshr.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_mshr.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_mshr_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_uncached.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_uncached.sv
@@ -6,6 +6,7 @@
 
 module hpdcache_uncached_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hwpf_stride.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hwpf_stride.sv
@@ -6,6 +6,8 @@
 
 module hwpf_stride_equiv
   import ariane_pkg::*;
+  import hwpf_stride_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hwpf_stride_arb.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hwpf_stride_arb.sv
@@ -6,6 +6,7 @@
 
 module hwpf_stride_arb_equiv
   import ariane_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_hwpf_stride_wrapper.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hwpf_stride_wrapper.sv
@@ -6,6 +6,8 @@
 
 module hwpf_stride_wrapper_equiv
   import ariane_pkg::*;
+  import hwpf_stride_pkg::*;
+  import hpdcache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_norm_div_sqrt_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_norm_div_sqrt_mvp.sv
@@ -6,6 +6,7 @@
 
 module norm_div_sqrt_mvp_equiv
   import ariane_pkg::*;
+  import defs_div_sqrt_mvp::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_nrbd_nrsc_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_nrbd_nrsc_mvp.sv
@@ -6,6 +6,7 @@
 
 module nrbd_nrsc_mvp_equiv
   import ariane_pkg::*;
+  import defs_div_sqrt_mvp::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_popcount.sv
+++ b/test/cva6_equiv/wrappers/wrapper_popcount.sv
@@ -305,7 +305,10 @@ module popcount_equiv
     `CVXIF_REQ_T(CVA6Cfg, x_compressed_req_t, x_issue_req_t, x_register_t, x_commit_t),
     parameter type cvxif_resp_t =
     `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t)
+,
 
+  parameter int unsigned INPUT_WIDTH = 256,
+  localparam int unsigned PopcountWidth = $clog2(INPUT_WIDTH)+1
 ) (
 
     input logic [INPUT_WIDTH-1:0]     data_i,
@@ -313,8 +316,35 @@ module popcount_equiv
 
 );
 
+  localparam type interrupts_t = struct packed {
+    logic [CVA6Cfg.XLEN-1:0] S_SW;
+    logic [CVA6Cfg.XLEN-1:0] VS_SW;
+    logic [CVA6Cfg.XLEN-1:0] M_SW;
+    logic [CVA6Cfg.XLEN-1:0] S_TIMER;
+    logic [CVA6Cfg.XLEN-1:0] VS_TIMER;
+    logic [CVA6Cfg.XLEN-1:0] M_TIMER;
+    logic [CVA6Cfg.XLEN-1:0] S_EXT;
+    logic [CVA6Cfg.XLEN-1:0] VS_EXT;
+    logic [CVA6Cfg.XLEN-1:0] M_EXT;
+    logic [CVA6Cfg.XLEN-1:0] HS_EXT;
+  };
+  localparam interrupts_t INTERRUPTS = '{
+      S_SW: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_S_SOFT),
+      VS_SW: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_VS_SOFT),
+      M_SW: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_M_SOFT),
+      S_TIMER: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_S_TIMER),
+      VS_TIMER: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_VS_TIMER),
+      M_TIMER: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_M_TIMER),
+      S_EXT: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_S_EXT),
+      VS_EXT: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_VS_EXT),
+      M_EXT: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_M_EXT),
+      HS_EXT: (CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN - 1)) | CVA6Cfg.XLEN'(riscv::IRQ_HS_EXT)
+  };
+  localparam NumPorts = 4;
+  localparam PC_QUEUE_DEPTH = 16;
+
   popcount #(
-      
+      .INPUT_WIDTH(INPUT_WIDTH)
   ) dut (.*);
 
 endmodule

--- a/test/cva6_equiv/wrappers/wrapper_preprocess_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_preprocess_mvp.sv
@@ -6,6 +6,7 @@
 
 module preprocess_mvp_equiv
   import ariane_pkg::*;
+  import defs_div_sqrt_mvp::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_wt_axi_adapter.sv
+++ b/test/cva6_equiv/wrappers/wrapper_wt_axi_adapter.sv
@@ -6,6 +6,7 @@
 
 module wt_axi_adapter_equiv
   import ariane_pkg::*;
+  import wt_cache_pkg::*;
 #(
 
     // CVA6 config

--- a/test/cva6_equiv/wrappers/wrapper_wt_dcache_missunit.sv
+++ b/test/cva6_equiv/wrappers/wrapper_wt_dcache_missunit.sv
@@ -6,6 +6,7 @@
 
 module wt_dcache_missunit_equiv
   import ariane_pkg::*;
+  import wt_cache_pkg::*;
 #(
 
     // CVA6 config


### PR DESCRIPTION
Two more generic generator fixes. Takes the wrappers that cannot elaborate from
**32 to 25**, adds four proofs, and surfaces two more real counterexamples.

Cumulative with #599: **elabfail 61 → 25, proven 30 → 41**.

## 1. Inherit the target's package imports

The wrapper always imported exactly `ariane_pkg`. But a module that says
`import hpdcache_pkg::*;` uses that package's types **in its port list**, and
the wrapper copies that port list verbatim — so slang stopped at:

```
use of undeclared identifier 'hpdcache_cfg_t'
use of undeclared identifier 'C_MANT_FP64'
```

The generator now scans the target for its own `import <pkg>::` statements and
repeats them. This applied to **22 of the 32** remaining wrappers — the
hpdcache, fpnew and div_sqrt_mvp families.

## 2. Find vendored modules

`gen_wrapper.py` only searched `rtl/core`, so anything in the vendored
common_cells / axi trees could not be wrapped at all:

```
popcount.sv not found under .../rtl/core
```

It now falls back to the whole `rtl` root. `popcount` proves immediately.

## Measured

| status | before | after | |
| --- | ---: | ---: | --- |
| `elabfail` | 32 | **25** | |
| `proven` | 37 | **41** | +4: `hpdcache_amo`, `popcount`, `norm_div_sqrt_mvp`, `nrbd_nrsc_mvp` |
| `timeout` | 36 | 37 | `div_sqrt_top_mvp` now reaches SAT |
| `cex` | 20 | 22 | +2 pre-existing bugs, previously masked |
| `crash` | 21 | 21 | |

The two new `cex` (`cache_ctrl`, `hpdcache_cbuf`) are frontend bugs that were
always there — the wrapper simply never got far enough to reach the miter.
Manifest updated from measured results and spot-verified at a 400 s budget.

## What remains, and what is *not* worth chasing

Two groups among the remaining 25 are **not wrapper defects**, and I would
rather record that than have someone spend time on them:

- `ariane_regfile_fpga`, `cvxif_example_coprocessor` — `unsupported system task
  '$random'` / `'$onehot0'`. A limitation of the reference frontend, not of our
  wrapper or of `read_uhdm`.
- `control_mvp`, `preprocess_mvp` — non-ANSI port lists (`port 'Mant_a_D' has
  no I/O member declaration`), which the copy-the-port-list approach cannot
  express.

The genuinely fixable remainder is parent-local types that live in neither a
package nor the instantiating parent, plus parameters defaulting to 0/-1 that
need a sane value (`$fatal: DEPTH must be greater than 0`). Those want
per-module `extras_<mod>.svh` files, which is the next step.