### PR TITLE
uhdm: `$bits` of a type parameter + Surelog chained-type-param bump

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -2439,6 +2439,55 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
 
                     auto first_arg = func_call->Tf_call_args()->at(0);
 
+                    // `$bits(T)` where T is a TYPE PARAMETER.  Surelog folds
+                    // `$bits(pkg::struct_t)` to a constant during elaboration,
+                    // but leaves the type-parameter form as an unevaluated
+                    // sys_func_call whose argument is a bare `ref_obj` naming
+                    // the parameter — importing that ref as an expression
+                    // yields 1 bit, so the query collapsed to 1.  CVA6's
+                    // hpdcache modules are built on exactly this shape
+                    // (`parameter type hpdcache_req_t = …;
+                    //   parameter int DATA_WIDTH = $bits(hpdcache_req_t)`),
+                    // which sized every data port to 1 instead of 147.
+                    // Resolve the parameter's BOUND typespec from the
+                    // elaborated instance and measure that instead.
+                    if (auto ro = dynamic_cast<const UHDM::ref_obj*>(first_arg)) {
+                        const UHDM::typespec* bound_ts = nullptr;
+                        if (auto ag = ro->Actual_group()) {
+                            if (ag->UhdmType() == uhdmtype_parameter)
+                                if (auto tp = any_cast<const UHDM::type_parameter*>(ag))
+                                    if (tp->Typespec())
+                                        bound_ts = tp->Typespec()->Actual_typespec();
+                        }
+                        // The ref is often unbound (no Actual_group) — look the
+                        // name up among the instance's type parameters.
+                        if (!bound_ts) {
+                            auto mi = dynamic_cast<const UHDM::module_inst*>(
+                                current_instance ? (const UHDM::scope*)current_instance : nullptr);
+                            if (mi && mi->Parameters()) {
+                                for (auto p : *mi->Parameters()) {
+                                    if (p->UhdmType() != uhdmtype_parameter) continue;
+                                    if (p->VpiName() != ro->VpiName()) continue;
+                                    if (auto tp = any_cast<const UHDM::type_parameter*>(p))
+                                        if (tp->Typespec())
+                                            bound_ts = tp->Typespec()->Actual_typespec();
+                                    break;
+                                }
+                            }
+                        }
+                        if (bound_ts) {
+                            int w = get_width_from_typespec(bound_ts, current_instance);
+                            if (w > 0) {
+                                total_bits = w;
+                                if (func_name == "$bits") {
+                                    log_debug("UHDM: $bits(type param %s) = %d\n",
+                                              std::string(ro->VpiName()).c_str(), w);
+                                    return RTLIL::SigSpec(RTLIL::Const(w, 32));
+                                }
+                            }
+                        }
+                    }
+
                     // Walk a typespec to extract its dimensions in outer→inner
                     // order.  For multi-range packed types (logic [a:b][c:d])
                     // the ranges are dim 1, dim 2, …; nested Elem_typespec

