### PR TITLE
cva6: inline chained type parameters in wrappers (3 of the 40 `error` modules)

### DIFF
--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -36,7 +36,7 @@ amo_alu                                4   180   error
 amo_buffer                             4   900   proven
 ariane_regfile_fpga                    4   400   elabfail  # slang gap: $random init (Verilator accepts); FPGA variant, not in the shipped config
 axi_adapter                            4   180   crash
-axi_shim                               4   400   error
+axi_shim                               4   400   proven
 bht                                    4   900   proven
 bht2lvl                                4   180   cex
 branch_unit                            4   900   proven
@@ -57,7 +57,7 @@ cva6_hpdcache_subsystem                4   180   crash
 cva6_hpdcache_subsystem_axi_arbiter    4   180   crash
 cva6_hpdcache_wrapper                  4   180   crash
 cva6_icache                            4   900   proven
-cva6_icache_axi_wrapper                4   400   error
+cva6_icache_axi_wrapper                4   400   cex      # cex now measurable (was error: 1-bit chained-type-param port) - TRIAGE
 cva6_mmu                               4   180   proven
 cva6_ptw                               1   900   proven
 cva6_rvfi_probes                       4   180   cex
@@ -166,7 +166,7 @@ store_buffer                           4   900   proven
 store_unit                             4   900   proven
 tag_cmp                                4   400   cex
 trigger_module                         4   900   proven
-wt_axi_adapter                         4   400   error
+wt_axi_adapter                         4   400   cex      # cex now measurable (was error: 1-bit chained-type-param port) - TRIAGE
 wt_cache_subsystem                     4   180   timeout
 wt_dcache                              4   180   timeout
 wt_dcache_ctrl                         4   180   crash

--- a/test/cva6_equiv/scripts/gen_wrapper.py
+++ b/test/cva6_equiv/scripts/gen_wrapper.py
@@ -771,6 +771,25 @@ def gen(target, out_path, extra_binds=None, import_pkgs=None):
     # depended on it — falling back to the module's own default, which is
     # exactly where this generator started.
     own = drop_unsupported(own, base_names, originals, added, providers)
