### PR TITLE
cva6: root-cause wt_dcache_mem's wr_ack_o counterexample (repro, no fix yet)

### DIFF
--- a/test/arb_idx_cast/README.md
+++ b/test/arb_idx_cast/README.md
@@ -1,0 +1,39 @@
+# arb_idx_cast — KNOWN FAILING (documented in ../failing_tests.txt)
+
+A bit- or part-select of an ELEMENT of a packed array whose element type is a
+TYPE PARAMETER collapses to a constant:
+
+    idx_t [3:0] nodes;          // idx_t is `parameter type idx_t = logic [1:0]`
+    assign elem_o = nodes[2];        // correct   -> arr_i[5:4]
+    assign bit_o  = nodes[2][0];     // WRONG     -> 1'h0   (want arr_i[4])
+    assign cat_o  = {1'b1, nodes[2][0:0]};  // WRONG -> 2'h3 (want {1'h1, arr_i[4]})
+
+The whole-element read is right, so the array geometry is known — the wire even
+carries correct `packed_elem_width` / `packed_outer_*` attributes.  Only the
+second index is dropped.
+
+## Why this matters
+
+`rr_arb_tree` (pulp common_cells) builds its `idx_o` from exactly this shape:
+
+    assign index_nodes[Idx0] = idx_t'({1'b1, index_nodes[Idx1+1][NumLevels-level-2:0]});
+
+so the child index bit is lost and the arbiter reports the wrong port.  That is
+what makes `wt_dcache_mem` gate `wr_ack_o` on the wrong port
+(`rtl=0 uhdm=1 slang=0` at cycle 4, stable across seeds).
+
+## Why the obvious fix is not enough
+
+Resolving the access from the wire's `packed_*` attributes fixes this test, but
+it also claims THREE-dimensional packed selects — tc_sram's
+`data_t [NumPorts-1:0][Latency-1:0] rdata_q`, where `rdata_q[i][j]` selects a
+whole 32-bit sub-element rather than a bit.  Reading those as 1 bit makes
+`rdata_q[i][j] <= rdata_d[i][j]` collapse and the async reset stops being
+constant, so `wt_dcache_mem` fails to import at all — a worse bug than the one
+being fixed.
+
+Neither discriminator tried works: the wires carry no packed-dimension count,
+and the declared range count is the same (1) for both shapes because Surelog
+represents `T [N-1:0]` and `data_t [N-1:0][L-1:0]` identically once the element
+type is erased.  A correct fix needs the frontend to record how many packed
+dimensions a wire has at the point where it still knows.

--- a/test/arb_idx_cast/dut.sv
+++ b/test/arb_idx_cast/dut.sv
@@ -1,0 +1,38 @@
+// rr_arb_tree's index tree: a packed array of a TYPE-PARAMETER type, written
+// in a generate loop with a cast over a concat whose part-select bounds are
+// computed from the genvar.
+module dut #(
+    parameter int unsigned NumIn     = 4,
+    parameter int unsigned NumLevels = 2,
+    parameter int unsigned IdxWidth  = 2,
+    parameter type         idx_t     = logic [IdxWidth-1:0]
+) (
+    input  logic                clk_i,
+    input  logic [NumIn-1:0]    req_i,
+    input  logic [NumLevels-1:0] rr_i,
+    output idx_t                idx_o
+);
+  idx_t [2**NumLevels-2:0] index_nodes;
+  logic [2**NumLevels-2:0] req_nodes;
+
+  for (genvar level = 0; unsigned'(level) < NumLevels; level++) begin : gen_levels
+    for (genvar l = 0; l < 2**level; l++) begin : gen_level
+      logic sel;
+      localparam int unsigned Idx0 = 2**level-1+l;
+      localparam int unsigned Idx1 = 2**(level+1)-1+l*2;
+      if (unsigned'(level) == NumLevels-1) begin : gen_first_level
+        assign req_nodes[Idx0]   = req_i[l*2] | req_i[l*2+1];
+        assign sel               = ~req_i[l*2] | req_i[l*2+1] & rr_i[NumLevels-1-level];
+        assign index_nodes[Idx0] = idx_t'(sel);
+      end else begin : gen_other_levels
+        assign req_nodes[Idx0]   = req_nodes[Idx1] | req_nodes[Idx1+1];
+        assign sel               = ~req_nodes[Idx1] | req_nodes[Idx1+1] & rr_i[NumLevels-1-level];
+        assign index_nodes[Idx0] = (sel) ?
+            idx_t'({1'b1, index_nodes[Idx1+1][NumLevels-unsigned'(level)-2:0]}) :
+            idx_t'({1'b0, index_nodes[Idx1][NumLevels-unsigned'(level)-2:0]});
+      end
+    end
+  end
+
+  assign idx_o = index_nodes[0];
+endmodule

--- a/test/arb_idx_cast/test_slang_equiv.ys
+++ b/test/arb_idx_cast/test_slang_equiv.ys
@@ -1,0 +1,15 @@
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gold
+design -stash gold
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast; async2sync; setundef -undriven -zero
+rename dut gate
+design -stash gate
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+hierarchy -top miter
+sat -verify -prove-asserts -seq 4 -set-init-zero miter

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -166,3 +166,10 @@
 #   2*32.  The UHDM frontend never even sees the func_call (verified by probing
 #   import_expression: only the pre-folded 2-bit constant arrives).  Fix belongs
 #   in Surelog`s function-return const-evaluation; deferred (Surelog change).
+
+arb_idx_cast
+    Bit/part-select of an element of a packed array with a TYPE-PARAMETER
+    element type drops the second index (folds to a constant).  Root cause of
+    rr_arb_tree's wrong idx_o and hence wt_dcache_mem's wr_ack_o
+    counterexample.  Minimal repro + analysis of why the obvious fix regresses
+    3-D packed selects: test/arb_idx_cast/README.md.

--- a/test/cva6_equiv/scripts/adjudicate.py
+++ b/test/cva6_equiv/scripts/adjudicate.py
@@ -39,7 +39,7 @@ if not (os.path.exists("adj_gold.v") and os.path.exists("adj_gate.v")):
     open("adj.ys", "w").write(f"""
 read_uhdm slpp_all/surelog.uhdm
 hierarchy -check -top {TOP}
-flatten; proc; memory; opt -fast; setundef -undriven -zero
+flatten; proc; memory; opt -fast; async2sync; setundef -undriven -zero
 delete t:$check t:$assert t:$assume t:$print
 simplemap t:$bwmux
 rename {TOP} gold_{TOP}
@@ -47,7 +47,7 @@ write_verilog -noattr adj_gold.v
 design -reset
 read_slang --ignore-assertions -f {FLIST} {WRAP} --top {TOP}
 hierarchy -check -top {TOP}
-flatten; proc; memory; opt -fast; setundef -undriven -zero
+flatten; proc; memory; opt -fast; async2sync; setundef -undriven -zero
 delete t:$check t:$assert t:$assume t:$print
 simplemap t:$bwmux
 rename {TOP} gate_{TOP}

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -682,3 +682,17 @@ Test: latch_packed_dyn_write
     design produces.  Kept as a note: out-of-range dynamic packed-element
     part-select writes are implementation-divergent territory — keep
     repro stimulus in range.
+
+Test: arb_idx_cast
+    A REAL UHDM bug, checked in deliberately as a reproducer (also listed in
+    failing_tests.txt and cosim_uhdm_bugs.txt).  A bit- or part-select of an
+    ELEMENT of a packed array whose element type is a TYPE PARAMETER drops the
+    second index and folds to a constant: for `idx_t [3:0] nodes`, `nodes[2]`
+    reads correctly but `nodes[2][0]` yields 1'h0 and `{1'b1, nodes[2][0:0]}`
+    yields 2'h3.  The wire carries correct packed_elem_width/packed_outer_*
+    attributes, so only the second index is lost.  This is what makes
+    rr_arb_tree's idx_o report the wrong port and gates wt_dcache_mem's
+    wr_ack_o incorrectly.  See arb_idx_cast/README.md for why resolving it
+    from those attributes is not a safe fix (it steals 3-D packed selects such
+    as tc_sram's `data_t [NumPorts-1:0][Latency-1:0] rdata_q`, whose second
+    index selects a whole sub-element, and wt_dcache_mem then fails to import).

--- a/test/sim_equiv_classification.txt
+++ b/test/sim_equiv_classification.txt
@@ -73,3 +73,4 @@ TaskReturn                            artefact   # procedural assign-in-task + u
 assignment-pattern                    artefact   # self-checking asserts $stop the Verilator sim
 rp32_r5p_mouse        artefact   # reset-dependent CPU core; miter runs without asserting rst -> false NON-EQ; co-sim X-prop adjudicated (verilog netlist diverges from Verilator the same way)
 ibex_register_file_fpga  artefact   # FPGA regfile; Verilator co-sim PASSES (0 mismatches), equiv_induct false NON-EQ on reset-dependent state (same class as rp32_r5p_mouse)
+arb_idx_cast          bug        # packed-array elem bit/part-select with a TYPE-PARAM element drops the 2nd index; see arb_idx_cast/README.md


### PR DESCRIPTION
**This PR contains no frontend fix.** It lands the root-cause analysis and a minimal reproducer, because the fix I built traded the bug for a worse one. Detail below.

## Root cause

`wr_ack_o` gates on `rd_ack_o[vld_sel_d]` and `bank_collision[vld_sel_d]`; both `vld_sel_d` and `rd_ack_o` come from `rr_arb_tree`. Exposing that arbiter's outputs one at a time: **`idx_o` differs**, `gnt_o` and `req_o` are fine. It is built as `idx_t'({1'b1, index_nodes[Idx1+1][NumLevels-level-2:0]})`.

Reduced to 17 lines (`test/arb_idx_cast`). For `idx_t [3:0] nodes` where `idx_t` is a **type parameter**:

| expression | got | want |
| --- | --- | --- |
| `nodes[2]` | `arr_i[5:4]` ✅ | whole element |
| `nodes[2][0]` | `1'h0` ❌ | `arr_i[4]` |
| `{1'b1, nodes[2][0:0]}` | `2'h3` ❌ | `{1'h1, arr_i[4]}` |

Surelog gives a `var_select` with two `Exprs`, and the wire carries correct `packed_elem_width` / `packed_outer_*` attributes. Only the second index is lost.

## Why no fix

Resolving the access from those attributes fixes this test — and then claims **three**-dimensional packed selects too. tc_sram's `data_t [NumPorts-1:0][Latency-1:0] rdata_q` has `rdata_q[i][j]` selecting a whole 32-bit sub-element. Read as one bit, `rdata_q[i][j] <= rdata_d[i][j]` collapses, its async reset stops being constant, and **`wt_dcache_mem` fails to import at all** — strictly worse than the original bug.

Three discriminators tried, none works:

1. **port vs internal wire** — the offending wire is internal, but so are `rdata_q`/`rdata_d`
2. **a new packed-dimension attribute** — four stamping sites, and the wire that needs it gets none
3. **declared range count at the reader** — Surelog reports one range for *both* shapes once the element type is erased

A correct fix has to record the packed dimension count where the frontend still knows it. `README.md` carries the full analysis so the next attempt starts from evidence.

## Bookkeeping

Recorded as a real bug in `sim_equiv_analyzed.txt`, `cosim_uhdm_bugs.txt`, `sim_equiv_classification.txt`.

**Not** in `failing_tests.txt`: the standard flow *passes* this test (UHDM handles type parameters that `read_verilog` cannot parse at all), so listing it produced a false "UNEXPECTED SUCCESS". I had it wrong first and corrected it.

Also fixes `scripts/adjudicate.py`, which needs `async2sync` to match the miter pipeline — without it, netlist generation fails outright on async-reset designs.

## Two harness gaps found on the way

- **`run_cva6_equiv.sh` reports a yosys ERROR as `timeout`.** This made `wt_dcache_mem` look like it had improved `cex` → `timeout` when it had actually stopped importing. Any `timeout` in the manifest may be masking a hard failure.
- **The `test_slang_equiv.ys` miters checked in with these reproducers are run by no harness**, so none of them guards against regression. They are documentation, not tests.

Regression (6 parallel shards): **SUITE PASSED**, 0 new sim-equiv warnings, Miter-Formal 0, 0 crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)