### PR TITLE
test: report a yosys ERROR as `error`, and actually run the slang miters

### DIFF
--- a/test/combine_regression.py
+++ b/test/combine_regression.py
@@ -20,7 +20,7 @@ COUNTS = [
     "YOSYS_FAILED", "YOSYS_SKIPPED", "YOSYS_UHDM_ONLY", "EQUIV_FAILED_TESTS",
     "MITER_FAILED_TESTS", "SIM_EQUIV_WARN_TESTS", "SIM_EQUIV_KNOWN_WARN_TESTS",
     "SIM_EQUIV_ANALYZED_TESTS", "SIM_EQUIV_ARTEFACT_TESTS",
-    "SIM_EQUIV_UNCLASS_TESTS",
+    "SIM_EQUIV_UNCLASS_TESTS", "SLANG_MITER_RUN", "SLANG_MITER_FAILED_TESTS", "SLANG_MITER_KNOWN_FAIL",
 ]
 
 def collect(paths):
@@ -108,6 +108,15 @@ def main():
         print(f"      └─ Miter-Formal (UHDM != Verilog, equiv_induct missed): {miter}")
         for t in names(lists, "MITER_FAILED_TEST_NAMES"):
             print(f"          - {t}")
+    if counts["SLANG_MITER_RUN"]:
+        ok = (counts["SLANG_MITER_RUN"] - counts["SLANG_MITER_FAILED_TESTS"]
+              - counts["SLANG_MITER_KNOWN_FAIL"])
+        print(f"  🔷 Slang-Miter (read_uhdm == read_slang): "
+              f"{ok}/{counts['SLANG_MITER_RUN']} passed, "
+              f"{counts['SLANG_MITER_KNOWN_FAIL']} known-fail, "
+              f"{counts['SLANG_MITER_FAILED_TESTS']} unexpected")
+        for t_ in names(lists, "SLANG_MITER_FAILED_TEST_NAMES"):
+            print(f"      - {t_}")
     print(f"  ❌ True failures: {failed}")
     print(f"  💥 Crashes: {crashed}")
     if total:
@@ -147,7 +156,8 @@ def main():
         section("🧪 CVA6 PER-MODULE EQUIVALENCE:")
         print(f"  modules: {len(cva6)}  "
               + "  ".join(f"{s}={status[s]}" for s in
-                          ("proven", "cex", "timeout", "elabfail") if status.get(s)))
+                          ("proven", "cex", "timeout", "crash", "error",
+                           "elabfail") if status.get(s)))
         print(f"  as expected {kinds.get('OK',0)}, regressions {kinds.get('BAD',0)}, "
               f"newly proven {kinds.get('PROMOTE',0)}, inconclusive {kinds.get('SOFT',0)}")
         for m, (k, got, want) in sorted(cva6.items()):

--- a/test/cosim_uhdm_bugs.txt
+++ b/test/cosim_uhdm_bugs.txt
@@ -173,3 +173,9 @@ arb_idx_cast
     rr_arb_tree's wrong idx_o and hence wt_dcache_mem's wr_ack_o
     counterexample.  Minimal repro + analysis of why the obvious fix regresses
     3-D packed selects: test/arb_idx_cast/README.md.
+
+latch_perf_counters
+    read_uhdm != read_slang (SAT counterexample on a 64-bit wdata_i write).
+    Present since the test was added in CVA6 latch triage round 2 and invisible
+    until the slang miters were wired into run_all_tests.sh.  read_verilog
+    cannot parse this design, so no other check covers it.  Untriaged.

--- a/test/cva6_equiv/README.md
+++ b/test/cva6_equiv/README.md
@@ -146,6 +146,7 @@ outcome:
 | `cex` | A real counterexample survives — a frontend bug still to fix. |
 | `timeout` | SAT capacity, **not** a known bug: no model found within budget. |
 | `crash` | yosys itself died on the miter (SIGSEGV/SIGFPE) — a real problem, not a budget outcome. |
+| `error` | yosys stopped with an ERROR (the design no longer imports, say) — also not a budget outcome. |
 | `elabfail` | The *wrapper* does not elaborate yet — a harness gap. |
 
 A degenerate parameter does not just weaken a proof, it can **hide a bug**.
@@ -220,6 +221,14 @@ tight: the classifier only sees that no model was produced. `wt_dcache` and
 `wt_cache_subsystem` were recorded as `timeout` from a 150 s sweep and turned
 out to be `elabfail` once given 400 s. When (re)classifying, give the sweep a
 generous budget, or re-check anything new that lands on `timeout`.
