### PR TITLE
uhdm: nested struct-field widths (Surelog bump) + `[-1:0]` range is 2 bits

### DIFF
--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -3094,17 +3094,18 @@ int UhdmImporter::get_width_from_typespec(const UHDM::any* typespec, const UHDM:
                     RTLIL::SigSpec rs = import_expression(r->Right_expr());
                     force_const_fold = saved_fcf;
                     if (ls.is_fully_const() && rs.is_fully_const()) {
-                        // A `[size-1:0]` range with size==0 collapses to `[-1:0]`
-                        // (a negative MSB).  Real packed bit indices are never
-                        // negative, so a negative bound means an intended
-                        // zero-width field (e.g. `logic [CFG.BUS.CTL-1:0] ctl`
-                        // with CTL==0) — elide it instead of the bogus
-                        // abs()-derived width of 2.
-                        if (ls.as_int() < 0 || rs.as_int() < 0) {
-                            log("UHDM: logic_typespec simple range is empty "
-                                "([%d:%d]) -> width 0\n", ls.as_int(), rs.as_int());
-                            return 0;
-                        }
+                        // A `[size-1:0]` range with size==0 collapses to
+                        // `[-1:0]`.  Verilog sizes a range as |msb-lsb|+1
+                        // regardless of sign, so that is TWO bits — both
+                        // Yosys's own `read_verilog` and `read_slang` produce
+                        // `wire width 2 upto offset -1` for a port and give a
+                        // packed struct member two bits as well.  Treating it
+                        // as an elided zero-width field (which this used to
+                        // do) makes us the odd one out: the wire disappears,
+                        // and every `sig[0]` read of it then fails with "bit
+                        // select index 0 is out of range" (CVA6's hpdcache
+                        // arbiters, whose `parameter int unsigned N = 0`
+                        // yields exactly this range).
                         int range_size = std::abs(ls.as_int() - rs.as_int()) + 1;
                         log("UHDM: logic_typespec simple range width = %d\n", range_size);
                         return range_size;

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -97,11 +97,11 @@ hpdcache_data_downsize                 4   400   elabfail  # dead at this config
 hpdcache_data_resize                   4   180   error
 hpdcache_data_upsize                   4   180   crash
 hpdcache_decoder                       4   180   crash
-hpdcache_demux                         4   180   error
+hpdcache_demux                         4   180   proven
 hpdcache_fifo_reg                      4   900   error
 hpdcache_fifo_reg_initialized          4   180   cex
 hpdcache_flush                         4   180   crash
-hpdcache_fxarb                         4   180   error
+hpdcache_fxarb                         4   180   proven
 hpdcache_lfsr                          4   900   proven
 hpdcache_mem_req_read_arbiter          4   180   crash
 hpdcache_mem_req_write_arbiter         4   180   error
@@ -112,11 +112,11 @@ hpdcache_memctrl                       4   180   timeout
 hpdcache_miss_handler                  4   180   crash
 hpdcache_mshr                          4   400   error
 hpdcache_mux                           4   180   error
-hpdcache_prio_1hot_encoder             4   180   error
+hpdcache_prio_1hot_encoder             4   180   proven
 hpdcache_prio_bin_encoder              4   180   error
 hpdcache_regbank_wbyteenable_1rw       4   180   crash
 hpdcache_regbank_wmask_1rw             4   180   crash
-hpdcache_rrarb                         4   180   error
+hpdcache_rrarb                         4   180   proven
 hpdcache_rtab                          4   180   error
 hpdcache_sram                          4   180   error
 hpdcache_sram_1rw                      4   180   error
@@ -126,7 +126,7 @@ hpdcache_sram_wmask                    4   180   error
 hpdcache_sram_wmask_1rw                4   180   error
 hpdcache_sync_buffer                   4   900   error
 hpdcache_uncached                      4   400   error
-hpdcache_victim_plru                   4   180   error
+hpdcache_victim_plru                   4   180   cex      # cex now measurable (was error: zero-width [-1:0] ports) - TRIAGE
 hpdcache_victim_random                 4   180   crash
 hpdcache_victim_sel                    4   180   error
 hpdcache_wbuf                          4   180   crash

--- a/test/cva6_equiv/run_cva6_equiv.sh
+++ b/test/cva6_equiv/run_cva6_equiv.sh
@@ -83,7 +83,13 @@ run_one() {
   work="$WORKROOT/$mod"; mkdir -p "$work"; pushd "$work" >/dev/null
   top="${mod}_equiv"
 
-  if [ ! -f slpp_all/surelog.uhdm ] || [ "$wrap" -nt slpp_all/surelog.uhdm ]; then
+  # Re-elaborate when the wrapper changed OR when surelog itself is newer than
+  # the cached UHDM.  The binary embeds the UHDM elaborator, so a Surelog/UHDM
+  # fix changes the elaborated model even though every source file is
+  # untouched.  Without the second test an elaborator fix silently measures
+  # STALE UHDM and looks like it did nothing.
+  if [ ! -f slpp_all/surelog.uhdm ] || [ "$wrap" -nt slpp_all/surelog.uhdm ] ||
+     [ "$SURELOG" -nt slpp_all/surelog.uhdm ]; then
     "$SURELOG" -parse -sverilog -d uhdm -f "$FLIST" "$wrap" -top "$top" \
         > surelog.log 2>&1
   fi

--- a/test/param_nested_struct_field_width/README.md
+++ b/test/param_nested_struct_field_width/README.md
@@ -1,0 +1,49 @@
+# param_nested_struct_field_width
+
+The module-parameter variant of [`pkg_nested_struct_param_width`](../pkg_nested_struct_param_width):
+a width expression that reads a **nested** field of a struct **module
+parameter** whose default comes from a package localparam built by a function.
+This is the shape CVA6's hpdcache modules use — `parameter hpdcache_cfg_t
+HPDcacheCfg = hpdcache_equiv_pkg::HPDcacheCfg` indexed as
+`HPDcacheCfg.u.accessWords`.
+
+```systemverilog
+module dut #(
+    parameter  pk::cfg_t CFG    = pk::CFG,
+    localparam int       SID_W  = CFG.u.sidWidth,       // NESTED    -> was 0
+    localparam int       DATA_W = CFG.derived,          // one level -> ok
+    localparam int       NOUT   = CFG.u.dataWidth /
+                                  CFG.u.sidWidth,       // nested / nested
+    localparam int       NLOG   = $clog2(NOUT),
+    ...
+```
+
+Covers three things the package-level test does not: the base is a *parameter*
+rather than a package localparam, two nested reads feed a **division**, and the
+result flows through `$clog2` into a further width.  Before the fix `NOUT`
+divided by zero and the whole chain collapsed; `sel_i` and `sid_i` came out
+zero-width while `data_i` (single-level) was correct.
+
+## Root cause
+
+UHDM `ExprEval::hierarchicalSelector` returned a matched struct member's value
+without checking `lastElem` or recursing, so a two-level path stopped at the
+first member.  See `pkg_nested_struct_param_width/README.md` for the full
+analysis — fixed in
+`third_party/Surelog/third_party/UHDM/templates/ExprEval.cpp`
+(chipsalliance/UHDM#1140).
+
+Because the bad range is stored *in* the elaborated `.uhdm`, Surelog must be
+re-run to observe the fix; a cached `slpp_all/surelog.uhdm` keeps reproducing
+the old width.
+
+## Checking
+
+`read_verilog` cannot parse a function-built struct localparam, so this is a
+**slang-miter-only** test (`test_slang_equiv.ys`).
+
+```
+wire width 3  input \sid_i     # was width 0
+wire width 64 input \data_i
+wire width 4  input \sel_i     # was width 0
+```

--- a/test/param_nested_struct_field_width/dut.sv
+++ b/test/param_nested_struct_field_width/dut.sv
@@ -1,0 +1,52 @@
+// A width expression that reads a NESTED field of a struct MODULE PARAMETER
+// (`CFG.u.sidWidth`), where the parameter's default comes from a package
+// localparam built by a function -- the shape of CVA6's
+// `parameter hpdcache_cfg_t HPDcacheCfg` + `HPDcacheCfg.u.accessWords`.
+package pk;
+  typedef struct packed {
+    int unsigned sidWidth;
+    int unsigned dataWidth;
+  } user_cfg_t;
+
+  typedef struct packed {
+    user_cfg_t   u;
+    int unsigned derived;
+  } cfg_t;
+
+  function automatic user_cfg_t mku();
+    user_cfg_t c;
+    c.sidWidth  = 3;
+    c.dataWidth = 32;
+    return c;
+  endfunction
+
+  function automatic cfg_t build(user_cfg_t uu);
+    cfg_t c;
+    c.u       = uu;
+    c.derived = uu.dataWidth * 2;
+    return c;
+  endfunction
+
+  localparam user_cfg_t UCFG = mku();
+  localparam cfg_t      CFG  = build(UCFG);
+endpackage
+
+module dut #(
+    parameter  pk::cfg_t CFG      = pk::CFG,
+    localparam int       SID_W    = CFG.u.sidWidth,   // NESTED  -> was 0
+    localparam int       DATA_W   = CFG.derived,      // one level -> ok
+    localparam int       NOUT     = CFG.u.dataWidth /
+                                    CFG.u.sidWidth,   // nested / nested
+    localparam int       NLOG     = $clog2(NOUT),
+    localparam type      sel_t    = logic [NLOG-1:0],
+    localparam type      sid_t    = logic [SID_W-1:0],
+    localparam type      data_t   = logic [DATA_W-1:0]
+) (
+    input  logic  clk_i,
+    input  sid_t  sid_i,
+    input  data_t data_i,
+    input  sel_t  sel_i,
+    output logic  o
+);
+  assign o = ^{sid_i, data_i, sel_i};
+endmodule

--- a/test/param_nested_struct_field_width/test_slang_equiv.ys
+++ b/test/param_nested_struct_field_width/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the
+# CVA6-realistic shapes here (struct parameter whose default is a package
+# localparam built by a function), so the golden reference is read_slang
+# — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/pkg_nested_struct_param_width/README.md
+++ b/test/pkg_nested_struct_param_width/README.md
@@ -1,0 +1,51 @@
+# pkg_nested_struct_param_width
+
+A width expression that reads a **nested** field of a package `localparam`
+struct:
+
+```systemverilog
+localparam user_cfg_t UCFG = mku();          // struct built by a function
+localparam cfg_t      CFG  = build(UCFG);    // nested: cfg_t.u is a user_cfg_t
+
+typedef logic [CFG.u.sidWidth-1:0] sid_t;    // TWO levels -- was broken
+typedef logic [CFG.derived-1:0]    data_t;   // ONE level  -- always worked
+```
+
+`sid_i` came out as `wire width 0 upto offset -1` (slang: 3 bits), so every
+downstream connection collapsed.  `data_i` was correct at 64 bits.
+
+## Root cause — UHDM `ExprEval::hierarchicalSelector`
+
+Not a uhdm2rtlil bug and not a folding failure: **Surelog baked a broken range
+into the elaborated UHDM**, and the frontend faithfully imported it.
+
+In the elaborated model `pk::data_t`'s left range is a folded `constant`, but
+`pk::sid_t`'s is still an `operation(vpiSubOp)` whose first operand is a
+`struct_var` — the *whole* `user_cfg_t` value substituted where the scalar
+`sidWidth` belonged.  `read_uhdm` cannot evaluate that (`Unsupported expression
+type: struct_var`), reads it as 0, and computes `[0-1 : 0]` → width 0.
+
+The substitution comes from `hierarchicalSelector`'s `struct_var` branch: on a
+`ReturnType::VALUE` walk it returned the matched member's value
+**unconditionally**, ignoring `lastElem` and never recursing into the remaining
+path elements.  So `CFG.u.sidWidth` stopped at `u` and yielded the nested
+struct.  One-level paths were unaffected because their only member *is* the
+last element — exactly the observed split between `sid_t` and `data_t`.
+
+The `struct_typespec` branch a few lines below already had the correct
+`if (lastElem) return res; else recurse` shape; the fix gives the `struct_var`
+branch (and the identical `io_decl` branch) the same walk.
+
+Fixed in `third_party/Surelog/third_party/UHDM/templates/ExprEval.cpp`.
+Requires re-running Surelog to re-elaborate — the bad range is stored *in* the
+`.uhdm` file, so an existing `slpp_all/surelog.uhdm` keeps reproducing it.
+
+## Checking
+
+`read_verilog` cannot parse function-built struct localparams, so this is a
+**slang-miter-only** test (`test_slang_equiv.ys`), like `def_ctx_struct_param`.
+
+```
+wire width 3  input 2 \sid_i      # was: width 0 upto offset -1
+wire width 64 input 3 \data_i
+```

--- a/test/pkg_nested_struct_param_width/dut.sv
+++ b/test/pkg_nested_struct_param_width/dut.sv
@@ -1,0 +1,13 @@
+package pk;
+  typedef struct packed { int unsigned sidWidth; int unsigned dataWidth; } user_cfg_t;
+  typedef struct packed { user_cfg_t u; int unsigned derived; } cfg_t;   // NESTED
+  function automatic user_cfg_t mku(); user_cfg_t c; c.sidWidth=3; c.dataWidth=32; return c; endfunction
+  function automatic cfg_t build(user_cfg_t uu); cfg_t c; c.u=uu; c.derived=uu.dataWidth*2; return c; endfunction
+  localparam user_cfg_t UCFG = mku();
+  localparam cfg_t CFG = build(UCFG);
+  typedef logic [CFG.u.sidWidth-1:0] sid_t;      // NESTED field  -> 3 bits
+  typedef logic [CFG.derived-1:0]    data_t;     // top-level field -> 64 bits
+endpackage
+module dut (input logic clk_i, input pk::sid_t sid_i, input pk::data_t data_i, output logic o);
+  assign o = ^{sid_i, data_i};
+endmodule

--- a/test/pkg_nested_struct_param_width/test_slang_equiv.ys
+++ b/test/pkg_nested_struct_param_width/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the
+# CVA6-realistic shapes here (cfg_t'(0) cast default, function with member
+# writes + return), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter


### PR DESCRIPTION
Two independent bugs, both surfaced by the CVA6 per-module `read_uhdm`-vs-`read_slang` sweep while chasing the round-24 "struct member sizing" group. **49 → 53 proven.**

### 1. Nested struct-field reads — Surelog bump (chipsalliance/UHDM#1140, merged)

`ExprEval::hierarchicalSelector`'s `struct_var`, `io_decl` and `struct_net` branches returned a matched member's value **unconditionally** on a `ReturnType::VALUE` walk — ignoring `lastElem`, never recursing — so `CFG.u.sidWidth` stopped at `u`.

Surelog then baked an `operation(vpiSubOp)` whose operand is a whole `struct_var` into the **elaborated** range. `read_uhdm` cannot evaluate that (`Unsupported expression type: struct_var`), read it as 0, and computed `[-1:0]` → a zero-width port. One-level paths always worked, because their only member *is* the last element — that asymmetry is the fingerprint. The `struct_typespec` branch in the same function already had the correct `if (lastElem) return res; else recurse` shape.

Since the bad range is stored *in* the `.uhdm`, Surelog must re-run to observe the fix.

### 2. `[-1:0]` is TWO bits, not an elided field

Reverts the premise of 5644ad55. Verilog sizes a range as `|msb-lsb|+1` regardless of sign, and both reference frontends agree:

| frontend | `logic [SEL-1:0] s` with `SEL=0` |
|---|---|
| `read_verilog` | `wire width 2 upto offset -1` |
| `read_slang` | `wire width 2 upto offset -1` |
| `read_uhdm` (before) | width 0 — **outlier** |

Same for packed struct members: a 2 + 0-size + 2 struct is **6** bits in both references, not 4. Eliding it makes the wire vanish, and every `sig[0]` read then fails "Bit select index 0 is out of range" — CVA6's hpdcache arbiters hit this directly (`hpdcache_fxarb` has `parameter int unsigned N = 0`).

### Harness fix

`run_cva6_equiv.sh` only re-elaborated when the **wrapper** was newer than the cached `slpp_all/surelog.uhdm`. The surelog binary embeds the UHDM elaborator, so an elaborator fix changes the model with every source file untouched — the sweep silently measured **stale UHDM** and the fix looked like a no-op (this bit me on the first post-fix run). It now also re-elaborates when the binary is newer.

### Manifest

`hpdcache_fxarb`, `hpdcache_rrarb`, `hpdcache_prio_1hot_encoder` are proven by fix 1 alone. `hpdcache_demux` needs **both** — verified by reverting fix 2, which drops it back to `error`. `hpdcache_victim_plru` moves `error` → `cex` (now measurable, marked TRIAGE).

### Tests

Both are **slang-miter-only** (`read_verilog` cannot parse a struct localparam built by a function), and both fail without the UHDM fix:

- `test/pkg_nested_struct_param_width` — package-localparam base; `CFG.derived` (one level) worked while `CFG.u.sidWidth` (two) gave width 0.
- `test/param_nested_struct_field_width` — module-parameter base, the CVA6 hpdcache shape; adds nested/nested division and `$clog2`.

### Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter 33/35 (only the 2 known-fails), 0 true failures, 0 crashes, 0 new sim-equiv warnings. Includes the rp32 SoC tests that motivated 5644ad55.
- **Surelog regression** 786 PASS / 5 DIFF / 0 FAIL. All 5 DIFFs are **byte-identical with and without the patch** (A/B: stash → rebuild → re-run per suite → diff the diffs) — they are pre-existing in that checkout on plain master, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)