### PR TITLE
uhdm: element select on a packed_array_var/net + adjudication harness fixes

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -7142,6 +7142,18 @@ RTLIL::SigSpec UhdmImporter::import_bit_select(const bit_select* uhdm_bit, const
                 net_ref_ts = logic_net->Typespec();
             } else if (auto logic_var = dynamic_cast<const UHDM::logic_var*>(actual_group)) {
                 net_ref_ts = logic_var->Typespec();
+            } else if (auto pav = dynamic_cast<const UHDM::packed_array_var*>(actual_group)) {
+                // A signal declared with a packed-array TYPE (`rt_t rt_i`,
+                // where `rt_t = id_t [DEPTH-1:0]`) elaborates to a
+                // packed_array_var/net, not a logic_var/net.  Only the logic_*
+                // forms were consulted here, so the element width stayed 1 and
+                // `rt_i[idx]` degenerated to an unscaled BIT select — reading
+                // bit `idx` instead of the element at `idx * ELEM_W`.  Correct
+                // only for index 0 (CVA6 hpdcache_mem_resp_demux's routing
+                // select was wrong for 3 of its 4 index values).
+                net_ref_ts = pav->Typespec();
+            } else if (auto pan = dynamic_cast<const UHDM::packed_array_net*>(actual_group)) {
+                net_ref_ts = pan->Typespec();
             }
             if (net_ref_ts && net_ref_ts->Actual_typespec()) {
                 auto ts = net_ref_ts->Actual_typespec();

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -105,7 +105,7 @@ hpdcache_fxarb                         4   180   proven
 hpdcache_lfsr                          4   900   proven
 hpdcache_mem_req_read_arbiter          4   180   crash
 hpdcache_mem_req_write_arbiter         4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
-hpdcache_mem_resp_demux                4   180   cex      # cex now measurable (was error: unpacked type-param port) - TRIAGE
+hpdcache_mem_resp_demux                4   180   proven
 hpdcache_mem_to_axi_read               4   400   proven
 hpdcache_mem_to_axi_write              4   400   proven
 hpdcache_memctrl                       4   180   timeout

--- a/test/cva6_equiv/scripts/adjudicate.py
+++ b/test/cva6_equiv/scripts/adjudicate.py
@@ -80,10 +80,83 @@ if not outs:
 def rnd(n, w):
     return " ".join(f"{n}[{min(b+31, w-1)}:{b}] <= $random;" for b in range(0, w, 32))
 
+# The netlists flatten an UNPACKED-array port to one wide vector, but the
+# behavioural RTL still declares it as an array -- connecting the flat wire to
+# it is a hard Verilator error ("mismatch between port which is an array, and
+# expression which is not"), which used to surface as an unexplained
+# "both simulators failed".  Find those ports in the wrapper and give the RTL
+# instance its own array-shaped nets, packed to/from the flat vector.
+unpacked = {}          # port name -> element count
+try:
+    wtxt = open(WRAP).read()
+    wtxt = re.sub(r"//[^\n]*", "", wtxt)
+    params = dict(re.findall(r"\bparameter\s+(?:int|int\s+unsigned)\s+(\w+)\s*=\s*(\d+)",
+                             wtxt))
+    for pname, dim in re.findall(
+            r"^\s*(?:input|output|inout)\s+\w+\s+(\w+)\s*\[([^\]]+)\]\s*,?\s*$",
+            wtxt, re.M):
+        m = re.fullmatch(r"\s*(\w+)\s*-\s*1\s*:\s*0\s*", dim)
+        cnt = None
+        if m:
+            cnt = int(params[m.group(1)]) if m.group(1) in params else None
+            if m.group(1).isdigit():
+                cnt = int(m.group(1))
+        elif re.fullmatch(r"\s*\d+\s*:\s*0\s*", dim):
+            cnt = int(dim.split(":")[0]) + 1
+        elif re.fullmatch(r"\s*\d+\s*", dim):
+            cnt = int(dim)
+        if cnt:
+            unpacked[pname] = cnt
+except OSError:
+    pass
+
+_allports = {n: w for n, w in ins + outs}
+_bad = [n for n, c in unpacked.items()
+        if n in _allports and (c <= 0 or _allports[n] % c)]
+for n in _bad:
+    del unpacked[n]
+if _bad:
+    print(f"{mod}: unpacked ports not evenly divisible, left flat: {_bad}")
+_unres = [n for n in re.findall(
+              r"^\s*(?:input|output|inout)\s+\w+\s+(\w+)\s*\[[^\]]+\]\s*,?\s*$",
+              re.sub(r"//[^\n]*", "", open(WRAP).read()), re.M)
+          if n in _allports and n not in unpacked]
+if _unres:
+    # Say so rather than let the simulator fail with a port-shape error that
+    # reads like a design problem.
+    print(f"{mod}: WARNING cannot size unpacked port(s) {_unres}; "
+          f"the RTL connection will fail to elaborate")
+
 decl  = "\n".join(f"  reg [{w-1}:0] {n};" for n, w in ins)
 wires = "\n".join(f"  wire [{w-1}:0] r_{n}, g_{n}, s_{n};" for n, w in outs)
+
+# Array-shaped views for the RTL instance only; the netlists stay flat.
+arr_decl, arr_glue = [], []
+for n, w in ins:
+    if n not in unpacked: continue
+    c = unpacked[n]; ew = w // c
+    arr_decl.append(f"  wire [{ew-1}:0] a_{n} [0:{c-1}];")
+    for k in range(c):
+        _kk = k if os.environ.get("ADJ_ELEM_ORDER","hi") == "lo" else (c-1-k)
+        arr_glue.append(f"  assign a_{n}[{k}] = {n}[{(_kk+1)*ew-1}:{_kk*ew}];")
+for n, w in outs:
+    if n not in unpacked: continue
+    c = unpacked[n]; ew = w // c
+    arr_decl.append(f"  wire [{ew-1}:0] a_r_{n} [0:{c-1}];")
+    _order = range(c-1, -1, -1) if os.environ.get("ADJ_ELEM_ORDER","hi") == "lo" \
+             else range(0, c)
+    arr_glue.append("  assign r_%s = {%s};" %
+                    (n, ", ".join(f"a_r_{n}[{k}]" for k in _order)))
+arrays = "\n".join(arr_decl + arr_glue)
+
 conn  = ", ".join(f".{n}({n})" for n, _ in ins)
+# The RTL sees the array views where a port is unpacked; the netlists never do.
+rtl_conn = ", ".join(f".{n}(a_{n})" if n in unpacked else f".{n}({n})"
+                     for n, _ in ins)
 def bind(p): return ", ".join(f".{n}({p}_{n})" for n, _ in outs)
+def bind_rtl():
+    return ", ".join(f".{n}(a_r_{n})" if n in unpacked else f".{n}(r_{n})"
+                     for n, _ in outs)
 drive = "\n      ".join(rnd(n, w) for n, w in ins)
 # Compare each netlist against the RTL, not against each other.  An X on the
 # RTL side is not a divergence -- it is the reference declining to say.
@@ -91,21 +164,29 @@ gbad = " || ".join(f"((r_{n} === r_{n}) && (g_{n} !== r_{n}))" for n, _ in outs)
 sbad = " || ".join(f"((r_{n} === r_{n}) && (s_{n} !== r_{n}))" for n, _ in outs)
 # Name the first output that diverges, per side -- "they differ" is not a
 # diagnosis, and with a dozen ports the count alone does not say where to look.
-seen  = "\n".join(f"  reg rep_{n};" for n, _ in outs)
-seeni = "\n    ".join(f"rep_{n} = 0;" for n, _ in outs)
+# Track the two sides SEPARATELY.  A single per-output flag is claimed by
+# whichever side diverges first, so if slang breaks at cycle 0 the uhdm
+# divergence is never printed and the run looks like "slang only" even when
+# both are counted as differing.
+seen  = "\n".join(f"  reg repg_{n}, reps_{n};" for n, _ in outs)
+seeni = "\n    ".join(f"repg_{n} = 0; reps_{n} = 0;" for n, _ in outs)
 report = "\n".join(
-    f'      if (!rep_{n} && (r_{n} === r_{n}) && (g_{n} !== r_{n} || s_{n} !== r_{n})) '
-    f'begin rep_{n} = 1; $display("FIRST %0d {n} rtl=%h uhdm=%h slang=%h", i, '
-    f'r_{n}, g_{n}, s_{n}); end' for n, _ in outs)
+    f'      if (!repg_{n} && (r_{n} === r_{n}) && (g_{n} !== r_{n})) '
+    f'begin repg_{n} = 1; $display("FIRST-UHDM %0d {n} rtl=%h uhdm=%h", i, '
+    f'r_{n}, g_{n}); end\n'
+    f'      if (!reps_{n} && (r_{n} === r_{n}) && (s_{n} !== r_{n})) '
+    f'begin reps_{n} = 1; $display("FIRST-SLANG %0d {n} rtl=%h slang=%h", i, '
+    f'r_{n}, s_{n}); end' for n, _ in outs)
 
 tb = f"""`timescale 1ns/1ps
 module tb;
   reg clk = 0, rst_ni = 0;
 {decl}
 {wires}
+{arrays}
   integer i, seed_r, g_err = 0, s_err = 0;
 {seen}
-  {TOP}      rtl (.clk_i(clk), .rst_ni(rst_ni), {conn}, {bind('r')});
+  {TOP}      rtl (.clk_i(clk), .rst_ni(rst_ni), {rtl_conn}, {bind_rtl()});
   gold_{TOP} gold(.clk_i(clk), .rst_ni(rst_ni), {conn}, {bind('g')});
   gate_{TOP} gate(.clk_i(clk), .rst_ni(rst_ni), {conn}, {bind('s')});
   // Free-running clock, inputs driven on the FALLING edge and outputs sampled

--- a/test/type_param_override_elem_sel/README.md
+++ b/test/type_param_override_elem_sel/README.md
@@ -1,0 +1,66 @@
+# type_param_override_elem_sel
+
+A `parameter type` that is **overridden at the instantiation**, used to build a
+packed-array type, then dynamically indexed:
+
+```systemverilog
+module child #(
+    parameter  type id_t  = logic,                 // DEFAULT: 1 bit
+    localparam int  DEPTH = (1 << $bits(id_t)),
+    localparam type rt_t  = id_t [DEPTH-1:0],
+    localparam type sel_t = logic [0:0]
+) (input rt_t rt_i, input id_t id_i, output sel_t sel_o);
+  assign sel_o = rt_i[int'(id_i)];
+endmodule
+
+child #(.id_t(logic [1:0])) u (...);               // OVERRIDE: 2-bit element
+```
+
+`rt_i[int'(id_i)]` came out as an **unscaled bit select** — `$shiftx` with
+`Y_WIDTH 1` reading bit `id` instead of the 2-bit element at `id*2`.  Correct
+only for `id == 0`; wrong for the other three.
+
+This is CVA6 `hpdcache_mem_resp_demux`'s routing select
+(`mem_resp_rt_i[int'(mem_resp_id_i)]`), which sent responses to the wrong
+output port on ~35% of cycles.
+
+## Two bugs, both required
+
+**1. Surelog — the element was resolved from the DECLARATION DEFAULT.**
+`compileParameterDeclaration` builds `rt_t`'s `packed_array_typespec` at
+definition time, where `id_t` is still its default `logic` (1 bit).  `rt_t` is
+a *localparam* type, so nothing re-resolved it per instance and the element
+stayed 1 bit even though the instance binds 2.
+
+The element reference now records the source type's name, and
+`ElaborationStep::elabTypeParameter_` re-binds it against the instance
+(`bindTypespec`), rebuilding the typespec when the binding differs.
+
+**2. uhdm2rtlil — `import_bit_select` never read that typespec.**
+Its element-width detection consulted only `logic_net` / `logic_var`, but a
+signal declared with a packed-array *type* elaborates to a
+`packed_array_var` / `packed_array_net`.  So even with the corrected UHDM the
+width stayed 1.  Both forms are now consulted.
+
+## Why it took a bisect
+
+Four narrower repros were built first and **all PROVED**, so each hypothesis
+was rejected in turn:
+
+| repro | result |
+|---|---|
+| `rt[int'(id)]` on a type-param packed array | PROVEN — not the bug |
+| pack/unpack generate loop (packed elem -> unpacked port elem) | PROVEN — not the bug |
+| assignment target narrower than the element | PROVEN — not the bug |
+| chained element type (`id_t = base_id_t`) | PROVEN — not the bug |
+
+The missing ingredient in every one was the **override at the instantiation**:
+with defaults only, the definition-time and bound types coincide and the bug is
+invisible.  That is also why `hpdcache_demux` and `hpdcache_mux` prove
+individually while their composition failed.
+
+## Checking
+
+`read_verilog` cannot parse the type-parameter override shape, so this is a
+**slang-miter-only** test (`test_slang_equiv.ys`).  It FAILS (miter finds a
+counterexample) without either fix.

--- a/test/type_param_override_elem_sel/dut.sv
+++ b/test/type_param_override_elem_sel/dut.sv
@@ -1,0 +1,37 @@
+// The CVA6 hpdcache_mem_resp_demux shape: a child whose type parameter
+// DEFAULTS to `logic` (1 bit) and is OVERRIDDEN at the instantiation, with a
+// localparam type built from it carrying a packed dimension.
+//
+//   parameter type resp_id_t = logic,                    // default 1 bit
+//   localparam int RT_DEPTH  = (1 << $bits(resp_id_t)),
+//   localparam type rt_t     = resp_id_t [RT_DEPTH-1:0]
+//   ...
+//   assign sel = rt_i[int'(id_i)];
+//
+// If rt_t's element type is resolved from the DEFAULT rather than the bound
+// type, the element is 1 bit and the select degenerates to an unscaled BIT
+// select -- reading bit `id` instead of the element at `id*ELEM_W`.
+module child #(
+    parameter type id_t     = logic,                 // default: 1 bit
+    localparam int DEPTH    = (1 << $bits(id_t)),
+    localparam type rt_t    = id_t [DEPTH-1:0],
+    localparam type sel_t   = logic [0:0]
+) (
+    input  rt_t  rt_i,
+    input  id_t  id_i,
+    output sel_t sel_o
+);
+  assign sel_o = rt_i[int'(id_i)];
+endmodule
+
+module dut (
+    input  logic [7:0] rt_i,      // 4 elements x 2 bits
+    input  logic [1:0] id_i,
+    output logic       sel_o
+);
+  child #(.id_t(logic [1:0])) u (   // OVERRIDE: element becomes 2 bits
+      .rt_i (rt_i),
+      .id_i (id_i),
+      .sel_o(sel_o)
+  );
+endmodule

--- a/test/type_param_override_elem_sel/test_slang_equiv.ys
+++ b/test/type_param_override_elem_sel/test_slang_equiv.ys
@@ -1,0 +1,20 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the
+# CVA6-realistic shape here (a type parameter OVERRIDDEN at the
+# instantiation), so the golden reference is the built-in read_slang
+# — the same reference used for CVA6 latch parity.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter


### PR DESCRIPTION
Completes the `hpdcache_mem_resp_demux` triage — the module is **now PROVEN** (CVA6: 63 proven / 40 cex / 10 error).

## The bug — two halves, both required

Either fix alone still gives the wrong answer.

**1. Surelog bump** (chipsalliance/Surelog#4144, merged). `localparam type rt_t = id_t [DEPTH-1:0]` where `id_t` is a `parameter type` **overridden at the instantiation** kept the element from `id_t`'s *declaration default* (the erased `= logic`, one bit) — `rt_t` is a localparam type, so it was never re-resolved per instance.

**2. `import_bit_select` never read that typespec** (`expression.cpp`). Its element-width detection consulted only `logic_net` / `logic_var`, but a signal declared with a packed-array *type* elaborates to a `packed_array_var` / `packed_array_net`. So even with corrected UHDM the element width stayed 1.

Net effect: `$shiftx` with `Y_WIDTH 1`, reading bit `idx` instead of the element at `idx * ELEM_W` — correct only for index 0. In CVA6 that made the routing select `mem_resp_rt_i[int'(mem_resp_id_i)]` wrong for three of its four index values: **right data, wrong output port**, on ~35% of simulated cycles.

Repro `test/type_param_override_elem_sel` — fails without either fix.

## Why this needed a bisect

Four narrower reproducers were built first and **all PROVED**, rejecting each hypothesis in turn:

| hypothesis | result |
|---|---|
| dynamic index on a type-param packed array (the open `arb_idx_cast` shape) | PROVEN — not the bug |
| pack/unpack generate loop (packed elem → unpacked port elem) | PROVEN — not the bug |
| assignment target narrower than the element | PROVEN — not the bug |
| chained element type | PROVEN — not the bug |

The missing ingredient in every one was the **override at the instantiation**: with defaults only, the definition-time and bound types coincide and the bug is invisible. That is also why `hpdcache_demux` and `hpdcache_mux` prove individually while their composition failed. This is recorded in the test README so it isn't re-walked.

## Adjudication harness (`scripts/adjudicate.py`)

Triage was blocked by the harness before any of the above was reachable — it reported only "NO VERDICT (both simulators failed)", which reads like a design problem:

1. **Unpacked-array ports.** The TB derives its ports from the *flat* netlist and bound flat wires to the RTL's still-unpacked ports; Verilator rejects that outright and iverilog cannot parse the CVA6 flist at all. The RTL instance now gets array-shaped views packed to/from the flat vector.
2. **Element order, measured not assumed.** With element 0 low, slang diverged from the RTL on 5000/5000 cycles; flipped, it matches 5000/5000. The wrong choice makes any module with an unpacked port look like `BOTH_DIFFER` — i.e. it would have been misread as a UHDM bug. `ADJ_ELEM_ORDER` overrides.
3. **Per-side first-divergence.** One flag per output was claimed by whichever side diverged first, so a slang mismatch at cycle 0 hid the uhdm one entirely and the run looked like "slang only".

With those, the verdict was unambiguous: slang 0/5000 errors vs the RTL, read_uhdm 1772/5000 → **UHDM_WRONG**.

## Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter **39/40** (`arb_idx_cast` the only known-fail), 0 true failures, 0 crashes, 0 new sim-equiv warnings.
- **Surelog regression 791 PASS / 0 DIFF / 0 FAIL.**
- Test and CVA6 module both re-verified after rebuilding against merged Surelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)