+
+`timeout` must mean one thing only: **SAT ran and found no model**. A yosys
+ERROR exits with a small non-zero code — not the timeout's own 124/137, and not
+a signal — so it used to fall through to `timeout`, and a module that had
+stopped importing altogether looked like a harmless budget outcome.
+`wt_dcache_mem` appeared to improve from `cex` to `timeout` that way while it
+was in fact failing to build. Such runs are now reported as `error` and fail
+the gate when unexpected.
 
 `crash` and `timeout` are easy to confuse and must not be. When the classifier
 was first written it lumped both together, and 21 modules that actually

--- a/test/cva6_equiv/run_cva6_equiv.sh
+++ b/test/cva6_equiv/run_cva6_equiv.sh
@@ -132,6 +132,14 @@ EOF
   # yosys itself died (SIGSEGV / SIGFPE seen on some hpdcache modules).  That
   # is not a SAT budget outcome and should not hide behind `timeout`.
   elif [ "$rc" -ne 124 ] && [ "$rc" -ne 137 ] && [ "$rc" -gt 128 ]; then got=crash
+  # A yosys ERROR exits with a small non-zero code -- not the timeout's own
+  # 124/137 and not a signal -- so it used to fall through to `timeout` and a
+  # module that had stopped IMPORTING looked like a SAT budget outcome.  That
+  # is how wt_dcache_mem appeared to improve from `cex` to `timeout` while it
+  # was in fact failing to build at all.  `timeout` must mean "SAT ran and
+  # found no model", nothing else.
+  elif [ "$rc" -ne 124 ] && [ "$rc" -ne 137 ] && [ "$rc" -ne 0 ] &&
+       grep -qE "^ERROR:" miter.log; then                got=error
   else                                          got=timeout
   fi
   popd >/dev/null
@@ -152,6 +160,9 @@ EOF
     echo "BAD $mod $got $want" >> "$WORKROOT/.results"
   elif [ "$got" = crash ] && [ "$want" != crash ]; then
     printf "  ❌ %-34s yosys CRASHED (want=%s) — see %s\n" "$mod" "$want" "work/$mod/miter.log"
+    echo "BAD $mod $got $want" >> "$WORKROOT/.results"
+  elif [ "$got" = error ] && [ "$want" != error ]; then
+    printf "  ❌ %-34s yosys ERROR (want=%s) — see %s\n" "$mod" "$want" "work/$mod/miter.log"
     echo "BAD $mod $got $want" >> "$WORKROOT/.results"
   elif [ "$got" = elabfail ] && [ "$want" = proven ]; then
     printf "  ❌ %-34s no longer elaborates (want=proven) — see %s\n" "$mod" "work/$mod/miter.log"

--- a/test/cva6_equiv/scripts/combine_report.py
+++ b/test/cva6_equiv/scripts/combine_report.py
@@ -48,7 +48,7 @@ def main():
     print(f"  modules reported : {len(rows)}")
     print("")
     print("  measured status:")
-    for s in ("proven", "cex", "timeout", "elabfail", "skip"):
+    for s in ("proven", "cex", "timeout", "crash", "error", "elabfail", "skip"):
         if by_status.get(s):
             print(f"    {s:<10} {by_status[s]:>4}")
     print("")

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -209,6 +209,46 @@ EQUIV_FAILED_TESTS=0
 # equiv_induct check passed — real bugs that equiv_induct's blind spot missed.
 MITER_FAILED_TESTS=0
 MITER_FAILED_TEST_NAMES=()