--- a/test/bits_of_type_param/README.md
+++ b/test/bits_of_type_param/README.md
@@ -1,0 +1,54 @@
+# bits_of_type_param
+
+`$bits(T)` where `T` is a **type parameter** folded to 1.
+
+```systemverilog
+module dut #(
+    parameter  type req_t      = pk::req_t,
+    parameter  int  DATA_WIDTH = $bits(req_t),        // -> was 1
+    localparam type data_t     = logic [DATA_WIDTH-1:0],
+    localparam int  DIRECT     = $bits(pk::req_t)     // direct: always worked
+) (...);
+```
+
+This is the shape CVA6's hpdcache modules are built on:
+
+```systemverilog
+parameter type         hpdcache_req_t = hpdcache_pkg::hpdcache_req_t,
+parameter int unsigned DATA_WIDTH     = $bits(hpdcache_req_t),
+localparam type        data_t         = logic [DATA_WIDTH-1:0]
+```
+
+`hpdcache_mux`'s `data_o` came out **1 bit instead of 147**, and `data_i`
+(`data_t [NINPUT-1:0]`) 5 instead of 735 — the miter could not even pair the
+ports (`No matching port in gate module was found for \data_o!`).
+
+## Root cause
+
+Surelog **folds** `$bits(pkg::struct_t)` to a constant during elaboration, so
+the direct form never reaches the frontend as a call.  The type-parameter form
+is left as an unevaluated `sys_func_call` whose argument is a bare `ref_obj`
+naming the parameter — usually with no `Actual_group` binding.  Importing that
+ref as an ordinary expression yields a 1-bit signal, and `$bits` reported
+`args[0].size()` == 1.
+
+The fix (`src/frontends/uhdm/expression.cpp`, the array/range-query handler)
+resolves the argument to the type parameter's **bound** typespec — via
+`Actual_group()` when present, else by name among the elaborated instance's
+type parameters — and measures that with `get_width_from_typespec`.
+
+## Related
+
+`port_chained_type_param` is the same family: a type parameter whose default is
+*another type parameter*.  Both are needed for the hpdcache modules.
+
+Still open (documented, not fixed here): `type X = <type_param> [range]` — a
+chained type parameter carrying a **packed dimension** — compiles to a bare
+`integer_typespec` in Surelog, so it measures 32 bits regardless of the element
+type.  Seen on `hpdcache_mem_resp_demux`'s `rt_t = resp_id_t [RT_DEPTH-1:0]`
+(32 vs slang's 8).
+
+## Checking
+
+`read_verilog` cannot parse `$bits` of a type parameter in a parameter default,
+so this is a **slang-miter-only** test (`test_slang_equiv.ys`).

--- a/test/bits_of_type_param/dut.sv
+++ b/test/bits_of_type_param/dut.sv
@@ -1,0 +1,27 @@
+// `$bits(T)` where T is a TYPE PARAMETER bound to a package struct.
+// This is CVA6's hpdcache_mux/_fifo_reg/_sync_buffer shape:
+//     parameter type hpdcache_req_t = hpdcache_pkg::hpdcache_req_t,
+//     parameter int unsigned DATA_WIDTH = $bits(hpdcache_req_t),
+//     localparam type data_t = logic [DATA_WIDTH-1:0]
+// $bits() of the type parameter folded to 1, so every data port collapsed.
+package pk;
+  typedef struct packed {
+    logic [31:0] addr;
+    logic [63:0] data;
+    logic        we;
+  } req_t;                       // 97 bits
+endpackage
+
+module dut #(
+    parameter  type      req_t      = pk::req_t,
+    parameter  int       DATA_WIDTH = $bits(req_t),          // -> was 1
+    localparam type      data_t     = logic [DATA_WIDTH-1:0],
+    localparam int       DIRECT     = $bits(pk::req_t)       // direct: control
+) (
+    input  logic  clk_i,
+    input  data_t d_i,
+    input  logic [DIRECT-1:0] c_i,
+    output logic  o
+);
+  assign o = ^{d_i, c_i};
+endmodule

--- a/test/bits_of_type_param/test_slang_equiv.ys
+++ b/test/bits_of_type_param/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the
+# CVA6-realistic shape here (`$bits` of a type parameter in a parameter
+# default), so the golden reference is the built-in read_slang frontend
+# — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -52,7 +52,7 @@ csr_buffer                             4   900   proven
 csr_regfile                            4   180   cex
 cva6                                   4   180   timeout
 cva6_fifo_v3                           4   900   proven
-cva6_hpdcache_if_adapter               4   400   error
+cva6_hpdcache_if_adapter               4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 cva6_hpdcache_subsystem                4   180   crash
 cva6_hpdcache_subsystem_axi_arbiter    4   180   crash
 cva6_hpdcache_wrapper                  4   180   crash
@@ -88,51 +88,51 @@ frontend                               4   180   cex
 hpdcache                               4   180   crash
 hpdcache_1hot_to_binary                4   180   crash
 hpdcache_amo                           4   900   proven
-hpdcache_cbuf                          4   180   error
-hpdcache_cmo                           4   400   error
+hpdcache_cbuf                          4   180   proven
+hpdcache_cmo                           4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_core_arbiter                  4   180   error
 hpdcache_ctrl                          4   180   crash
 hpdcache_ctrl_pe                       4   180   cex
 hpdcache_data_downsize                 4   400   elabfail  # dead at this config: accessWidth == memDataWidth, so hpdcache_data_resize instantiates neither resizer (both binding directions hit its own $fatal)
-hpdcache_data_resize                   4   180   error
+hpdcache_data_resize                   4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_data_upsize                   4   180   crash
 hpdcache_decoder                       4   180   crash
 hpdcache_demux                         4   180   proven
-hpdcache_fifo_reg                      4   900   error
+hpdcache_fifo_reg                      4   900   proven
 hpdcache_fifo_reg_initialized          4   180   cex
 hpdcache_flush                         4   180   crash
 hpdcache_fxarb                         4   180   proven
 hpdcache_lfsr                          4   900   proven
 hpdcache_mem_req_read_arbiter          4   180   crash
-hpdcache_mem_req_write_arbiter         4   180   error
+hpdcache_mem_req_write_arbiter         4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_mem_resp_demux                4   180   error
-hpdcache_mem_to_axi_read               4   400   error
-hpdcache_mem_to_axi_write              4   400   error
+hpdcache_mem_to_axi_read               4   400   proven
+hpdcache_mem_to_axi_write              4   400   proven
 hpdcache_memctrl                       4   180   timeout
 hpdcache_miss_handler                  4   180   crash
