### PR TITLE
uhdm: read elements of a parameter that is an unpacked array of structs

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7443,6 +7443,193 @@ void UhdmImporter::resolve_xmr_read(RTLIL::Module* mod, RTLIL::Cell* cell, const
 }
 
 // Import hierarchical path (e.g., bus.a, interface.signal)
+// `PARAM[idx].field` for a parameter that is an unpacked array of structs.
+//
+// Surelog keeps such a parameter's value in the enclosing scope's param_assign
+// (an assignment pattern of assignment patterns), not in VpiValue/Expr, and the
+// element is a struct rather than a plain vector -- so neither the wire-based
+// element/field paths nor the scalar parameter path applies.  Evaluate the
+// whole array to one constant, then cut the requested field out of the
+// requested element.  A non-constant index selects between the per-element
+// field slices.
+RTLIL::SigSpec UhdmImporter::import_param_array_elem_field(
+        const bit_select* bs, const std::vector<std::string>& fields,
+        const scope* inst,
+        const std::map<std::string, RTLIL::SigSpec>* input_mapping,
+        const RTLIL::SigSpec* idx_in) {
+    if (!bs || fields.empty())
+        return RTLIL::SigSpec();
+    const UHDM::any* actual = bs->Actual_group();
+    auto param = actual ? dynamic_cast<const UHDM::parameter*>(actual) : nullptr;
+    if (!param)
+        return RTLIL::SigSpec();
+
+    // The initialiser: Expr() when Surelog put it there, otherwise the
+    // param_assign the enclosing package/module holds for this name.
+    const UHDM::expr* rhs = dynamic_cast<const UHDM::expr*>(param->Expr());
+    if (!rhs) {
+        std::string pname = std::string(param->VpiName());
+        const UHDM::any* parent = param->VpiParent();
+        if (parent && parent->UhdmType() == uhdmparam_assign) {
+            if (auto pa = any_cast<const UHDM::param_assign*>(parent))
+                rhs = dynamic_cast<const UHDM::expr*>(pa->Rhs());
+        } else if (auto sc = dynamic_cast<const UHDM::instance*>(parent)) {
+            if (sc->Param_assigns())
+                for (auto pa : *sc->Param_assigns())
+                    if (pa->Lhs() && std::string(pa->Lhs()->VpiName()) == pname)
+                        rhs = dynamic_cast<const UHDM::expr*>(pa->Rhs());
+        }
+    }
+    if (!rhs)
+        return RTLIL::SigSpec();
+
+    // The initialiser may just NAME another parameter -- a wrapper writes
+    // `parameter copro_issue_resp_t CoproInstr[NbInstr] =
+    // cvxif_instr_pkg::CoproInstr`, and the array literal lives on the package
+    // parameter.  Follow the reference to the declaration that actually holds
+    // the pattern.
+    for (int hop = 0; hop < 4 && rhs && rhs->UhdmType() == uhdmref_obj; hop++) {
+        auto r = any_cast<const UHDM::ref_obj*>(rhs);
+        auto rp = r ? dynamic_cast<const UHDM::parameter*>(r->Actual_group())
+                    : nullptr;
+        if (!rp) break;
+        const UHDM::expr* nxt = dynamic_cast<const UHDM::expr*>(rp->Expr());
+        if (!nxt) {
+            std::string rn = std::string(rp->VpiName());
+            const UHDM::any* rpar = rp->VpiParent();
+            if (rpar && rpar->UhdmType() == uhdmparam_assign) {
+                if (auto pa = any_cast<const UHDM::param_assign*>(rpar))
+                    nxt = dynamic_cast<const UHDM::expr*>(pa->Rhs());
+            } else if (auto rsc = dynamic_cast<const UHDM::instance*>(rpar)) {
+                if (rsc->Param_assigns())
+                    for (auto pa : *rsc->Param_assigns())
+                        if (pa->Lhs() && std::string(pa->Lhs()->VpiName()) == rn)
+                            nxt = dynamic_cast<const UHDM::expr*>(pa->Rhs());
+            }
+        }
+        if (!nxt) break;
+        rhs = nxt;
+        param = rp;   // widths/typespec come from the declaration we landed on
+    }
+
+    // How many elements: the initialiser's own operand count is the most
+    // reliable source -- the parameter's range can be written in terms of
+    // another parameter (`[NbInstr]`).
+    int nelem = 0;
+    if (rhs->UhdmType() == uhdmoperation)
+        if (auto ops = any_cast<const UHDM::operation*>(rhs)->Operands())
+            nelem = (int)ops->size();
+    if (nelem <= 0)
+        return RTLIL::SigSpec();
+
+    // Import the array literal at its NATURAL width.  The ambient context
+    // width belongs to the field being read (1 bit for `.accept`, 8 for
+    // `.tag`), and letting it size the whole-array pattern truncates it -- the
+    // element width then comes out as 1 or 2 bits and the read is nonsense.
+    bool saved_fcf = force_const_fold;
+    int saved_ctx = expression_context_width;
+    force_const_fold = true;
+    expression_context_width = 0;
+    RTLIL::SigSpec all = import_expression(rhs, input_mapping);
+    expression_context_width = saved_ctx;
+    force_const_fold = saved_fcf;
+    if (all.size() <= 0 || all.size() % nelem != 0)
+        return RTLIL::SigSpec();
+    int elem_w = all.size() / nelem;
+
+    // Field offset within the element struct, counting from the LSB (members
+    // are declared MSB-first).
+    const UHDM::struct_typespec* st = nullptr;
+    if (auto rt = param->Typespec())
+        if (auto ats = rt->Actual_typespec()) {
+            if (ats->UhdmType() == uhdmarray_typespec) {
+                auto arr = any_cast<const UHDM::array_typespec*>(ats);
+                if (arr->Elem_typespec())
+                    if (auto et = arr->Elem_typespec()->Actual_typespec())
+                        st = dynamic_cast<const UHDM::struct_typespec*>(et);
+            } else {
+                st = dynamic_cast<const UHDM::struct_typespec*>(ats);
+            }
+        }
+    if (!st || !st->Members())
+        return RTLIL::SigSpec();
+
+    // Walk the whole field chain, not just one level: the decoder reads
+    // `CoproInstr[i].resp.accept`, so stopping after `resp` leaves the access
+    // unresolved and the value falls back to zero.
+    int field_offset = 0, field_width = 0;
+    for (size_t f = 0; f < fields.size(); f++) {
+        if (!st || !st->Members())
+            return RTLIL::SigSpec();
+        int off = 0, w = 0;
+        bool found = false;
+        const UHDM::struct_typespec* next = nullptr;
+        for (int i = (int)st->Members()->size() - 1; i >= 0; i--) {
+            auto m = (*st->Members())[i];
+            const UHDM::any* mats = nullptr;
+            int mw = 0;
+            if (auto mts = m->Typespec())
+                if ((mats = mts->Actual_typespec()))
+                    mw = get_width_from_typespec(mats, inst);
+            if (std::string(m->VpiName()) == fields[f]) {
+                w = mw; found = true;
+                next = mats ? dynamic_cast<const UHDM::struct_typespec*>(mats)
+                            : nullptr;
+                break;
+            }
+            off += mw;
+        }
+        if (!found || w <= 0)
+            return RTLIL::SigSpec();
+        field_offset += off;
+        field_width = w;
+        st = next;
+    }
+    if (field_width <= 0 || field_offset + field_width > elem_w)
+        return RTLIL::SigSpec();
+
+    // The assignment pattern is concatenated with element 0 FIRST, and a
+    // Verilog concatenation puts its first operand in the HIGH bits -- so
+    // element 0 lives at the top of the flattened value, not the bottom.
+    // Indexing from the bottom silently reverses the array: the decoder table
+    // still matched, but against the wrong entries.
+    auto slice_of = [&](int idx) {
+        return all.extract((nelem - 1 - idx) * elem_w + field_offset, field_width);
+    };
+
+    RTLIL::SigSpec idx_sig;
+    if (idx_in)
+        idx_sig = *idx_in;      // caller already evaluated it (loop unrolling)
+    else if (bs->VpiIndex())
+        idx_sig = import_expression(bs->VpiIndex(), input_mapping);
+    if (idx_sig.size() > 0 && idx_sig.is_fully_const()) {
+        int idx = idx_sig.as_const().as_int();
+        if (idx < 0 || idx >= nelem)
+            return RTLIL::SigSpec();
+        if (mode_debug)
+            log("    param array elem field: %s[%d].%s -> %d bits\n",
+                std::string(param->VpiName()).c_str(), idx,
+                fields.back().c_str(), field_width);
+        return slice_of(idx);
+    }
+    if (idx_sig.size() == 0)
+        return RTLIL::SigSpec();
+
+    // Runtime index: mux the per-element field slices.  Built as a chain so the
+    // out-of-range index yields the same 'x' a select would.
+    RTLIL::SigSpec result = RTLIL::SigSpec(RTLIL::State::Sx, field_width);
+    for (int idx = nelem - 1; idx >= 0; idx--) {
+        RTLIL::SigSpec eq = module->Eq(NEW_ID, idx_sig,
+                                       RTLIL::Const(idx, idx_sig.size()));
+        result = module->Mux(NEW_ID, result, slice_of(idx), eq);
+    }
+    if (mode_debug)
+        log("    param array elem field: %s[<dyn>].%s -> %d-bit mux of %d\n",
+            std::string(param->VpiName()).c_str(), fields.back().c_str(),
+            field_width, nelem);
+    return result;
+}
+
 RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const scope* inst, const std::map<std::string, RTLIL::SigSpec>* input_mapping) {
     if (mode_debug)
         log("    Importing hier_path\n");
@@ -7484,6 +7671,32 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 path_name.c_str(), fs.size());
         return fs;
     }