+# Slang-miter checks: a per-test `test_slang_equiv.ys` proves read_uhdm ==
+# read_slang.  These reproducers used to be run by NOTHING, so they documented
+# bugs without guarding against them.  Needed because the Induct-Formal check
+# above requires a read_verilog netlist, which does not exist for the very
+# constructs (type parameters, packed struct params) these tests cover.
+SLANG_MITER_RUN=0
+SLANG_MITER_FAILED_TESTS=0
+SLANG_MITER_KNOWN_FAIL=0
+SLANG_MITER_FAILED_TEST_NAMES=()
+
+# Slang miter: proves read_uhdm == read_slang for a test that ships a
+# `test_slang_equiv.ys`.  Called from EVERY exit path that produced UHDM
+# output -- notably the "UHDM succeeds where Verilog fails" one, which returns
+# early and covers exactly the constructs (type parameters, packed struct
+# params) that have no read_verilog netlist to check against.  A known-failing
+# miter is listed in slang_miter_expected_fail.txt with its reason.
+run_slang_miter() {
+    local test_dir="$1"
+    [ "${SLANG_MITER_DONE:-}" = "$test_dir" ] && return 0
+    # The caller's CWD is not the test directory on every path, so address it
+    # explicitly and run yosys from inside it (the .ys reads slpp_all/... and
+    # dut.sv by relative path).
+    local d="$SCRIPT_DIR/$test_dir"
+    [ -f "$d/test_slang_equiv.ys" ] && [ -f "$d/slpp_all/surelog.uhdm" ] || return 0
+    SLANG_MITER_DONE="$test_dir"
+    SLANG_MITER_RUN=$((SLANG_MITER_RUN + 1))
+    if (cd "$d" && timeout 300 "$YOSYS_BIN" -m "$UHDM_PLUGIN" ./test_slang_equiv.ys \
+            > slang_miter.log 2>&1); then
+        echo "    ✅ Slang-Miter: read_uhdm == read_slang"
+    elif grep -qxF "$test_dir" "$SCRIPT_DIR/slang_miter_expected_fail.txt" 2>/dev/null; then
+        echo "    ⚠️  Slang-Miter FAILED (known — see slang_miter_expected_fail.txt)"
+        SLANG_MITER_KNOWN_FAIL=$((SLANG_MITER_KNOWN_FAIL + 1))
+    else
+        echo "    ❌ Slang-Miter FAILED - read_uhdm != read_slang (see slang_miter.log)"
+        SLANG_MITER_FAILED_TESTS=$((SLANG_MITER_FAILED_TESTS + 1))
+        SLANG_MITER_FAILED_TEST_NAMES+=("$test_dir")
+        UNEXPECTED_FAILURES+=("$test_dir (slang-miter)")
+    fi
+}
+
 SIM_EQUIV_WARN_TESTS=0
 SIM_EQUIV_WARN_NAMES=()
 SIM_EQUIV_ANALYZED_TESTS=0