+    # A `parameter type X = <another type parameter>` chain leaves the port
+    # 1 BIT wide: Surelog attaches no typespec to a port whose type is a type
+    # parameter defaulted to another type parameter, so read_uhdm sees a bare
+    # logic_var while read_slang sizes it properly, and `miter` then reports
+    # "No matching port in gate module was found".  A type parameter defaulted
+    # to a STRUCT resolves fine, so inline the referenced parameter's own
+    # definition instead of naming it.
+    wrapper_types = {}
+    for e in split_param_entries(cva6_params) + split_param_entries(extras):
+        nm = param_names(e)
+        if nm and re.search(r"\bparameter\s+type\b|\blocalparam\s+type\b", e):
+            wrapper_types[nm[0]] = rhs_of(e)
+    for i, e in enumerate(own):
+        if not re.search(r"\bparameter\s+type\b", e):
+            continue
+        r = rhs_of(e)
+        if re.fullmatch(r"\w+", r) and r in wrapper_types:
+            own[i] = retarget_entry(e, wrapper_types[r])
+            print(f"  inlined chained type param: {param_names(e)[0]} = {r}")
     if own:
         own = order_by_dependency(own)
         extras_pl += ("," if extras_pl else ",\n") + "\n" + ",\n".join(

--- a/test/cva6_equiv/wrappers/wrapper_acc_dispatcher.sv
+++ b/test/cva6_equiv/wrappers/wrapper_acc_dispatcher.sv
@@ -309,8 +309,8 @@ module acc_dispatcher_equiv
     `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t)
 ,
 
-  parameter type acc_req_t = cvxif_req_t,
-  parameter type acc_resp_t = cvxif_resp_t
+  parameter type acc_req_t = `CVXIF_REQ_T(CVA6Cfg, x_compressed_req_t, x_issue_req_t, x_register_t, x_commit_t),
+  parameter type acc_resp_t = `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t)
 ) (
 
     input logic clk_i,

--- a/test/cva6_equiv/wrappers/wrapper_axi_adapter.sv
+++ b/test/cva6_equiv/wrappers/wrapper_axi_adapter.sv
@@ -312,8 +312,25 @@ module axi_adapter_equiv
   parameter logic        CRITICAL_WORD_FIRST   = 0,
   // the AXI subsystem needs to support wrapping reads for this feature
       parameter int unsigned CACHELINE_BYTE_OFFSET = CVA6Cfg.DCACHE_OFFSET_WIDTH,
-  parameter type axi_req_t = noc_req_t,
-  parameter type axi_rsp_t = noc_resp_t
+  parameter type axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      }
 ) (
 
     input logic clk_i,  // Clock

--- a/test/cva6_equiv/wrappers/wrapper_axi_shim.sv
+++ b/test/cva6_equiv/wrappers/wrapper_axi_shim.sv
@@ -311,8 +311,25 @@ module axi_shim_equiv
   parameter int unsigned AxiNumWords = (CVA6Cfg.ICACHE_LINE_WIDTH/CVA6Cfg.AxiDataWidth) * (CVA6Cfg.ICACHE_LINE_WIDTH  > CVA6Cfg.DCACHE_LINE_WIDTH)  +
                              (CVA6Cfg.DCACHE_LINE_WIDTH/CVA6Cfg.AxiDataWidth) * (CVA6Cfg.ICACHE_LINE_WIDTH <= CVA6Cfg.DCACHE_LINE_WIDTH),
   // data width in dwords, this is also the maximum burst length, must be >=2
-      parameter type axi_req_t = noc_req_t,
-  parameter type axi_rsp_t = noc_resp_t
+      parameter type axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      }
 ) (
 
     input logic clk_i,  // Clock

--- a/test/cva6_equiv/wrappers/wrapper_cva6_hpdcache_subsystem.sv
+++ b/test/cva6_equiv/wrappers/wrapper_cva6_hpdcache_subsystem.sv
@@ -309,8 +309,18 @@ module cva6_hpdcache_subsystem_equiv
 
   localparam NumPorts = 4,
   parameter int NrHwPrefetchers = 4,
-  parameter type axi_b_chan_t = b_chan_t,
-  parameter type axi_r_chan_t = r_chan_t
+  parameter type axi_b_chan_t = struct packed {
+        logic [CVA6Cfg.AxiIdWidth-1:0]   id;
+        axi_pkg::resp_t                  resp;
+        logic [CVA6Cfg.AxiUserWidth-1:0] user;
+      },
+  parameter type axi_r_chan_t = struct packed {
+        logic [CVA6Cfg.AxiIdWidth-1:0]   id;
+        logic [CVA6Cfg.AxiDataWidth-1:0] data;
+        axi_pkg::resp_t                  resp;
+        logic                            last;
+        logic [CVA6Cfg.AxiUserWidth-1:0] user;
+      }
 ) (
 
 

--- a/test/cva6_equiv/wrappers/wrapper_cva6_hpdcache_subsystem_axi_arbiter.sv
+++ b/test/cva6_equiv/wrappers/wrapper_cva6_hpdcache_subsystem_axi_arbiter.sv
@@ -319,10 +319,37 @@ module cva6_hpdcache_subsystem_axi_arbiter_equiv
   parameter int unsigned AxiDataWidth = CVA6Cfg.AxiDataWidth,
   parameter int unsigned AxiIdWidth = CVA6Cfg.AxiIdWidth,
   parameter int unsigned AxiUserWidth = CVA6Cfg.AxiUserWidth,
-  parameter type axi_b_chan_t = b_chan_t,
-  parameter type axi_r_chan_t = r_chan_t,
-  parameter type axi_req_t = noc_req_t,
-  parameter type axi_rsp_t = noc_resp_t
+  parameter type axi_b_chan_t = struct packed {
+        logic [CVA6Cfg.AxiIdWidth-1:0]   id;
+        axi_pkg::resp_t                  resp;
+        logic [CVA6Cfg.AxiUserWidth-1:0] user;
+      },
+  parameter type axi_r_chan_t = struct packed {
+        logic [CVA6Cfg.AxiIdWidth-1:0]   id;
+        logic [CVA6Cfg.AxiDataWidth-1:0] data;
+        axi_pkg::resp_t                  resp;
+        logic                            last;
+        logic [CVA6Cfg.AxiUserWidth-1:0] user;
+      },
+  parameter type axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      }
 ) (
 
     input logic clk_i,

--- a/test/cva6_equiv/wrappers/wrapper_cva6_icache_axi_wrapper.sv
+++ b/test/cva6_equiv/wrappers/wrapper_cva6_icache_axi_wrapper.sv
@@ -309,8 +309,25 @@ module cva6_icache_axi_wrapper_equiv
     `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t)
 ,
 