-hpdcache_mshr                          4   400   error
-hpdcache_mux                           4   180   error
+hpdcache_mshr                          4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
+hpdcache_mux                           4   180   proven
 hpdcache_prio_1hot_encoder             4   180   proven
-hpdcache_prio_bin_encoder              4   180   error
+hpdcache_prio_bin_encoder              4   180   proven
 hpdcache_regbank_wbyteenable_1rw       4   180   crash
 hpdcache_regbank_wmask_1rw             4   180   crash
 hpdcache_rrarb                         4   180   proven
 hpdcache_rtab                          4   180   error
-hpdcache_sram                          4   180   error
-hpdcache_sram_1rw                      4   180   error
+hpdcache_sram                          4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
+hpdcache_sram_1rw                      4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_sram_wbyteenable              4   400   error
 hpdcache_sram_wbyteenable_1rw          4   400   error
-hpdcache_sram_wmask                    4   180   error
-hpdcache_sram_wmask_1rw                4   180   error
-hpdcache_sync_buffer                   4   900   error
-hpdcache_uncached                      4   400   error
+hpdcache_sram_wmask                    4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
+hpdcache_sram_wmask_1rw                4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
+hpdcache_sync_buffer                   4   900   proven
+hpdcache_uncached                      4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_victim_plru                   4   180   cex      # cex now measurable (was error: zero-width [-1:0] ports) - TRIAGE
 hpdcache_victim_random                 4   180   crash
-hpdcache_victim_sel                    4   180   error
+hpdcache_victim_sel                    4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_wbuf                          4   180   crash
-hwpf_stride                            4   400   error
-hwpf_stride_arb                        4   400   error
-hwpf_stride_wrapper                    4   400   error
+hwpf_stride                            4   400   proven
+hwpf_stride_arb                        4   400   proven
+hwpf_stride_wrapper                    4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 id_stage                               4   180   cex
 instr_decoder                          4   400   proven
 instr_queue                            4   900   proven

--- a/test/port_chained_type_param/README.md
+++ b/test/port_chained_type_param/README.md
@@ -1,7 +1,7 @@
-# port_chained_type_param — KNOWN FAILING frontend limitation
+# port_chained_type_param
 
 A port whose type is a type parameter **defaulted to another type parameter**
-comes out ONE BIT wide:
+came out ONE BIT wide:
 
     parameter type noc_req_t = struct packed { ... 49 bits ... },
     parameter type req_t     = noc_req_t     // chained
@@ -12,23 +12,46 @@ comes out ONE BIT wide:
     read_slang:  wire width 49 input 2 \in_i   <- correct
 
 A type parameter defaulted DIRECTLY to a struct (or to a package-qualified
-struct) resolves correctly — only the chain fails.
+struct) always resolved — only the chain failed.
 
-Cause: Surelog attaches no typespec to such a port (`vpiTypedef` is absent
-where a normal port has one), and the port's LowConn resolves to a bare
-`logic_var`, so there is nothing for the importer to size from.  Fixing it
-properly means resolving the type-parameter chain during elaboration, which is
-Surelog-side work.
+## Root cause — Surelog `CompileHelper::compileParameterDeclaration`
+
+Surelog attached **no typespec at all** to the chained parameter (`vpiTypespec`
+absent, where the non-chained one has `ref_typespec → struct_typespec`), so the
+port had nothing to size from and fell back to 1 bit.
+
+The `paTYPE` branch compiles the parameter's default with
+
+    compileTypespec(component, fC, Data_type, compileDesign, Reduce::No,
+                    p, /*instance=*/nullptr, false)
+
+and `compileTypespec`'s `paExpression` case can only resolve a *named* type via
+`bindTypespec(name, instance, s)` — which it skips entirely when `instance` is
+null.  So the call returned null and the parameter was left untyped.
+
+The referenced parameter is already in the same `parameters` vector being
+built, so the fix resolves the chain directly against that list — no instance
+needed.  NOTE the borrowed typespec still belongs to the parameter it was
+declared on: it is referenced **without re-parenting**, otherwise the original
+loses its owner and the chain breaks in the other direction.
 
 ## Why it mattered
 
