### PR TITLE
uhdm: `'{default: V}` on a packed array filled BIT-wise in procedural context

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3707,9 +3707,21 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                     }
                 }
                 if (tw <= 0) tw = expression_context_width;
+                RTLIL::SigSpec defval = import_expression(
+                    any_cast<const expr*>(deftp->Pattern()), input_mapping);
+                // In a PROCEDURAL assignment the pattern carries no typespec,
+                // so the element width above stays 1 and the value is
+                // replicated BIT-wise -- `'{default: rd_idx_i[sel]}` on a
+                // `logic [3:0][7:0]` filled all 32 bits with bit 0 of the
+                // 8-bit value (wt_dcache_mem's bank_idx).  When the fill value
+                // is a NON-CONSTANT expression narrower than the target and
+                // dividing it evenly, it is already element-typed, so take its
+                // width as the element width.  Constant fills (`'{default: 0}`,
+                // `'{default: 1}`) keep the bitwise semantics they need.
+                if (ew == 1 && !defval.is_fully_const() && defval.size() > 1 &&
+                    tw > defval.size() && tw % defval.size() == 0)
+                    ew = defval.size();
                 if (tw > 0 && ew > 0 && tw % ew == 0) {
-                    RTLIL::SigSpec defval = import_expression(
-                        any_cast<const expr*>(deftp->Pattern()), input_mapping);
                     if (defval.size() < ew) defval.extend_u0(ew);
                     else if (defval.size() > ew) defval = defval.extract(0, ew);
                     RTLIL::SigSpec result;

--- a/test/comb_dyn_2d_packed_sel/dut.sv
+++ b/test/comb_dyn_2d_packed_sel/dut.sv
@@ -1,0 +1,60 @@
+// The shapes wt_dcache_mem's p_bank_req block is built from:
+//   - 2-D packed inputs indexed by a REGISTERED selector  (rd_off_i[vld_sel_d])
+//   - a part-select of such an element, inside a for loop (bank_collision[k])
+//   - an unpacked array written at a COMPUTED dynamic index (bank_idx[...])
+//   - an output gated on a dynamic bit-select of a vector written earlier in
+//     the same always_comb
+module dut #(
+    parameter int unsigned NumPorts = 4,
+    parameter int unsigned OFF_W    = 6,
+    parameter int unsigned IDX_W    = 8,
+    parameter int unsigned ALIGN    = 3
+) (
+    input  logic                              clk_i,
+    input  logic                              rst_ni,
+    input  logic [NumPorts-1:0][OFF_W-1:0]    rd_off_i,
+    input  logic [NumPorts-1:0][IDX_W-1:0]    rd_idx_i,
+    input  logic [NumPorts-1:0]               rd_req_i,
+    input  logic [NumPorts-1:0]               rd_tag_only_i,
+    input  logic [NumPorts-1:0]               rd_ack_i,
+    input  logic [OFF_W-1:0]                  wr_off_i,
+    input  logic                              wr_req_i,
+    output logic                              wr_ack_o,
+    output logic [IDX_W-1:0]                  bank_idx_o,
+    output logic [NumPorts-1:0]               bank_req_o
+);
+  localparam int SEL_W = $clog2(NumPorts);
+  logic [SEL_W-1:0]  vld_sel_d, vld_sel_q;
+  logic [NumPorts-1:0] bank_collision;
+  logic [NumPorts-1:0][IDX_W-1:0] bank_idx;
+
+  // a registered selector, like vld_sel_q
+  assign vld_sel_d = rd_req_i[0] ? SEL_W'(1) : SEL_W'(2);
+  always_ff @(posedge clk_i or negedge rst_ni)
+    if (!rst_ni) vld_sel_q <= '0;
+    else         vld_sel_q <= vld_sel_d;
+
+  always_comb begin
+    bank_req_o = '0;
+    wr_ack_o   = 1'b0;
+    bank_idx   = '{default: rd_idx_i[vld_sel_q]};
+
+    for (int k = 0; k < NumPorts; k++)
+      bank_collision[k] = rd_off_i[k][OFF_W-1:ALIGN] == wr_off_i[OFF_W-1:ALIGN];
+
+    if (|rd_req_i) begin
+      // write at a COMPUTED dynamic index
+      bank_idx[rd_off_i[vld_sel_q][OFF_W-1:ALIGN]] = rd_idx_i[vld_sel_q];
+      bank_req_o[vld_sel_q] = 1'b1;
+    end
+
+    if (wr_req_i) begin
+      if (rd_tag_only_i[vld_sel_q] ||
+          !(rd_ack_i[vld_sel_q] && bank_collision[vld_sel_q])) begin
+        wr_ack_o = 1'b1;
+      end
+    end
+  end
+
+  assign bank_idx_o = bank_idx[vld_sel_q];
+endmodule

--- a/test/comb_dyn_2d_packed_sel/test_slang_equiv.ys
+++ b/test/comb_dyn_2d_packed_sel/test_slang_equiv.ys
@@ -1,0 +1,15 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gold
+design -stash gold
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+hierarchy -top miter
+sat -verify -prove-asserts -seq 4 -set-init-zero miter


### PR DESCRIPTION
`bank_idx = '{default: rd_idx_i[sel]}` on a `logic [3:0][7:0]` filled all 32 bits with **bit 0** of the 8-bit value instead of giving each element the value.

- slang: `{v, v, v, v}`
- uhdm: `{bank_idx[0] × 32}`

The packed-array fill path derives the element width from the pattern's typespec, but in a **procedural** assignment the pattern carries no typespec — the only context is the LHS width — so the element width stayed 1 and the value was replicated bit-wise.

## The fix, and why it is deliberately narrow

Infer the element width from a fill value that is **non-constant**, narrower than the target, and divides it evenly. Such a value is already element-typed, which is exactly the `'{default: <element expression>}` case.

Constant fills keep the bit-wise semantics they rely on:

- `'{default: 0}` / `'{default: 1}` on a plain vector must still touch every bit
- `'{default: 32'd5}` on a 32-bit vector means all-ones-after-truncation, **not** the literal 5

A broader "always infer from the value" rule would have silently changed both.

## Verification

`test/comb_dyn_2d_packed_sel` is SAT-proven against `read_slang`, both minimal and in the full shape of `wt_dcache_mem`'s `p_bank_req` block (2-D packed inputs indexed by a registered selector, a part-select of such an element inside a loop, an array written at a computed dynamic index).

Regression (6 parallel shards): **SUITE PASSED**, Miter-Formal **0**, **0 new** sim-equiv warnings, 0 crashes. CVA6 spot check: 8 modules, 0 regressions.

## Method note

Found by bisecting the RTL down to a 12-line module. Two earlier hypotheses — nested-loop unrolling, and a dynamic read after a loop write in the same `always_comb` — both produced reproducers that **pass** the miter. Neither a printed warning nor a plausible-sounding story is evidence.

## Scope

This does **not** close the `wt_dcache` counterexamples. `wt_dcache_mem`'s `wr_ack_o` still differs at cycle 4 (`rtl=0 uhdm=1 slang=0`) and `wt_dcache_missunit` still shows 3 divergences in 3000 cycles — separate causes in the same modules, which I'll continue on rather than bundle here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)