-  parameter type axi_req_t = noc_req_t,
-  parameter type axi_rsp_t = noc_resp_t
+  parameter type axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      }
 ) (
 
     input logic             clk_i,

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_read.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_read.sv
@@ -312,7 +312,19 @@ module hpdcache_mem_to_axi_read_equiv
 
   parameter type hpdcache_mem_req_t = hpdcache_equiv_pkg::hpdcache_mem_req_t,
   parameter type hpdcache_mem_resp_r_t = hpdcache_equiv_pkg::hpdcache_mem_resp_r_t,
-  parameter type ar_chan_t = axi_ar_chan_t
+  parameter type ar_chan_t = struct packed {
+        logic [CVA6Cfg.AxiIdWidth-1:0]   id;
+        logic [CVA6Cfg.AxiAddrWidth-1:0] addr;
+        axi_pkg::len_t                   len;
+        axi_pkg::size_t                  size;
+        axi_pkg::burst_t                 burst;
+        logic                            lock;
+        axi_pkg::cache_t                 cache;
+        axi_pkg::prot_t                  prot;
+        axi_pkg::qos_t                   qos;
+        axi_pkg::region_t                region;
+        logic [CVA6Cfg.AxiUserWidth-1:0] user;
+      }
 ) (
 
     output logic                          req_ready_o,

--- a/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_write.sv
+++ b/test/cva6_equiv/wrappers/wrapper_hpdcache_mem_to_axi_write.sv
@@ -313,8 +313,26 @@ module hpdcache_mem_to_axi_write_equiv
   parameter type hpdcache_mem_req_t = hpdcache_equiv_pkg::hpdcache_mem_req_t,
   parameter type hpdcache_mem_req_w_t = hpdcache_equiv_pkg::hpdcache_mem_req_w_t,
   parameter type hpdcache_mem_resp_w_t = hpdcache_equiv_pkg::hpdcache_mem_resp_w_t,
-  parameter type aw_chan_t = axi_aw_chan_t,
-  parameter type w_chan_t = axi_w_chan_t
+  parameter type aw_chan_t = struct packed {
+        logic [CVA6Cfg.AxiIdWidth-1:0]   id;
+        logic [CVA6Cfg.AxiAddrWidth-1:0] addr;
+        axi_pkg::len_t                   len;
+        axi_pkg::size_t                  size;
+        axi_pkg::burst_t                 burst;
+        logic                            lock;
+        axi_pkg::cache_t                 cache;
+        axi_pkg::prot_t                  prot;
+        axi_pkg::qos_t                   qos;
+        axi_pkg::region_t                region;
+        axi_pkg::atop_t                  atop;
+        logic [CVA6Cfg.AxiUserWidth-1:0] user;
+      },
+  parameter type w_chan_t = struct packed {
+        logic [CVA6Cfg.AxiDataWidth-1:0]     data;
+        logic [(CVA6Cfg.AxiDataWidth/8)-1:0] strb;
+        logic                                last;
+        logic [CVA6Cfg.AxiUserWidth-1:0]     user;
+      }
 ) (
 
     output logic                          req_ready_o,

--- a/test/cva6_equiv/wrappers/wrapper_miss_handler.sv
+++ b/test/cva6_equiv/wrappers/wrapper_miss_handler.sv
@@ -309,8 +309,25 @@ module miss_handler_equiv
 ,
 
   parameter int unsigned           NR_PORTS = 4,
-  parameter type                   axi_req_t = noc_req_t,
-  parameter type                   axi_rsp_t = noc_resp_t,
+  parameter type                   axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type                   axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      },
   parameter type                   cache_line_t = struct packed {
       logic [CVA6Cfg.DCACHE_TAG_WIDTH-1:0]  tag;    // tag array
       logic [CVA6Cfg.DCACHE_LINE_WIDTH-1:0] data;   // data array

--- a/test/cva6_equiv/wrappers/wrapper_rr_arb_tree.sv
+++ b/test/cva6_equiv/wrappers/wrapper_rr_arb_tree.sv
@@ -1,10 +1,10 @@
-// AUTO-GENERATED per-module equivalence wrapper for wt_axi_adapter
+// AUTO-GENERATED per-module equivalence wrapper for rr_arb_tree
 // Parameter environment copied verbatim from cva6.sv (build_config-computed
 // CVA6Cfg + shared type params) = the values used in the real hierarchy.
 `include "rvfi_types.svh"
 `include "cvxif_types.svh"
 
-module wt_axi_adapter_equiv
+module rr_arb_tree_equiv
   import ariane_pkg::*;
   import wt_cache_pkg::*;
 #(
@@ -308,83 +308,69 @@ module wt_axi_adapter_equiv
     `CVXIF_RESP_T(CVA6Cfg, x_compressed_resp_t, x_issue_resp_t, x_result_t)
 ,
 
-  parameter int unsigned ReqFifoDepth = 2,
-  parameter int unsigned MetaFifoDepth = CVA6Cfg.DCACHE_MAX_TX,
-  parameter type axi_req_t = struct packed {
-        axi_aw_chan_t aw;
-        logic         aw_valid;
-        axi_w_chan_t  w;
-        logic         w_valid;
-        logic         b_ready;
-        axi_ar_chan_t ar;
-        logic         ar_valid;
-        logic         r_ready;
-      },
-  parameter type axi_rsp_t = struct packed {
-        logic    aw_ready;
-        logic    ar_ready;
-        logic    w_ready;
-        logic    b_valid;
-        b_chan_t b;
-        logic    r_valid;
-        r_chan_t r;
-      },
-  parameter type dcache_req_t = struct packed {
-      wt_cache_pkg::dcache_out_t rtype;  // see definitions above
-      logic [2:0]                                      size;        // transaction size: 000=Byte 001=2Byte; 010=4Byte; 011=8Byte; 111=Cache line (16/32Byte)
-      logic [CVA6Cfg.DCACHE_SET_ASSOC_WIDTH-1:0] way;  // way to replace
-      logic [CVA6Cfg.PLEN-1:0] paddr;  // physical address
-      logic [CVA6Cfg.XLEN-1:0] data;  // word width of processor (no block stores at the moment)
-      logic [CVA6Cfg.DCACHE_USER_WIDTH-1:0]          user;        // user width of processor (no block stores at the moment)
-      logic nc;  // noncacheable
-      logic [CVA6Cfg.MEM_TID_WIDTH-1:0] tid;  // thread id (used as transaction id in Ariane)
-      ariane_pkg::amo_t amo_op;  // amo opcode
-    },
-  parameter type dcache_inval_t = struct packed {
-      logic                                      vld;  // invalidate only affected way
-      logic                                      all;  // invalidate all ways
-      logic [CVA6Cfg.DCACHE_INDEX_WIDTH-1:0]     idx;  // physical address to invalidate
-      logic [CVA6Cfg.DCACHE_SET_ASSOC_WIDTH-1:0] way;  // way to invalidate
-    },
-  parameter type dcache_rtrn_t = struct packed {
-      wt_cache_pkg::dcache_in_t rtype;  // see definitions above
-      logic [CVA6Cfg.DCACHE_LINE_WIDTH-1:0] data;  // full cache line width
-      logic [CVA6Cfg.DCACHE_USER_LINE_WIDTH-1:0] user;  // user bits
-      dcache_inval_t inv;  // invalidation vector
-      logic [CVA6Cfg.MEM_TID_WIDTH-1:0] tid;  // thread id (used as transaction id in Ariane)
-    }
+  /// Number of inputs to be arbitrated.
+    parameter int unsigned NumIn = 2,
+  /// Data width of the payload in bits. Not needed if `DataType` is overwritten.
+    parameter int unsigned DataWidth = 1,
+  /// Data type of the payload, can be overwritten with custom type. Only use of `DataWidth`.
+    parameter type         DataType   = logic [DataWidth-1:0],
+  /// The `ExtPrio` option allows to override the internal round robin counter via the
+    /// `rr_i` signal. This can be useful in case multiple arbiters need to have
+    /// rotating priorities that are operating in lock-step. If static priority arbitration
+    /// is needed, just connect `rr_i` to '0.
+    ///
+    /// Set to 1'b1 to enable.
+    parameter bit          ExtPrio    = 1'b0,
+  /// If `AxiVldRdy` is set, the req/gnt signals are compliant with the AXI style vld/rdy
+    /// handshake. Namely, upstream vld (req) must not depend on rdy (gnt), as it can be deasserted
+    /// again even though vld is asserted. Enabling `AxiVldRdy` leads to a reduction of arbiter
+    /// delay and area.
+    ///
+    /// Set to `1'b1` to treat req/gnt as vld/rdy.
+    parameter bit          AxiVldRdy  = 1'b0,
+  /// The `LockIn` option prevents the arbiter from changing the arbitration
+    /// decision when the arbiter is disabled. I.e., the index of the first request
+    /// that wins the arbitration will be locked in case the destination is not
+    /// able to grant the request in the same cycle.
+    ///
+    /// Set to `1'b1` to enable.
+    parameter bit          LockIn     = 1'b0,
+  /// When set, ensures that throughput gets distributed evenly between all inputs.
+    ///
+    /// Set to `1'b0` to disable.
+    parameter bit          FairArb    = 1'b1,
+  /// Dependent parameter, do **not** overwrite.
+    /// Width of the arbitration priority signal and the arbitrated index.
+    parameter int unsigned IdxWidth   = (NumIn > 32'd1) ? unsigned'($clog2(NumIn)) : 32'd1,
+  /// Dependent parameter, do **not** overwrite.
+    /// Type for defining the arbitration priority and arbitrated index signal.
+    parameter type         idx_t      = logic [IdxWidth-1:0]
 ) (
 
-    input logic clk_i,
-    input logic rst_ni,
-
-    // icache
-    input  logic         icache_data_req_i,
-    output logic         icache_data_ack_o,
-    input  icache_req_t  icache_data_i,
-    // returning packets must be consumed immediately
-    output logic         icache_rtrn_vld_o,
-    output icache_rtrn_t icache_rtrn_o,
-
-    // dcache
-    input  logic         dcache_data_req_i,
-    output logic         dcache_data_ack_o,
-    input  dcache_req_t  dcache_data_i,
-    // returning packets must be consumed immediately
-    output logic         dcache_rtrn_vld_o,
-    output dcache_rtrn_t dcache_rtrn_o,
-
-    // AXI port
-    output axi_req_t axi_req_o,
-    input  axi_rsp_t axi_resp_i,
-
-    // Endianness Control Signal from CSR
-    input logic mbe_i,
-
-    // Invalidations
-    input  logic [63:0] inval_addr_i,
-    input  logic        inval_valid_i,
-    output logic        inval_ready_o
+  /// Clock, positive edge triggered.
+  input  logic                clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                rst_ni,
+  /// Clears the arbiter state. Only used if `ExtPrio` is `1'b0` or `LockIn` is `1'b1`.
+  input  logic                flush_i,
+  /// External round-robin priority. Only used if `ExtPrio` is `1'b1.`
+  input  idx_t                rr_i,
+  /// Input requests arbitration.
+  input  logic    [NumIn-1:0] req_i,
+  /* verilator lint_off UNOPTFLAT */
+  /// Input request is granted.
+  output logic    [NumIn-1:0] gnt_o,
+  /* verilator lint_on UNOPTFLAT */
+  /// Input data for arbitration.
+  input  DataType [NumIn-1:0] data_i,
+  /// Output request is valid.
+  output logic                req_o,
+  /// Output request is granted.
+  input  logic                gnt_i,
+  /// Output data.
+  output DataType             data_o,
+  /// Index from which input the data came from.
+  output idx_t                idx_o
 
 );
 
@@ -415,17 +401,16 @@ module wt_axi_adapter_equiv
   localparam NumPorts = 4;
   localparam PC_QUEUE_DEPTH = 16;
 
-  wt_axi_adapter #(
-      .CVA6Cfg(CVA6Cfg),
-      .ReqFifoDepth(ReqFifoDepth),
-      .MetaFifoDepth(MetaFifoDepth),
-      .axi_req_t(axi_req_t),
-      .axi_rsp_t(axi_rsp_t),
-      .dcache_req_t(dcache_req_t),
-      .dcache_rtrn_t(dcache_rtrn_t),
-      .dcache_inval_t(dcache_inval_t),
-      .icache_req_t(icache_req_t),
-      .icache_rtrn_t(icache_rtrn_t)
+  rr_arb_tree #(
+      .NumIn(NumIn),
+      .DataWidth(DataWidth),
+      .DataType(DataType),
+      .ExtPrio(ExtPrio),
+      .AxiVldRdy(AxiVldRdy),
+      .LockIn(LockIn),
+      .FairArb(FairArb),
+      .IdxWidth(IdxWidth),
+      .idx_t(idx_t)
   ) dut (.*);
 
 endmodule

