### PR TITLE
cva6: bound the parameter-block search (elabfail 5 -> 3, +2 proven)

### DIFF
--- a/test/cva6_equiv/README.md
+++ b/test/cva6_equiv/README.md
@@ -191,13 +191,25 @@ wrong trade: `read_uhdm` keeps the initial block, so the two sides disagree
 about initial memory content and the miter reports a counterexample that is
 purely an artefact of the flag.
 
-Not every `elabfail` is a harness gap we can close. Five modules use system
-tasks the reference frontend does not implement (`$random` in
-`ariane_regfile_fpga`; `$onehot0` in the cvxif example decoders and, via
-`hpdcache_rrarb`, the `hwpf_stride` pair), so there is no reference netlist to
-miter against. Two more (`control_mvp`, `preprocess_mvp`) declare their ports
-non-ANSI, which the port-list-copying wrapper cannot mirror. Those are marked
-with a comment in `cva6_modules.txt` rather than re-triaged each round.
+Three `elabfail` entries remain, each annotated in `cva6_modules.txt` with a
+reason rather than re-triaged each round:
+
+- `ariane_regfile_fpga` — a real gap in the reference frontend: Verilator
+  accepts the `$random` memory initialiser that slang rejects. It is also the
+  FPGA variant, which the shipped configuration does not instantiate.
+- `hpdcache_data_downsize` — dead at this configuration. `accessWidth ==
+  memDataWidth`, so `hpdcache_data_resize` instantiates neither resizer;
+  *both* binding directions trip the module's own `$fatal`.
+- `fpnew_divsqrt_multi` — ours: the fpnew `Implementation` chain is four levels
+  up and still unresolved, leaving `NUM_INP_REGS = 0` and an out-of-range
+  select that Verilator flags at the same line.
+
+`control_mvp` and `preprocess_mvp` were on this list as "non-ANSI ports". They
+were not. Neither module has a `#(` block, and the generator searched the whole
+file for `#(`, ran into the body, and lifted a later *instantiation's*
+parameter list — after which the port list it copied was that instance's
+connections. Verilator's "complex ports" complaint was about the generated
+wrapper, which is exactly where the bug was. Both now prove.
 
 Treat the non-`proven` entries as a shrink-only backlog: a module that starts
 proving should be promoted in the same commit, and a module that stops proving

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -34,7 +34,7 @@ alu                                    4   900   proven
 alu_wrapper                            4   900   proven
 amo_alu                                4   180   timeout
 amo_buffer                             4   900   proven
-ariane_regfile_fpga                    4   400   elabfail  # slang gap: $random in initial (Verilator ACCEPTS this source)
+ariane_regfile_fpga                    4   400   elabfail  # slang gap: $random init (Verilator accepts); FPGA variant, not in the shipped config
 axi_adapter                            4   180   crash
 axi_shim                               4   400   timeout
 bht                                    4   900   proven
@@ -45,7 +45,7 @@ cache_ctrl                             4   180   cex
 commit_stage                           4   900   proven
 compressed_decoder                     4   900   proven
 compressed_instr_decoder               4   400   cex      # cex exposed once assertions stopped blocking elaboration - TRIAGE
-control_mvp                            4   400   elabfail  # non-ANSI ports; Verilator rejects the generated wrapper too
+control_mvp                            4   400   proven
 controller                             4   900   proven
 copro_alu                              4   400   proven
 csr_buffer                             4   900   proven
@@ -72,7 +72,7 @@ div_sqrt_top_mvp                       4   180   timeout
 ex_stage                               4   180   cex
 fpnew_cast_multi                       4   180   timeout
 fpnew_classifier                       4   180   cex
-fpnew_divsqrt_multi                    4   400   elabfail  # harness: NUM_INP_REGS=0 -> OOB select (Verilator agrees, same line)
+fpnew_divsqrt_multi                    4   400   elabfail  # harness: fpnew Implementation chain unresolved -> NUM_INP_REGS=0 -> OOB select (Verilator agrees, same line)
 fpnew_divsqrt_th_32                    4   180   cex
 fpnew_divsqrt_th_64_multi              4   900   proven
 fpnew_fma                              4   180   cex
@@ -93,7 +93,7 @@ hpdcache_cmo                           4   400   timeout
 hpdcache_core_arbiter                  4   180   timeout
 hpdcache_ctrl                          4   180   crash
 hpdcache_ctrl_pe                       4   180   cex
