### PR TITLE
cva6: drop assertions symmetrically in the miter (elabfail 13 -> 5, +2 proven)

### DIFF
--- a/test/cva6_equiv/README.md
+++ b/test/cva6_equiv/README.md
@@ -159,6 +159,38 @@ lesson — a status measured against a degenerate configuration says little abou
 the design that ships, so treat a parameter fix as invalidating the statuses
 around it.
 
+### Assertions, and not blaming the reference frontend
+
+Nine modules used to report `unsupported system task '$onehot0'` (or `$onehot`,
+or an SVA feature) and were written off as reference-frontend limitations. They
+were not. Those calls live inside `assert property`, and the reason a full CVA6
+read never trips over them is that the shipped configuration does not
+instantiate those modules at all — CVXIF is disabled, the FPGA regfile is
+unused, hpdcache is not the default cache. Only this per-module flow forces
+them to elaborate.
+
+Assertions are not hardware and this flow compares hardware, so the miter drops
+them — **on both sides**. `read_slang` takes `--ignore-assertions`; `read_uhdm`
+turns the same assertions into `$check` cells, so gold deletes
+`$check`/`$assert`/`$assume`/`$print` too. Doing it on one side only would also
+leave `sat -prove-asserts` proving the *design's own* assertions, where a
+failing design assertion would masquerade as a counterexample.
+
+When a module still will not elaborate, adjudicate with **Verilator** before
+calling it a reference-frontend bug — the same rule this suite already applies
+to counterexamples. Doing that here found exactly one genuine gap
+(`ariane_regfile_fpga`: Verilator accepts the `$random` initialiser that slang
+rejects) and confirmed the rest as real: Verilator flags
+`fpnew_divsqrt_multi`'s out-of-range select at the same line, reports
+`hpdcache_data_downsize`'s own `$fatal`, and rejects the non-ANSI port lists in
+`control_mvp`/`preprocess_mvp` — pointing at the generated wrapper, which is
+what actually needs fixing.
+
+`--ignore-initial` would make `ariane_regfile_fpga` elaborate, and it is the
+wrong trade: `read_uhdm` keeps the initial block, so the two sides disagree
+about initial memory content and the miter reports a counterexample that is
+purely an artefact of the flag.
+
 Not every `elabfail` is a harness gap we can close. Five modules use system
 tasks the reference frontend does not implement (`$random` in
 `ariane_regfile_fpga`; `$onehot0` in the cvxif example decoders and, via

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -34,7 +34,7 @@ alu                                    4   900   proven
 alu_wrapper                            4   900   proven
 amo_alu                                4   180   timeout
 amo_buffer                             4   900   proven
-ariane_regfile_fpga                    4   400   elabfail  # slang: no $random
+ariane_regfile_fpga                    4   400   elabfail  # slang gap: $random in initial (Verilator ACCEPTS this source)
 axi_adapter                            4   180   crash
 axi_shim                               4   400   timeout
 bht                                    4   900   proven
@@ -44,8 +44,8 @@ btb                                    4   900   proven
 cache_ctrl                             4   180   cex
 commit_stage                           4   900   proven
 compressed_decoder                     4   900   proven
-compressed_instr_decoder               4   400   elabfail  # slang: no $onehot0
-control_mvp                            4   400   elabfail  # non-ANSI port list
+compressed_instr_decoder               4   400   cex      # cex exposed once assertions stopped blocking elaboration - TRIAGE
+control_mvp                            4   400   elabfail  # non-ANSI ports; Verilator rejects the generated wrapper too
 controller                             4   900   proven
 copro_alu                              4   400   proven
 csr_buffer                             4   900   proven
@@ -58,13 +58,13 @@ cva6_hpdcache_subsystem_axi_arbiter    4   180   crash
 cva6_hpdcache_wrapper                  4   180   crash
 cva6_icache                            4   900   proven
 cva6_icache_axi_wrapper                4   400   timeout
-cva6_mmu                               4   180   timeout
+cva6_mmu                               4   180   proven
 cva6_ptw                               1   900   proven
 cva6_rvfi_probes                       4   180   cex
 cva6_shared_tlb                        4   900   proven
 cva6_tlb                               4   900   proven
 cvxif_compressed_if_driver             4   900   proven
-cvxif_example_coprocessor              4   400   elabfail  # slang: no $onehot0
+cvxif_example_coprocessor              4   400   cex      # cex exposed once assertions stopped blocking elaboration - TRIAGE
 cvxif_fu                               4   900   proven
 cvxif_issue_register_commit_if_driver  4   900   proven
 decoder                                4   900   proven
@@ -72,7 +72,7 @@ div_sqrt_top_mvp                       4   180   timeout
 ex_stage                               4   180   cex
 fpnew_cast_multi                       4   180   timeout
 fpnew_classifier                       4   180   cex
-fpnew_divsqrt_multi                    4   400   elabfail  # harness: needs fpnew Implementation resolved 4 levels up
+fpnew_divsqrt_multi                    4   400   elabfail  # harness: NUM_INP_REGS=0 -> OOB select (Verilator agrees, same line)
 fpnew_divsqrt_th_32                    4   180   cex
 fpnew_divsqrt_th_64_multi              4   900   proven
 fpnew_fma                              4   180   cex
@@ -89,11 +89,11 @@ hpdcache                               4   180   crash
 hpdcache_1hot_to_binary                4   180   crash
 hpdcache_amo                           4   900   proven
 hpdcache_cbuf                          4   180   cex
-hpdcache_cmo                           4   400   elabfail  # slang: no $onehot
+hpdcache_cmo                           4   400   timeout
 hpdcache_core_arbiter                  4   180   timeout
 hpdcache_ctrl                          4   180   crash
 hpdcache_ctrl_pe                       4   180   cex
-hpdcache_data_downsize                 4   400   elabfail  # harness: not instantiated at this config (its own $fatal: RD>=WR)
+hpdcache_data_downsize                 4   400   elabfail  # not instantiated at this config (own $fatal; Verilator: USERFATAL)
 hpdcache_data_resize                   4   180   timeout
 hpdcache_data_upsize                   4   180   crash
 hpdcache_decoder                       4   180   crash
@@ -104,7 +104,7 @@ hpdcache_flush                         4   180   crash
 hpdcache_fxarb                         4   180   timeout
 hpdcache_lfsr                          4   900   proven
 hpdcache_mem_req_read_arbiter          4   180   crash
-hpdcache_mem_req_write_arbiter         4   180   elabfail  # slang: no $onehot0
+hpdcache_mem_req_write_arbiter         4   180   timeout
 hpdcache_mem_resp_demux                4   180   timeout
 hpdcache_mem_to_axi_read               4   400   timeout
 hpdcache_mem_to_axi_write              4   400   timeout
@@ -125,16 +125,16 @@ hpdcache_sram_wbyteenable_1rw          4   400   timeout  # harness: zero-width 
 hpdcache_sram_wmask                    4   180   timeout
 hpdcache_sram_wmask_1rw                4   180   timeout
 hpdcache_sync_buffer                   4   900   timeout  # was proven on a 1-bit data type; now the real one
-hpdcache_uncached                      4   400   elabfail  # slang: unsupported SVA feature
+hpdcache_uncached                      4   400   timeout
 hpdcache_victim_plru                   4   180   timeout
 hpdcache_victim_random                 4   180   crash
 hpdcache_victim_sel                    4   180   timeout
 hpdcache_wbuf                          4   180   crash
 hwpf_stride                            4   400   timeout
-hwpf_stride_arb                        4   400   elabfail  # slang: no $onehot0
-hwpf_stride_wrapper                    4   400   elabfail  # slang: no $onehot0
+hwpf_stride_arb                        4   400   timeout
+hwpf_stride_wrapper                    4   400   timeout
 id_stage                               4   180   cex
-instr_decoder                          4   400   elabfail  # slang: no $onehot0
+instr_decoder                          4   400   cex      # cex exposed once assertions stopped blocking elaboration - TRIAGE
 instr_queue                            4   900   proven
 instr_realign                          4   900   proven
 instr_scan                             4   900   proven
@@ -151,11 +151,11 @@ multiplier                             4   180   timeout
 norm_div_sqrt_mvp                      4   900   proven
 nrbd_nrsc_mvp                          4   900   proven
 perf_counters                          4   900   proven
-pmp                                    4   180   timeout
+pmp                                    4   180   proven
 pmp_data_if                            4   180   cex
 pmp_entry                              4   900   proven
 popcount                               4   900   proven
-preprocess_mvp                         4   400   elabfail  # non-ANSI port list
+preprocess_mvp                         4   400   elabfail  # non-ANSI ports; Verilator rejects the generated wrapper too
 ras                                    4   900   proven
 raw_checker                            4   900   proven
 scoreboard                             4   180   timeout

--- a/test/cva6_equiv/run_cva6_equiv.sh
+++ b/test/cva6_equiv/run_cva6_equiv.sh
@@ -92,15 +92,28 @@ run_one() {
     echo "SKIP $mod" >> "$WORKROOT/.results"; popd >/dev/null; return 0
   fi
 
+  # Assertions are not hardware, and this flow compares hardware.  Both sides
+  # must drop them, symmetrically:
+  #   - read_slang REFUSES to elaborate `assert property ($onehot0(sel))` at
+  #     all ("unsupported system task"), which looked like a slang limitation
+  #     but is just this flow forcing elaboration of modules the shipped CVA6
+  #     config never instantiates (CVXIF, the FPGA regfile, hpdcache).
+  #   - read_uhdm turns the same assertions into `\$check` cells, so leaving
+  #     them in gold would ALSO make `sat -prove-asserts` try to prove the
+  #     design's own assertions rather than just the miter's equivalence
+  #     asserts -- a failed design assertion would masquerade as a
+  #     counterexample.
   cat > miter.ys <<EOF
 read_uhdm slpp_all/surelog.uhdm
 hierarchy -check -top $top
 flatten; proc; memory; opt -fast; async2sync; setundef -undriven -zero
+delete t:\$check t:\$assert t:\$assume t:\$print
 rename $top gold
 design -stash gold
-read_slang -f $FLIST $wrap --top $top
+read_slang --ignore-assertions -f $FLIST $wrap --top $top
 hierarchy -check -top $top
 flatten; proc; memory; opt -fast; async2sync; setundef -undriven -zero
+delete t:\$check t:\$assert t:\$assume t:\$print
 rename $top gate
 design -stash gate
 design -copy-from gold -as gold gold


### PR DESCRIPTION
## The "slang limitation" was ours

Nine modules reported `unsupported system task '$onehot0'` (or `$onehot`, or an SVA feature) and had been written off as reference-frontend limitations. They were not.

Those calls live inside `assert property`. A full CVA6 read never trips over them because the shipped configuration **does not instantiate those modules at all** — CVXIF is disabled, the FPGA regfile is unused, hpdcache is not the default cache. Only this per-module flow forces them to elaborate.

Assertions are not hardware and this flow compares hardware, so the miter now drops them **on both sides**:

- `read_slang --ignore-assertions`
- `delete t:$check t:$assert t:$assume t:$print` in each pipeline, because `read_uhdm` turns the same assertions into `$check` cells

## The symmetry matters beyond elaboration

Leaving gold's `$check` cells in place meant `sat -prove-asserts` was proving the **design's own assertions** alongside the miter's equivalence asserts — so a module could fail for reasons that have nothing to do with the two frontends agreeing.

That is what was holding back `cva6_mmu` and `pmp`. Neither had any trouble elaborating; both now **prove**.

## Verilator as ground truth for what's left

Adjudicated rather than guessed — the same rule this suite already applies to counterexamples:

| module | Verilator | verdict |
| --- | --- | --- |
| `ariane_regfile_fpga` | **accepts** the `$random` initialiser | genuine slang gap |
| `fpnew_divsqrt_multi` | flags the out-of-range select at the **same line** | harness: our degenerate `NUM_INP_REGS=0` |
| `hpdcache_data_downsize` | reports the design's own `$fatal` | not instantiated at this config |
| `control_mvp`, `preprocess_mvp` | rejects the **generated wrapper's** non-ANSI port list | harness |

`--ignore-initial` would make `ariane_regfile_fpga` elaborate, and it is the wrong trade: `read_uhdm` keeps the initial block, so the two sides then disagree about initial memory content and the miter reports a counterexample that is purely an artefact of the flag. Verified, not assumed.

## Results

`JOBS=6`, documented budgets: **141 as expected, 0 regressions.**

| status | before | after |
| --- | --- | --- |
| proven | 40 | **42** (+`cva6_mmu`, +`pmp`) |
| cex | 26 | 29 |
| timeout | 46 | 49 |
| crash | 21 | 21 |
| elabfail | 13 | **5** |

Three cvxif modules yield counterexamples once assertions stop blocking them (`instr_decoder`, `compressed_instr_decoder`, `cvxif_example_coprocessor`), marked **TRIAGE** alongside the three `wt_dcache_*` ones — the miter says the frontends differ, not which is wrong, so they need iverilog adjudication before any frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)