--- a/test/cva6_equiv/wrappers/wrapper_std_cache_subsystem.sv
+++ b/test/cva6_equiv/wrappers/wrapper_std_cache_subsystem.sv
@@ -309,8 +309,25 @@ module std_cache_subsystem_equiv
 ,
 
   localparam NumPorts = 4,
-  parameter type axi_req_t = noc_req_t,
-  parameter type axi_rsp_t = noc_resp_t
+  parameter type axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      }
 ) (
 
     input logic clk_i,

--- a/test/cva6_equiv/wrappers/wrapper_std_nbdcache.sv
+++ b/test/cva6_equiv/wrappers/wrapper_std_nbdcache.sv
@@ -309,8 +309,25 @@ module std_nbdcache_equiv
 ,
 
   localparam NumPorts = 4,
-  parameter type axi_req_t = noc_req_t,
-  parameter type axi_rsp_t = noc_resp_t
+  parameter type axi_req_t = struct packed {
+        axi_aw_chan_t aw;
+        logic         aw_valid;
+        axi_w_chan_t  w;
+        logic         w_valid;
+        logic         b_ready;
+        axi_ar_chan_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+      },
+  parameter type axi_rsp_t = struct packed {
+        logic    aw_ready;
+        logic    ar_ready;
+        logic    w_ready;
+        logic    b_valid;
+        b_chan_t b;
+        logic    r_valid;
+        r_chan_t r;
+      }
 ) (
 
     input logic clk_i,  // Clock

--- a/test/port_chained_type_param/README.md
+++ b/test/port_chained_type_param/README.md
@@ -1,0 +1,34 @@
+# port_chained_type_param — KNOWN FAILING frontend limitation
+
+A port whose type is a type parameter **defaulted to another type parameter**
+comes out ONE BIT wide:
+
+    parameter type noc_req_t = struct packed { ... 49 bits ... },
+    parameter type req_t     = noc_req_t     // chained
+    ...
+    input req_t in_i
+
+    read_uhdm :  wire input 2 \in_i            <- 1 bit   WRONG
+    read_slang:  wire width 49 input 2 \in_i   <- correct
+
+A type parameter defaulted DIRECTLY to a struct (or to a package-qualified
+struct) resolves correctly — only the chain fails.
+
+Cause: Surelog attaches no typespec to such a port (`vpiTypedef` is absent
+where a normal port has one), and the port's LowConn resolves to a bare
+`logic_var`, so there is nothing for the importer to size from.  Fixing it
+properly means resolving the type-parameter chain during elaboration, which is
+Surelog-side work.
+
+## Why it mattered
+
+This is why 29 CVA6 modules reported
+
+    ERROR: No matching port in gate module was found for \<port>!
+
+which reads like a wrapper bug but is really a width mismatch: gold had the
+port at 1 bit, gate at its true width (`axi_shim`: 32 vs 470).  The per-module
+wrapper generator now inlines the referenced parameter's definition instead of
+naming it, which sidesteps the chain — see `inlined chained type param` in
+scripts/gen_wrapper.py.  That is a workaround in generated code, NOT a fix for
+this limitation, which still affects hand-written RTL.

--- a/test/port_chained_type_param/dut.sv
+++ b/test/port_chained_type_param/dut.sv
@@ -1,0 +1,10 @@
+module dut #(
+    parameter type noc_req_t = struct packed { logic [31:0] a; logic [15:0] b; logic c; },
+    parameter type req_t     = noc_req_t      // type param defaulted to ANOTHER type param
+) (
+    input  logic clk_i,
+    input  req_t in_i,
+    output req_t out_o
+);
+  assign out_o = in_i;
+endmodule