+
+    // `TBL[i].field` where TBL is a PARAMETER that is an unpacked array of a
+    // struct type (cvxif's `parameter copro_issue_resp_t CoproInstr[NbInstr]`).
+    // There is no wire to select from: the whole array is a constant, and the
+    // value lives in the enclosing scope's param_assign rather than in the
+    // parameter's VpiValue/Expr.  Without this the read produced X, which after
+    // synthesis reads as the field simply being zero.
+    if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 2) {
+        auto& pe_pa = *uhdm_hier->Path_elems();
+        if (pe_pa[0]->UhdmType() == uhdmbit_select) {
+            std::vector<std::string> fields;
+            for (size_t i = 1; i < pe_pa.size(); i++) {
+                if (pe_pa[i]->UhdmType() != uhdmref_obj) { fields.clear(); break; }
+                fields.push_back(
+                    std::string(any_cast<const ref_obj*>(pe_pa[i])->VpiName()));
+            }
+            if (!fields.empty()) {
+                RTLIL::SigSpec r = import_param_array_elem_field(
+                    any_cast<const bit_select*>(pe_pa[0]), fields, inst,
+                    input_mapping);
+                if (r.size() > 0)
+                    return r;
+            }
+        }
+    }
+
 
     // Nested interface struct-parameter field: `s.CFG.BUS.DAT` where `s` is a
     // modport port and `CFG` is a (nested struct) parameter on the connected