-hpdcache_data_downsize                 4   400   elabfail  # not instantiated at this config (own $fatal; Verilator: USERFATAL)
+hpdcache_data_downsize                 4   400   elabfail  # dead at this config: accessWidth == memDataWidth, so hpdcache_data_resize instantiates neither resizer (both binding directions hit its own $fatal)
 hpdcache_data_resize                   4   180   timeout
 hpdcache_data_upsize                   4   180   crash
 hpdcache_decoder                       4   180   crash
@@ -155,7 +155,7 @@ pmp                                    4   180   proven
 pmp_data_if                            4   180   cex
 pmp_entry                              4   900   proven
 popcount                               4   900   proven
-preprocess_mvp                         4   400   elabfail  # non-ANSI ports; Verilator rejects the generated wrapper too
+preprocess_mvp                         4   400   proven
 ras                                    4   900   proven
 raw_checker                            4   900   proven
 scoreboard                             4   180   timeout

--- a/test/cva6_equiv/scripts/gen_wrapper.py
+++ b/test/cva6_equiv/scripts/gen_wrapper.py
@@ -65,11 +65,20 @@ def extract_param_block(text, modname):
     m = re.search(r"module\s+" + re.escape(modname) + r"\b", text)
     if not m: raise SystemExit(f"module {modname} not found")
     mask = code_mask(text)
+    # A module without a parameter block must not borrow one: searching the
+    # whole file for `#(` ran into the BODY and picked up a later
+    # instantiation's parameter list, after which the "port list" scanned from
+    # there was really that instance's connections (control_mvp,
+    # preprocess_mvp).  The parameter block, if any, comes before the port
+    # list's `(`.
+    port_open = m.end()
+    while port_open < len(text) and not (text[port_open] == "(" and mask[port_open]):
+        port_open += 1
     # allow 'import pkg::*;' and comments between the name and #(
     i = m.end()
     while True:
         i = text.find("#(", i)
-        if i < 0: return "", m.end()
+        if i < 0 or i > port_open: return "", m.end()
         if mask[i]: break
         i += 2
     j = match_close(text, i + 1, mask)

--- a/test/cva6_equiv/wrappers/wrapper_control_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_control_mvp.sv
@@ -308,17 +308,43 @@ module control_mvp_equiv
     `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t)
 
 ) (
+//Input
+   input logic                                        Clk_CI,
+   input logic                                        Rst_RBI,
+   input logic                                        Div_start_SI ,
+   input logic                                        Sqrt_start_SI,
+   input logic                                        Start_SI,
+   input logic                                        Kill_SI,
+   input logic                                        Special_case_SBI,
+   input logic                                        Special_case_dly_SBI,
+   input logic [C_PC-1:0]                             Precision_ctl_SI,
+   input logic [1:0]                                  Format_sel_SI,
+   input logic [C_MANT_FP64:0]                        Numerator_DI,
+   input logic [C_EXP_FP64:0]                         Exp_num_DI,
+   input logic [C_MANT_FP64:0]                        Denominator_DI,
+   input logic [C_EXP_FP64:0]                         Exp_den_DI,
 
-          .A_DI                                    (Iteration_cell_a_D[i]            ),
-          .B_DI                                    (Iteration_cell_b_D[i]            ),
-          .Div_enable_SI                           (Div_enable_SI[i]                 ),
-          .Div_start_dly_SI                        (Div_start_dly_SI[i]              ),
-          .Sqrt_enable_SI                          (Sqrt_enable_SI[i]                ),
-          .D_DI                                    (Sqrt_DI[i]                       ),
-          .D_DO                                    (Sqrt_DO[i]                       ),
-          .Sum_DO                                  (Iteration_cell_sum_D[i]          ),
-          .Carry_out_DO                            (Iteration_cell_carry_D[i]        )
-         
+
+   output logic                                       Div_start_dly_SO ,
+   output logic                                       Sqrt_start_dly_SO,
+   output logic                                       Div_enable_SO,
+   output logic                                       Sqrt_enable_SO,
+
+
+   //To next stage
+   output logic                                       Full_precision_SO,
+   output logic                                       FP32_SO,
+   output logic                                       FP64_SO,
+   output logic                                       FP16_SO,
+   output logic                                       FP16ALT_SO,
+
+   output logic                                       Ready_SO,
+   output logic                                       Done_SO,
+
+   output logic [C_MANT_FP64+4:0]                     Mant_result_prenorm_DO,
+ //  output logic [3:0]                                 Round_bit_DO,
+   output logic [C_EXP_FP64+1:0]                      Exp_result_prenorm_DO
+ 
 );
 
   localparam type interrupts_t = struct packed {

--- a/test/cva6_equiv/wrappers/wrapper_preprocess_mvp.sv
+++ b/test/cva6_equiv/wrappers/wrapper_preprocess_mvp.sv
@@ -309,10 +309,37 @@ module preprocess_mvp_equiv
 
 ) (
 
-    .in_i    ( Mant_a_D          ),
-    .cnt_o   ( Mant_leadingOne_a ),
-    .empty_o ( Mant_zero_S_a     )
-  
+   input logic                   Clk_CI,
+   input logic                   Rst_RBI,
+   input logic                   Div_start_SI,
+   input logic                   Sqrt_start_SI,
+   input logic                   Ready_SI,
+   //Input Operands
+   input logic [C_OP_FP64-1:0]   Operand_a_DI,
+   input logic [C_OP_FP64-1:0]   Operand_b_DI,
+   input logic [C_RM-1:0]        RM_SI,    //Rounding Mode
+   input logic [C_FS-1:0]        Format_sel_SI,  // Format Selection
+
+   // to control
+   output logic                  Start_SO,
+   output logic [C_EXP_FP64:0]   Exp_a_DO_norm,
+   output logic [C_EXP_FP64:0]   Exp_b_DO_norm,
+   output logic [C_MANT_FP64:0]  Mant_a_DO_norm,
+   output logic [C_MANT_FP64:0]  Mant_b_DO_norm,
+
+   output logic [C_RM-1:0]       RM_dly_SO,
+
+   output logic                  Sign_z_DO,
+   output logic                  Inf_a_SO,
+   output logic                  Inf_b_SO,
+   output logic                  Zero_a_SO,
+   output logic                  Zero_b_SO,
+   output logic                  NaN_a_SO,
+   output logic                  NaN_b_SO,
+   output logic                  SNaN_SO,
+   output logic                  Special_case_SBO,
+   output logic                  Special_case_dly_SBO
+   
 );
 
   localparam type interrupts_t = struct packed {


### PR DESCRIPTION
## `control_mvp` / `preprocess_mvp` were never non-ANSI

Both were recorded as unfixable *"non-ANSI port list"* cases. They are ordinary ANSI modules.

Neither has a `#(` block, and `extract_param_block` searched the whole file for `#(` — so it ran into the **body**, lifted a later *instantiation's* parameter list, and the port list scanned from there was that instance's connection list. That is what got copied into the wrapper.