--- a/test/port_chained_type_param/test_slang_equiv.ys
+++ b/test/port_chained_type_param/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/slang_miter_expected_fail.txt
+++ b/test/slang_miter_expected_fail.txt
@@ -13,3 +13,8 @@
 arb_idx_cast
 
 
+
+# A port typed by a type parameter that is defaulted to ANOTHER type parameter
+# comes out 1 bit wide (Surelog attaches no typespec).  See README.md; the CVA6
+# wrapper generator sidesteps it by inlining, but the limitation is real.
+port_chained_type_param


### PR DESCRIPTION
29 of the 40 `error` modules reported

```
ERROR: No matching port in gate module was found for \<port>!
```

which reads like a wrapper bug but is a **width mismatch**. For `axi_shim`, gold had `wire output 32 \axi_req_o` — **one bit** — where gate had 470.

## Cause

A port whose type is a type parameter **defaulted to another type parameter** (`parameter type axi_req_t = noc_req_t`, itself a `parameter type`) comes out 1 bit wide. Surelog attaches no typespec to such a port and its LowConn resolves to a bare `logic_var`, so there is nothing to size from.

A type parameter defaulted directly to a struct — or to a package-qualified struct — resolves fine. Only the chain fails.

## The change, and what it is not

The wrappers are generated, so they can sidestep it: emit the referenced parameter's own definition instead of naming it.