--- a/src/frontends/uhdm/functions.cpp
+++ b/src/frontends/uhdm/functions.cpp
@@ -1065,6 +1065,33 @@ RTLIL::Const UhdmImporter::evaluate_single_operand(const any* operand,
         // (RISC-V decoder immediate functions).  Extract the member bits from
         // the base struct constant using the base variable's struct typespec.
         const hier_path* hp = any_cast<const hier_path*>(operand);
+        // `CoproInstr[i].resp.accept`: an element of a PARAMETER that is an
+        // unpacked array of structs, read while this loop is being unrolled.
+        // The base is not a local variable, so the struct-member path below
+        // does not apply and the read used to fall through as zero -- which is
+        // how the cvxif decoders silently decoded every instruction as "not
+        // mine".  The index is a loop variable, already known here, so hand it
+        // to the shared resolver rather than re-importing it.
+        if (hp && hp->Path_elems() && hp->Path_elems()->size() >= 2 &&
+            (*hp->Path_elems())[0]->UhdmType() == uhdmbit_select) {
+            auto& pe0 = *hp->Path_elems();
+            std::vector<std::string> fields;
+            for (size_t i = 1; i < pe0.size(); i++) {
+                if (pe0[i]->UhdmType() != uhdmref_obj) { fields.clear(); break; }
+                fields.push_back(std::string(pe0[i]->VpiName()));
+            }
+            const bit_select* pbs = any_cast<const bit_select*>(pe0[0]);
+            if (!fields.empty() && pbs && pbs->VpiIndex()) {
+                RTLIL::Const iv = evaluate_single_operand(pbs->VpiIndex(), local_vars);
+                if (iv.size() > 0) {
+                    RTLIL::SigSpec idx(iv);
+                    RTLIL::SigSpec r = import_param_array_elem_field(
+                        pbs, fields, nullptr, nullptr, &idx);
+                    if (r.size() > 0 && r.is_fully_const())
+                        return r.as_const();
+                }
+            }
+        }
         if (hp && hp->Path_elems() && hp->Path_elems()->size() >= 2) {
             auto& pe = *hp->Path_elems();
             std::string base = std::string(pe[0]->VpiName());

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -900,6 +900,13 @@ struct UhdmImporter {
     RTLIL::SigSpec import_indexed_part_select(const UHDM::indexed_part_select* uhdm_indexed, const UHDM::scope* inst = nullptr, const std::map<std::string, RTLIL::SigSpec>* input_mapping = nullptr);
     RTLIL::SigSpec import_concat(const UHDM::operation* uhdm_concat, const UHDM::scope* inst = nullptr);
     RTLIL::SigSpec import_hier_path(const UHDM::hier_path* uhdm_hier, const UHDM::scope* inst = nullptr, const std::map<std::string, RTLIL::SigSpec>* input_mapping = nullptr);
+    // `PARAM[idx].field` where PARAM is an unpacked array of structs.  Empty
+    // SigSpec when this is not that shape, so callers can fall through.
+    RTLIL::SigSpec import_param_array_elem_field(const UHDM::bit_select* bs,
+                                                 const std::vector<std::string>& fields,
+                                                 const UHDM::scope* inst = nullptr,
+                                                 const std::map<std::string, RTLIL::SigSpec>* input_mapping = nullptr,
+                                                 const RTLIL::SigSpec* idx_in = nullptr);
     
     // Side-effect helpers for assignment expressions and inc/dec
     void emit_comb_assign(RTLIL::SigSpec lhs, RTLIL::SigSpec rhs, RTLIL::Process* proc);

--- a/test/param_unpacked_struct_array/dut.sv
+++ b/test/param_unpacked_struct_array/dut.sv
@@ -1,0 +1,45 @@
+// N == 2**$bits(sel_i) on purpose: an OUT-OF-RANGE unpacked-array read is
+// undefined behaviour and simulators legitimately differ, which would swamp
+// the behaviour under test.
+// A parameter that is an UNPACKED ARRAY of a STRUCT type, indexed at runtime.
+// This is how cvxif's instr_decoder is configured (`parameter copro_issue_resp_t
+// CoproInstr [NbInstr]`), and reading an element's fields is what went to zero.
+package pk;
+  typedef struct packed {
+    logic [7:0] tag;
+    logic [3:0] code;
+    logic       accept;
+  } entry_t;
+
+  parameter int N = 4;
+  parameter entry_t TBL[N] = '{
+      '{tag: 8'hA1, code: 4'h5, accept: 1'b1},
+      '{tag: 8'hB2, code: 4'h6, accept: 1'b0},
+      '{tag: 8'hC3, code: 4'h7, accept: 1'b1},
+      '{tag: 8'hD4, code: 4'h8, accept: 1'b0}
+  };
+endpackage
+
+module dut (
+    input  logic       clk_i,
+    input  logic [1:0] sel_i,
+    input  logic [7:0] tag_i,
+    output logic [7:0] tag_o,
+    output logic [3:0] code_o,
+    output logic       accept_o,
+    output logic       hit_o
+);
+  import pk::*;
+
+  // element selected by a runtime index
+  assign tag_o    = TBL[sel_i].tag;
+  assign code_o   = TBL[sel_i].code;
+  assign accept_o = TBL[sel_i].accept;
+
+  // the decoder pattern: compare an input against every entry
+  logic [N-1:0] match;
+  always_comb begin
+    for (int i = 0; i < N; i++) match[i] = (TBL[i].tag == tag_i);
+  end
+  assign hit_o = |match;
+endmodule