-This is why 29 CVA6 modules reported
+CVA6's hpdcache modules chain their types this way — e.g.
+`parameter type fifo_data_t = hpdcache_mem_req_t` in `hpdcache_fifo_reg` and
+`hpdcache_sync_buffer`, whose data ports were 1 bit instead of 84.  The wrapper
+generator used to sidestep this by inlining the referenced definition into
+generated code (PR #614); that workaround is no longer load-bearing.
 
-    ERROR: No matching port in gate module was found for \<port>!
+## Still open — chained type parameter WITH a packed dimension
 
-which reads like a wrapper bug but is really a width mismatch: gold had the
-port at 1 bit, gate at its true width (`axi_shim`: 32 vs 470).  The per-module
-wrapper generator now inlines the referenced parameter's definition instead of
-naming it, which sidesteps the chain — see `inlined chained type param` in
-scripts/gen_wrapper.py.  That is a workaround in generated code, NOT a fix for
-this limitation, which still affects hand-written RTL.
+`type X = <type_param> [range]` (e.g. `hpdcache_mem_resp_demux`'s
+`localparam type rt_t = resp_id_t [RT_DEPTH-1:0]`) compiles to a bare
+`integer_typespec`, so it measures 32 bits regardless of the element type
+(32 vs slang's 8).  That is a separate Surelog defect in the same family and is
+not fixed here.
+
+## Checking
+
+`read_verilog` cannot parse a type parameter defaulted to another type
+parameter, so this is a **slang-miter-only** test (`test_slang_equiv.ys`).

--- a/test/slang_miter_expected_fail.txt
+++ b/test/slang_miter_expected_fail.txt
@@ -13,8 +13,3 @@
 arb_idx_cast
 
 
-
-# A port typed by a type parameter that is defaulted to ANOTHER type parameter
-# comes out 1 bit wide (Surelog attaches no typespec).  See README.md; the CVA6
-# wrapper generator sidesteps it by inlining, but the limitation is real.
-port_chained_type_param


### PR DESCRIPTION
Two type-parameter width gaps. With the nested-struct-field fix from #615, the CVA6 sweep's `error` bucket goes **32 → 11** and proven **53 → 62**.

### 1. `$bits(T)` where T is a type parameter folded to 1

`src/frontends/uhdm/expression.cpp`

Surelog folds `$bits(pkg::struct_t)` to a constant during elaboration, so the direct form never reaches the frontend as a call. The type-parameter form stays an unevaluated `sys_func_call` whose argument is a bare `ref_obj` naming the parameter — usually with no `Actual_group`. Importing that as an ordinary expression yields a 1-bit signal, and `$bits` reported `args[0].size()` == 1.

CVA6's hpdcache modules are built on exactly this shape:

```systemverilog
parameter type         hpdcache_req_t = hpdcache_pkg::hpdcache_req_t,
parameter int unsigned DATA_WIDTH     = $bits(hpdcache_req_t),
localparam type        data_t         = logic [DATA_WIDTH-1:0]
```

`hpdcache_mux`'s `data_o` came out **1 bit instead of 147** (`data_i`: 5 instead of 735), so the miter could not even pair the ports. The fix resolves the argument to the parameter's **bound** typespec — via `Actual_group()` when present, else by name among the elaborated instance's type parameters — and measures that.

Repro: `test/bits_of_type_param`.

### 2. Surelog bump — `parameter type A = B` where B is another type parameter

chipsalliance/Surelog#4142 (merged). Such a parameter got **no typespec at all**, so every port declared with it collapsed to 1 bit — `hpdcache_fifo_reg`/`hpdcache_sync_buffer` data ports were 1 bit instead of 84.

This is the limitation `test/port_chained_type_param` documented as a known-fail. It is now fixed at the source, so the wrapper-generator workaround from #614 is no longer load-bearing, and the test drops off `slang_miter_expected_fail.txt` — leaving `arb_idx_cast` as the only entry.

### Manifest

9 promoted to `proven`: `hpdcache_cbuf`, `hpdcache_fifo_reg`, `hpdcache_mem_to_axi_read`, `hpdcache_mem_to_axi_write`, `hpdcache_mux`, `hpdcache_prio_bin_encoder`, `hpdcache_sync_buffer`, `hwpf_stride`, `hwpf_stride_arb`. 12 move `error` → `cex` (now measurable, marked TRIAGE).

### On the round-24 "struct member sizing" entry

It was **already fixed** by the UHDM nested-struct change in #615 — its canonical example `cva6_hpdcache_if_adapter` (recorded as gold=3 vs gate=70) now yields a real counterexample instead of a width error. That catalogue had been measured on stale UHDM, before the cache-invalidation fix in #615; re-sweeping the bucket with fresh elaboration is what surfaced the two *actual* remaining causes fixed here.

### Still open (documented in both test READMEs)

`type X = <type_param> [range]` — a chained type parameter carrying a **packed dimension** — compiles to a bare `integer_typespec` and measures 32 bits regardless of element type (`hpdcache_mem_resp_demux`'s `rt_t = resp_id_t [RT_DEPTH-1:0]`: 32 vs slang's 8). Same family, separate defect, kept out so the two stay bisectable.

### Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter **36/37** (`arb_idx_cast` the only known-fail, down from 2), 0 true failures, 0 crashes, 0 new sim-equiv warnings.
- **Surelog regression 791 PASS / 0 DIFF / 0 FAIL** (the Ariane2024 golden update in #4142 is A/B-verified as that fix's own footprint).
- All four type-parameter tests re-proven after rebuilding against merged Surelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)