Verilator's `Unsupported: complex ports` was pointing at **the generated wrapper**, not at the module. Reading it as a property of the source was the mistake.

A parameter block, if there is one, comes before the port list's `(`, so the search now stops there. Both modules **prove**.

## The three that remain

None is a wrapper-generation gap that resolving parameters harder will close:

| module | why |
| --- | --- |
| `ariane_regfile_fpga` | a real reference-frontend gap — Verilator **accepts** the `$random` memory initialiser slang rejects. Also the FPGA variant, which the shipped config doesn't instantiate. |
| `hpdcache_data_downsize` | **dead at this configuration**: `accessWidth == memDataWidth`, so `hpdcache_data_resize` instantiates neither resizer |
| `fpnew_divsqrt_multi` | **ours** — the fpnew `Implementation` chain is four levels up and unresolved, leaving `NUM_INP_REGS = 0` and an out-of-range select Verilator flags at the same line |

Two negative results worth recording, since both cost real time and would otherwise be retried:

- **`--ignore-initial` does not rescue `ariane_regfile_fpga`.** `read_uhdm` keeps the initial block, and stripping the init symmetrically — *before* the `memory` pass, so it isn't already folded into the memory cell's `INIT` — still leaves a counterexample. The flag buys a comparison that isn't apples-to-apples.
- **`hpdcache_data_downsize` really is instantiated** in the design, via `hpdcache_miss_handler` rather than `hpdcache_flush` (the two pass WR/RD opposite ways). I added a site-override mechanism to resolve through the miss handler — and removed it again, because resolving through *either* parent trips the module's own `$fatal`. Both directions failing the same assertion is what proves the two widths are equal. Unused machinery is worse than none.

## Results

`JOBS=6`, documented budgets: **140 as expected, 0 regressions.**

| status | before | after |
| --- | --- | --- |
| proven | 42 | **44** (+`control_mvp`, +`preprocess_mvp`) |
| cex | 29 | 29 |
| timeout | 49 | 49 |
| crash | 21 | 21 |
| elabfail | 5 | **3** |

For context, the `elabfail` backlog across this run of work went **25 → 3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)