@@ -832,6 +872,7 @@ analyze_test_result() {
     if [ ! -f "$uhdm_file" ] && [ ! -f "$verilog_file" ] && [ -f "$uhdm_nohier" ] && [ -f "$verilog_nohier" ]; then
         # Both paths failed at hierarchy but produced nohier ILs - compare those
         echo "✅ Test $test_dir PASSED - comparing nohier ILs (both paths fail at hierarchy)"
+        run_slang_miter "$test_dir"
         PASSED_TESTS=$((PASSED_TESTS + 1))
         return 0
     fi
@@ -842,6 +883,7 @@ analyze_test_result() {
         if [ -f "${test_dir}/verilog_path.log" ] && grep -q "ERROR" "${test_dir}/verilog_path.log"; then
             echo "✅ Test $test_dir PASSED - UHDM succeeds where Verilog fails!"
             echo "    Demonstrates UHDM's superior SystemVerilog support"
+            run_slang_miter "$test_dir"
             run_sim_equivalence_softwarn "$test_dir" "$sim_cycles"
             UHDM_ONLY_TESTS=$((UHDM_ONLY_TESTS + 1))
             UHDM_ONLY_TEST_NAMES+=("$test_dir")
@@ -903,6 +945,8 @@ analyze_test_result() {
             fi
         fi
     fi
+
+    run_slang_miter "$test_dir"
 
     # Verilator co-sim now runs for EVERY test (not just UHDM-only ones),
     # using the per-test cycle count (SIM_CYCLES, default 200).  For a
@@ -1148,12 +1192,15 @@ dump_results_file() {
         for v in TOTAL_TESTS PASSED_TESTS FAILED_TESTS SKIPPED_TESTS \
                  CRASHED_TESTS UHDM_ONLY_TESTS YOSYS_TOTAL YOSYS_PASSED \
                  YOSYS_FAILED YOSYS_SKIPPED YOSYS_UHDM_ONLY \
-                 EQUIV_FAILED_TESTS MITER_FAILED_TESTS SIM_EQUIV_WARN_TESTS \
+                 EQUIV_FAILED_TESTS MITER_FAILED_TESTS \
+                 SLANG_MITER_RUN SLANG_MITER_FAILED_TESTS SLANG_MITER_KNOWN_FAIL \
+                 SIM_EQUIV_WARN_TESTS \
                  SIM_EQUIV_KNOWN_WARN_TESTS SIM_EQUIV_ANALYZED_TESTS \
                  SIM_EQUIV_ARTEFACT_TESTS SIM_EQUIV_UNCLASS_TESTS; do
             eval "printf 'count %s %s\n' \"\$v\" \"\${$v:-0}\""
         done
-        for arr in FAILED_TEST_NAMES CRASHED_TEST_NAMES PASSED_TEST_NAMES \
+        for arr in SLANG_MITER_FAILED_TEST_NAMES \
+                   FAILED_TEST_NAMES CRASHED_TEST_NAMES PASSED_TEST_NAMES \
                    UHDM_ONLY_TEST_NAMES EQUIV_FAILED_TEST_NAMES \
                    MITER_FAILED_TEST_NAMES SIM_EQUIV_WARN_NAMES \
                    SIM_EQUIV_KNOWN_WARN_NAMES SIM_EQUIV_ANALYZED_NAMES \
@@ -1278,6 +1325,12 @@ if [ "$TOTAL_EQUIV_FAILED" -gt 0 ]; then
     echo "      └─ Miter-Formal (UHDM != Verilog, equiv_induct missed): $MITER_FAILED_TESTS"
     for t in "${MITER_FAILED_TEST_NAMES[@]}"; do
         echo "          - $t"
+    done
+fi
+if [ "${SLANG_MITER_RUN:-0}" -gt 0 ]; then
+    echo "  🔷 Slang-Miter (read_uhdm == read_slang): $((SLANG_MITER_RUN - SLANG_MITER_FAILED_TESTS - SLANG_MITER_KNOWN_FAIL))/$SLANG_MITER_RUN passed, $SLANG_MITER_KNOWN_FAIL known-fail, $SLANG_MITER_FAILED_TESTS unexpected"
+    for t_ in "${SLANG_MITER_FAILED_TEST_NAMES[@]}"; do
+        echo "      - $t_"
     done
 fi
 echo "  ❌ True failures: $FAILED_TESTS"

--- a/test/slang_miter_expected_fail.txt
+++ b/test/slang_miter_expected_fail.txt
@@ -1,0 +1,21 @@
+# Tests whose `test_slang_equiv.ys` miter is KNOWN to fail.
+# One test directory name per line.  Each entry must say why, and should be
+# removed as soon as the underlying bug is fixed.
+#
+# A slang miter proves read_uhdm == read_slang.  It is the only check that
+# covers constructs read_verilog cannot parse at all (type parameters, packed
+# struct parameters), so a test here is a real, tracked frontend bug.
+
+# Bit/part-select of an element of a packed array whose element type is a TYPE
+# PARAMETER drops the second index.  Root cause of rr_arb_tree's wrong idx_o
+# and hence wt_dcache_mem's wr_ack_o counterexample.  The obvious fix also
+# claims 3-D packed selects and breaks tc_sram — see arb_idx_cast/README.md.
+arb_idx_cast
+
+# Surfaced the moment these miters were wired up: this test's miter has been
+# failing since the test was added (commit 3e77690b, CVA6 latch triage round 2)
+# with nothing running it.  read_uhdm != read_slang on a 64-bit `wdata_i`
+# write; read_verilog cannot parse the shapes here, so the slang miter is the
+# ONLY check that covers it.  Untriaged — a real frontend divergence to chase,
+# not a harness artefact.
+latch_perf_counters


### PR DESCRIPTION
Two harness gaps, both found while chasing `wt_dcache_mem`.

## 1. `timeout` was hiding hard failures

A yosys ERROR exits with a small non-zero code — not the timeout's own 124/137, and not a signal — so it fell through to `timeout`. `wt_dcache_mem` appeared to improve from `cex` → `timeout` while it had in fact **stopped importing**; SAT never ran.

There is now a distinct `error` status, and an unexpected one fails the gate like a crash. Both branches verified directly: `rc=1` with `ERROR:` in the log → `error`; `rc=124` with a clean log → still `timeout`.

## 2. The slang miters were run by nothing

32 `test_slang_equiv.ys` files had accumulated as reproducers — documenting bugs without guarding against them. They matter because the Induct-Formal check requires a `read_verilog` netlist, which does not exist for the very constructs these tests cover (type parameters, packed struct parameters).

Three things this needed:

- **A function, not an inline block.** The "UHDM succeeds where Verilog fails" and "both paths fail at hierarchy" paths `return` early, and between them they cover most of the tests that need this check. My first version sat after those returns and never ran for them.
- **Absolute paths.** The caller's CWD is not the test directory on every path; with relative paths the check silently did nothing while appearing wired up.
- **Separate known-fail accounting.** Otherwise the summary reports "1/1 passed" for a test that just failed.

Tested both directions: with a test listed in `slang_miter_expected_fail.txt` it is tolerated; un-listed, the suite reports an unexpected failure and **fails**.

## Wiring this up immediately found a real bug

`latch_perf_counters` reaches the third exit path, and its miter — which had never run — **fails** with a SAT counterexample on a 64-bit `wdata_i` write. It has been failing since the test was added in CVA6 latch triage round 2 (`3e77690b`), and `read_verilog` cannot parse the design, so nothing else covers it.

Recorded as untriaged in `slang_miter_expected_fail.txt` and `cosim_uhdm_bugs.txt` rather than quietly absorbed. That is a frontend divergence someone should chase.

## Verification

Regression (6 parallel shards): **SUITE PASSED**

- Slang-Miter: **30/32 passed**, 2 known-fail (`arb_idx_cast`, `latch_perf_counters`), 0 unexpected
- 0 new sim-equiv warnings, 0 crashes, Miter-Formal 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)