**This is a workaround in generated code, not a fix.** Hand-written RTL with a chained type parameter is still mis-sized, so `test/port_chained_type_param` records the limitation with a 10-line reproducer and is listed as a known slang-miter failure. Resolving it properly is Surelog-side elaboration work.

## Result: 3 of the 40 clear

| module | was | now |
| --- | --- | --- |
| `axi_shim` | error | **proven** |
| `cva6_icache_axi_wrapper` | error | cex (now measurable, TRIAGE) |
| `wt_axi_adapter` | error | cex (now measurable, TRIAGE) |

Manifest: **49 proven**, 27 cex, 37 error, 21 crash, 10 timeout, 3 elabfail.

## Why only 3, when 29 shared the error text

Worth being precise rather than optimistic: the remaining modules fail the same way for a **different reason**. `cva6_hpdcache_if_adapter` has `gold=3 bits` vs `gate=70` for a struct whose *members* are themselves package typedefs — the scalar fields size correctly and the typedef'd ones collapse. Same message, different cause, needs its own fix.

The rest split into `Found error in internal cell $paramod\hpdcache_sram_wmask_1rw` and `Module '\spill_register' … not part of the design` — another missing-from-flist case like `amo_alu`.

Also adds `rr_arb_tree` to the manifest (proven) — new coverage, added while tracing `wt_dcache_mem`'s `wr_ack_o` to that arbiter.

## Verification

- Internal: **SUITE PASSED**, Slang-Miter 32/34, 0 unexpected, 0 new sim-equiv warnings, 0 crashes
- CVA6: **141 as expected, 0 regressions**; re-verified after the manifest update

🤖 Generated with [Claude Code](https://claude.com/claude-code)