--- a/test/param_unpacked_struct_array/test_slang_equiv.ys
+++ b/test/param_unpacked_struct_array/test_slang_equiv.ys
@@ -1,0 +1,15 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gold
+design -stash gold
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+hierarchy -top miter
+sat -verify -prove-asserts -seq 4 -set-init-zero miter


### PR DESCRIPTION
`PARAM[idx].field` returned **X**. Surelog keeps such a parameter's value in the enclosing scope's `param_assign` — an assignment pattern of assignment patterns — rather than in `VpiValue`/`Expr`, and the element is a struct rather than a vector, so neither the wire-based element/field paths nor the scalar-parameter path applied.

The fix evaluates the whole array to one constant and cuts the requested field out of the requested element; a non-constant index selects between the per-element field slices.

## Three defects, each of which alone produced a plausible wrong answer

**Order.** An assignment pattern is concatenated with element 0 first, and a Verilog concatenation puts its first operand in the **high** bits — so element 0 lives at the *top* of the flattened value. Indexing from the bottom silently **reverses the array**: a decoder table still matches, just against the wrong entries. Caught only because the test compares element by element against `read_slang`.

**Width.** `import_expression` sizes an assignment pattern to the ambient context width, which here belongs to the *field being read*. Reading a 1-bit `.accept` imported the whole 4-element table as 1 bit, so the element width came out as 1. The 1-bit field then "worked" while the 8-bit one bailed — partial success that reads as progress. The array literal is now imported at its natural width.

