### PR TITLE
uhdm: resolve an erased type-parameter element type for param array reads

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7542,13 +7542,25 @@ RTLIL::SigSpec UhdmImporter::import_param_array_elem_field(
     const UHDM::struct_typespec* st = nullptr;
     if (auto rt = param->Typespec())
         if (auto ats = rt->Actual_typespec()) {
+            const UHDM::typespec* et = nullptr;
             if (ats->UhdmType() == uhdmarray_typespec) {
                 auto arr = any_cast<const UHDM::array_typespec*>(ats);
                 if (arr->Elem_typespec())
-                    if (auto et = arr->Elem_typespec()->Actual_typespec())
-                        st = dynamic_cast<const UHDM::struct_typespec*>(et);
+                    et = arr->Elem_typespec()->Actual_typespec();
             } else {
-                st = dynamic_cast<const UHDM::struct_typespec*>(ats);
+                et = dynamic_cast<const UHDM::typespec*>(ats);
+            }
+            st = et ? dynamic_cast<const UHDM::struct_typespec*>(et) : nullptr;
+            // The element type can be a TYPE PARAMETER whose default has been
+            // erased to plain `logic` (`parameter type copro_issue_resp_t =
+            // logic`, bound at the instance to the package's struct).  The
+            // erased default has no members, so the field offsets cannot be
+            // computed from it -- resolve it to the type the instance actually
+            // binds.
+            if (!st && et) {
+                const UHDM::typespec* bound = resolve_type_param_typespec(et, inst);
+                if (bound && bound != et)
+                    st = dynamic_cast<const UHDM::struct_typespec*>(bound);
             }
         }
     if (!st || !st->Members())


### PR DESCRIPTION
Follow-up to #606. `PARAM[i].field` still read as **zero** for the cvxif decoders.

The element type there is a **type parameter** whose default has been erased to plain `logic` — `parameter type copro_issue_resp_t = logic`, bound at the instance to the package's struct. An erased default has no members, so there were no field offsets to compute and every access bailed: in `instr_decoder`, all **60** of them.

The fix routes the element typespec through the existing `resolve_type_param_typespec()`, so it becomes the type the instance actually binds.

## Adjudicated against the behavioural RTL

`scripts/adjudicate.py`, 5000 cycles, three-way RTL vs uhdm vs slang:

| module | before | after |
| --- | --- | --- |
| `compressed_instr_decoder` | 86 divergences | **0 — NO_DIVERGENCE** |
| `cvxif_example_coprocessor` | 90 | 6 |
| `instr_decoder` | 2 | 1 |

## The residue is a different defect

Not leftover type-parameter trouble. Both remaining modules warn `Reference to unknown signal: j` for the **inner** loop of:

```systemverilog
for (int unsigned i = 0; i < NbInstr; i++)
  ...
  for (int unsigned j = 0; j < NrRgprPorts; j++)
    registers_o[j] = issue_resp_o.register_read[j] ? register_i.rs[j] : '0;
```

The outer loop unrolls; the nested one does not resolve its index. `cvxif_resp_o` differing in exactly the register-read nibble (`fe` vs `7a`) is consistent with that, and it is the next thing to fix.

## Verification

Full regression: **ALL RESULTS AS EXPECTED**, Miter-Formal **0**, 0 crashes. The 3 Induct-Formal failures are the unchanged pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)