### PR TITLE
uhdm: allow a trailing bit-select on a param-array struct field (cvxif PROVEN)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7693,18 +7693,45 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
     if (uhdm_hier->Path_elems() && uhdm_hier->Path_elems()->size() >= 2) {
         auto& pe_pa = *uhdm_hier->Path_elems();
         if (pe_pa[0]->UhdmType() == uhdmbit_select) {
+            // The LAST element may itself be a bit_select -- the field is a
+            // vector and a bit of it is taken
+            // (`CoproInstr[i].resp.register_read[2]`).  Treating that as "not a
+            // field chain" abandoned the whole access, which is what still
+            // fed `issue_ready_o` from a zero.
             std::vector<std::string> fields;
+            const bit_select* tail_sel = nullptr;
             for (size_t i = 1; i < pe_pa.size(); i++) {
-                if (pe_pa[i]->UhdmType() != uhdmref_obj) { fields.clear(); break; }
-                fields.push_back(
-                    std::string(any_cast<const ref_obj*>(pe_pa[i])->VpiName()));
+                if (pe_pa[i]->UhdmType() == uhdmref_obj) {
+                    fields.push_back(
+                        std::string(any_cast<const ref_obj*>(pe_pa[i])->VpiName()));
+                } else if (pe_pa[i]->UhdmType() == uhdmbit_select &&
+                           i + 1 == pe_pa.size()) {
+                    tail_sel = any_cast<const bit_select*>(pe_pa[i]);
+                    fields.push_back(std::string(tail_sel->VpiName()));
+                } else {
+                    fields.clear(); break;
+                }
             }
             if (!fields.empty()) {
                 RTLIL::SigSpec r = import_param_array_elem_field(
                     any_cast<const bit_select*>(pe_pa[0]), fields, inst,
                     input_mapping);
-                if (r.size() > 0)
-                    return r;
+                if (r.size() > 0) {
+                    if (!tail_sel)
+                        return r;
+                    RTLIL::SigSpec bi = tail_sel->VpiIndex()
+                        ? import_expression(tail_sel->VpiIndex(), input_mapping)
+                        : RTLIL::SigSpec();
+                    if (bi.size() > 0 && bi.is_fully_const()) {
+                        int b = bi.as_const().as_int();
+                        if (b >= 0 && b < r.size())
+                            return r.extract(b, 1);
+                    } else if (bi.size() > 0) {
+                        RTLIL::Wire* yw = module->addWire(NEW_ID, 1);
+                        module->addShiftx(NEW_ID, r, bi, yw, false);
+                        return RTLIL::SigSpec(yw);
+                    }
+                }
             }
         }
     }

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -44,7 +44,7 @@ btb                                    4   900   proven
 cache_ctrl                             4   180   cex
 commit_stage                           4   900   proven
 compressed_decoder                     4   900   proven
-compressed_instr_decoder               4   400   cex      # UHDM WRONG (adjudicated): c17 compressed_resp_o low bits zeroed by uhdm
+compressed_instr_decoder               4   400   proven
 control_mvp                            4   400   proven
 controller                             4   900   proven
 copro_alu                              4   400   proven
@@ -64,7 +64,7 @@ cva6_rvfi_probes                       4   180   cex
 cva6_shared_tlb                        4   900   proven
 cva6_tlb                               4   900   proven
 cvxif_compressed_if_driver             4   900   proven
-cvxif_example_coprocessor              4   400   cex      # UHDM WRONG (adjudicated): c20 cvxif_resp_o field zeroed by uhdm
+cvxif_example_coprocessor              4   400   proven
 cvxif_fu                               4   900   proven
 cvxif_issue_register_commit_if_driver  4   900   proven
 decoder                                4   900   proven
@@ -134,7 +134,7 @@ hwpf_stride                            4   400   timeout
 hwpf_stride_arb                        4   400   timeout
 hwpf_stride_wrapper                    4   400   timeout
 id_stage                               4   180   cex
-instr_decoder                          4   400   cex      # UHDM WRONG (adjudicated): c163 issue_resp_o/registers_o uhdm=0, slang==rtl
+instr_decoder                          4   400   proven
 instr_queue                            4   900   proven
 instr_realign                          4   900   proven
 instr_scan                             4   900   proven