**Depth.** The chain can be more than one field deep (`CoproInstr[i].resp.accept`); stopping after the first field left the read unresolved, which again reads as zero.

The resolver is also reachable from the compile-time evaluator, so the same read works while a for-loop is being unrolled — there the loop index is already known, so it is handed to the shared resolver rather than re-imported.

## Verification

`test/param_unpacked_struct_array` is **SAT-proven equivalent** to `read_slang` and passes the Verilator co-sim with **0 mismatches**.

Its table has exactly `2**$bits(sel_i)` entries on purpose: an out-of-range unpacked-array read is undefined behaviour and simulators legitimately disagree, which would otherwise swamp the behaviour under test. (My first version had 3 entries against a 2-bit index and spent a co-sim run chasing that.)

Full regression: **ALL RESULTS AS EXPECTED**, Miter-Formal **0**, 0 crashes. The 3 Induct-Formal failures are the unchanged pre-existing baseline.

## Scope

This does **not** yet fix the cvxif modules in the CVA6 suite, which is where the bug was found. There the wrapper binds `parameter type copro_issue_resp_t = ...` and the element typespec resolves to `logic_typespec` — the struct layout is erased, so there are no members to compute a field offset from. That is a separate gap in type-parameter resolution, and I'd rather land this proven piece than stack a speculative change on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)