### PR TITLE
uhdm: chained type parameter with a packed dimension (3 stacked bugs)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -2460,10 +2460,23 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                                         bound_ts = tp->Typespec()->Actual_typespec();
                         }
                         // The ref is often unbound (no Actual_group) — look the
-                        // name up among the instance's type parameters.
+                        // name up among the enclosing instance's type
+                        // parameters.  `current_instance` is NOT yet set while
+                        // the module's own parameters are being imported (and
+                        // `$bits` in a parameter default is exactly that
+                        // case), so fall back to walking the call's parent
+                        // chain to whatever scope encloses it.
                         if (!bound_ts) {
-                            auto mi = dynamic_cast<const UHDM::module_inst*>(
-                                current_instance ? (const UHDM::scope*)current_instance : nullptr);
+                            const UHDM::module_inst* mi =
+                                dynamic_cast<const UHDM::module_inst*>(
+                                    (const UHDM::any*)current_instance);
+                            if (!mi) {
+                                for (const UHDM::any* up = func_call->VpiParent();
+                                     up; up = up->VpiParent()) {
+                                    if ((mi = dynamic_cast<const UHDM::module_inst*>(up)))
+                                        break;
+                                }
+                            }
                             if (mi && mi->Parameters()) {
                                 for (auto p : *mi->Parameters()) {
                                     if (p->UhdmType() != uhdmtype_parameter) continue;

--- a/src/frontends/uhdm/module.cpp
+++ b/src/frontends/uhdm/module.cpp
@@ -1755,7 +1755,17 @@ void UhdmImporter::import_parameter(const any* uhdm_param) {
                     }
         // Check if parameter has an expression (its value)
         if (expr) {
+            // A parameter's value is by definition compile-time constant, so
+            // fold arithmetic over it here.  import_operation otherwise only
+            // folds inside loop/function/generate/dynports contexts, which
+            // left `parameter int DEPTH = 1 << $bits(some_type_param)`
+            // unfolded — reported "non-constant value" and defaulted to 0,
+            // which then collapsed every range built from it (CVA6
+            // hpdcache_mem_resp_demux's `rt_t = resp_id_t [DEPTH-1:0]`).
+            bool saved_fcf = force_const_fold;
+            force_const_fold = true;
             RTLIL::SigSpec value_spec = import_expression(expr);
+            force_const_fold = saved_fcf;
             // import_expression of an interface struct-parameter field hier_path
             // yields a fully-X constant (is_fully_const() is TRUE for X), so test
             // is_fully_def() and resolve via the interface instead.
@@ -2992,6 +3002,15 @@ int UhdmImporter::get_width_from_typespec(const UHDM::any* typespec, const UHDM:
                 }
                 int range_total = 1;
                 if (pa->Ranges()) {
+                    // Force folding: a packed dimension is compile-time
+                    // constant by definition, but its bound is often an
+                    // OPERATION over parameters (`[DEPTH-1:0]`), which
+                    // import_operation leaves unfolded outside
+                    // loop/function/generate contexts — the range then
+                    // silently contributes 1 and the array collapses to a
+                    // single element.  Same guard import_port already uses.
+                    bool saved_fcf = force_const_fold;
+                    force_const_fold = true;
                     for (auto r : *pa->Ranges()) {
                         if (r->Left_expr() && r->Right_expr()) {
                             RTLIL::SigSpec lspec = import_expression(r->Left_expr());
@@ -3003,6 +3022,7 @@ int UhdmImporter::get_width_from_typespec(const UHDM::any* typespec, const UHDM:
                             }
                         }
                     }
+                    force_const_fold = saved_fcf;
                 }
                 int total = elem_width * range_total;
                 log("UHDM: packed_array_typespec: elem_w=%d, range_total=%d, total=%d\n",

--- a/test/type_param_packed_dim/README.md
+++ b/test/type_param_packed_dim/README.md
@@ -1,0 +1,75 @@
+# type_param_packed_dim
+
+A chained type parameter carrying a **packed dimension**:
+
+```systemverilog
+parameter  type id_t      = logic [1:0],
+parameter  type resp_id_t = id_t,                    // chained
+localparam int  DEPTH     = (1 << $bits(resp_id_t)), // 1<<2 = 4
+localparam type rt_t      = resp_id_t [DEPTH-1:0]    // 2*4 = 8 bits
+```
+
+`rt_i` came out **32 bits** instead of 8 (slang: 8).  This is CVA6
+`hpdcache_mem_resp_demux`'s `rt_t = resp_id_t [RT_DEPTH-1:0]`.
+
+It took three independent fixes, each of which alone left a plausible-looking
+but wrong width — the intermediate results were 32 → 2 → 2 → 8.
+
+## 1. Surelog: the declaration was compiled as an expression
+
+`CompileHelper.cpp`, `compileParameterDeclaration`'s `paTYPE` branch.
+
+`resp_id_t [DEPTH-1:0]` does **not** parse as a data type with a packed
+dimension.  The grammar produces an *expression*:
+
+```
+Constant_primary
+  ├─ StringConst  "resp_id_t"        <- element type
+  └─ Constant_select
+       └─ Constant_part_select_range
+            └─ Constant_range        <- [DEPTH-1 : 0]
+```
+
+so `compileTypespec` sized it as a plain integer — 32 bits, regardless of the
+element type.  The fix detects that shape and builds the
+`packed_array_typespec` the declaration actually means, resolving the element
+type from the same parameter list (as the chained-type-param fix does).  As
+there, the element typespec is referenced **without re-parenting**.
+
+## 2. `$bits` lookup needs the call's parent chain
+
+`expression.cpp`.  `$bits(resp_id_t)` in a *parameter default* is evaluated
+while the module's own parameters are being imported — at which point
+`current_instance` is not yet set, so the by-name type-parameter lookup added
+for `bits_of_type_param` found nothing.  It now falls back to walking the
+call's `VpiParent()` chain to the enclosing `module_inst`.
+
+## 3. Two const-fold gaps
+
+`import_operation` only folds inside loop / function / generate / `dynports`
+contexts, so two compile-time-constant expressions were left unfolded:
+
+- **`module.cpp` `import_parameter`** — `DEPTH = 1 << $bits(...)` reported
+  "non-constant value" and defaulted to **0**.  A parameter's value is
+  constant by definition; fold it.
+- **`module.cpp` `get_width_from_typespec`, packed_array_typespec ranges** —
+  `[DEPTH-1:0]` is an *operation*, so the range silently contributed 1 and the
+  array collapsed to a single element (width 2 = the element alone).  The same
+  guard `import_port` already uses.
+
+## Still open — unpacked array port of a type parameter
+
+`hpdcache_mem_resp_demux` also has `output resp_t mem_resp_o [N-1:0]`, which
+comes out 69 bits instead of 138 (one element instead of N).  That is an
+*unpacked* dimension on a type-param port — a different shape from this test —
+and is not fixed here.
+
+## Checking
+
+`read_verilog` cannot parse a chained type parameter, so this is a
+**slang-miter-only** test (`test_slang_equiv.ys`).
+
+```
+wire width 2 input \id_i
+wire width 8 input \rt_i     # was 32
+```

--- a/test/type_param_packed_dim/dut.sv
+++ b/test/type_param_packed_dim/dut.sv
@@ -1,0 +1,12 @@
+module dut #(
+    parameter type id_t     = logic [1:0],
+    parameter type resp_id_t = id_t,                   // chained
+    localparam int DEPTH    = (1 << $bits(resp_id_t)), // 1<<2 = 4
+    localparam type rt_t    = resp_id_t [DEPTH-1:0]    // 2*4 = 8
+) (
+    input  resp_id_t id_i,
+    input  rt_t      rt_i,
+    output logic     o
+);
+  assign o = ^{id_i, rt_i};
+endmodule

--- a/test/type_param_packed_dim/test_slang_equiv.ys
+++ b/test/type_param_packed_dim/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the
+# CVA6-realistic shape here (chained type parameter carrying a packed
+# dimension), so the golden reference is the built-in read_slang frontend
+# — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter


### PR DESCRIPTION
`localparam type rt_t = resp_id_t [DEPTH-1:0]` — a chained type parameter carrying a **packed dimension** — sized to **32 bits instead of 8** (CVA6 `hpdcache_mem_resp_demux`'s `rt_t`).

It took **three independent fixes**. Each one alone still produced a plausible-but-wrong width, the sequence being **32 → 2 → 2 → 8** — worth stating because stopping at any intermediate step would have looked like success.

### 1. Surelog bump — chipsalliance/Surelog#4143 (merged)

`<name> [msb:lsb]` does **not** parse as a data type with a packed dimension. The grammar yields an *expression*:

```
Constant_primary
  ├─ StringConst  "resp_id_t"          <- element type
  └─ Constant_select
       └─ Constant_part_select_range
            └─ Constant_range          <- [DEPTH-1 : 0]
```

so `compileTypespec` sized it as a plain integer, losing both the dimension and the element type.

The bump also picks up `ClassScope`'s regenerated golden — that upstream test already contained the construct (`localparam type T = PARAM_T [PARAM_E - 1:0]`) and now gets a proper `packed_array_typespec` where it previously had none.

### 2. `$bits` needs the call's parent chain — `expression.cpp`

The by-name type-parameter lookup added for `bits_of_type_param` keyed off `current_instance`, which is **not yet set while the module's own parameters are being imported** — and `$bits` in a parameter default is exactly that case. It now falls back to walking the call's `VpiParent()` chain to the enclosing `module_inst`.

### 3. Two const-fold gaps — `module.cpp`

`import_operation` only folds inside loop / function / generate / `dynports` contexts, so two expressions that are compile-time constant *by definition* were left unfolded:

- **`import_parameter`** — `DEPTH = 1 << $bits(...)` reported "non-constant value" and defaulted to **0**.
- **`get_width_from_typespec`, packed_array_typespec ranges** — `[DEPTH-1:0]` is an *operation*, so the range silently contributed 1 and the array collapsed to a single element (width 2 = the element alone). This is the same guard `import_port` already uses.

### Test

`test/type_param_packed_dim` (slang-miter-only — `read_verilog` cannot parse a chained type parameter). Its README records the 32 → 2 → 2 → 8 sequence so a future partial fix isn't mistaken for success.

### CVA6

`hpdcache_mem_resp_demux`'s `mem_resp_rt_i` is now correct at 8 bits (was 32). The module **still errors**, but on a *different* port: `output resp_t mem_resp_o [N-1:0]` gives 69 instead of 138 — an **unpacked** dimension on a type-param port. Different shape, documented in the README, deliberately not fixed here so the two stay bisectable.

### Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter **37/38** (`arb_idx_cast` the only known-fail), 0 true failures, 0 crashes, 0 new sim-equiv warnings.
- **Surelog regression 791 PASS / 0 DIFF / 0 FAIL.**
- All five type-parameter tests re-proven after rebuilding against merged Surelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)