--- a/test/param_struct_field_bitsel/dut.sv
+++ b/test/param_struct_field_bitsel/dut.sv
@@ -1,0 +1,47 @@
+// Reading a BIT of a struct field of an element of a parameter that is an
+// unpacked array of structs: `TBL[i].flags[b]`.
+//
+// The path is hier_path[bit_select(TBL,i), ref_obj(flags), bit_select(b)] --
+// the trailing element is a bit_select rather than a plain field reference,
+// and treating that as "not a field chain" abandons the whole access, which
+// then reads as zero.  cvxif's instr_decoder gates issue_ready_o on exactly
+// this shape (`CoproInstr[i].resp.register_read[2]`).
+package pk;
+  typedef struct packed {
+    logic [7:0] tag;
+    logic [3:0] flags;
+  } entry_t;
+
+  parameter int N = 4;
+  parameter entry_t TBL[N] = '{
+      '{tag: 8'hA1, flags: 4'b1101},
+      '{tag: 8'hB2, flags: 4'b0010},
+      '{tag: 8'hC3, flags: 4'b0111},
+      '{tag: 8'hD4, flags: 4'b1000}
+  };
+endpackage
+
+module dut (
+    input  logic       clk_i,
+    input  logic [1:0] sel_i,
+    input  logic [1:0] bit_i,   // 2 bits vs a 4-bit field: always in range
+    output logic       const_bit_o,
+    output logic       dyn_bit_o,
+    output logic [3:0] all_flags_o,
+    output logic       ready_o
+);
+  import pk::*;
+
+  // constant bit index of a field of a dynamically selected element
+  assign const_bit_o = TBL[sel_i].flags[2];
+  // dynamic bit index too
+  assign dyn_bit_o   = TBL[sel_i].flags[bit_i];
+  assign all_flags_o = TBL[sel_i].flags;
+
+  // the cvxif gating shape: a loop-constant element, bit of a vector field
+  always_comb begin
+    ready_o = 1'b0;
+    for (int unsigned i = 0; i < N; i++)
+      if (i == sel_i) ready_o = ~TBL[i].flags[0] || TBL[i].flags[1];
+  end
+endmodule

--- a/test/param_struct_field_bitsel/test_slang_equiv.ys
+++ b/test/param_struct_field_bitsel/test_slang_equiv.ys
@@ -1,0 +1,15 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gold
+design -stash gold
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+hierarchy -top miter
+sat -verify -prove-asserts -seq 4 -set-init-zero miter


### PR DESCRIPTION
`CoproInstr[i].resp.register_read[2]` is a hier_path whose **last** element is a `bit_select`, not a plain field reference. The field-chain walk required every trailing element to be a `ref_obj`, so it abandoned the whole access and the read fell back to zero — which is what still gated cvxif's `issue_ready_o` after #606 and #607.

Accept a `bit_select` in the final position: resolve the field as before, then take the bit (constant index → extract, dynamic → `$shiftx`).

## All three cvxif modules are now PROVEN

They started this sequence as counterexamples:

| module | before | after |
| --- | --- | --- |
| `compressed_instr_decoder` | cex | **proven** |
| `instr_decoder` | cex | **proven** |
| `cvxif_example_coprocessor` | cex | **proven** |

CVA6 manifest: **47 proven** (+3), 26 cex.

## A note on the diagnosis, because my first attempt was wrong

Both modules also warn `Reference to unknown signal: j` for the inner loop of a nested `for`, and I built a reproducer for that first — **it passes the miter**. The warning is benign, and chasing it would have kept me busy on the wrong defect.

Going back to the failing expression's own dependency chain (`issue_ready_o` → … → `register_read[2]`) is what found the real shape. `test/param_struct_field_bitsel` covers it with both a constant and a dynamic bit index, and is SAT-proven against `read_slang`.

Its `flags` field is 4 bits against a 2-bit index on purpose: an out-of-range bit select is undefined behaviour and the simulators legitimately disagree (uhdm `0`, slang `x`, Verilator `1`). In-range indices match slang exactly — I verified index by index rather than assuming.

## Verification

Regression run with 6 parallel shards: **REGRESSION SUITE PASSED**, no Miter-Formal escapes, 0 crashes.

One unrelated observation: the parallel combiner counts a Verilator co-sim *skip* as a new warning where the sequential runner tolerates it, which is why `rp32_r5p_csr` shows up. That netlist has a 104256-bit constant Verilator cannot build; it predates this work (my code path never fires on that test) and is a reporting discrepancy worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)