### PR TITLE
uhdm: memory word of a packed 2-D element + per-byte writes into it

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -1570,7 +1570,8 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                         RTLIL::Memory* memory = module->memories.at(mem_id);
                         const expr* addr_expr = nullptr;
                         int psel_lo = 0, psel_hi = 0;
-                        bool have_psel = parse_mem_partial_select(vs, addr_expr, psel_lo, psel_hi);
+                        bool have_psel = parse_mem_partial_select(vs, addr_expr, psel_lo, psel_hi,
+                                                                  memory->width);
                         if (!addr_expr && !exprs->empty())
                             addr_expr = (*exprs)[0];   // plain `mem[addr]` read (no slice)
                         if (addr_expr) {
@@ -2165,6 +2166,48 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                             }
                         } else {
                             log_warning("vpiVarSelect: non-constant part select on '%s'\n", base_name.c_str());
+                        }
+                    } else if (second_idx->VpiType() == vpiIndexedPartSelect) {
+                        // Indexed part select WITHIN the element:
+                        // `wdata[j][i*8 +: 8]`.  This case was missing, so the
+                        // access fell through to the generic branch below,
+                        // which re-imports the select against the FULL base
+                        // wire instead of the element — for a base narrower
+                        // than base+width that aborts yosys outright with
+                        // "Assert `offset + length <= size()' failed"
+                        // (CVA6's behavioural byte-enable SRAM, whose write
+                        // loop is exactly this shape).
+                        const indexed_part_select* ips =
+                            any_cast<const indexed_part_select*>(second_idx);
+                        RTLIL::SigSpec base_sig =
+                            import_expression(ips->Base_expr(), input_mapping);
+                        RTLIL::SigSpec w_sig =
+                            import_expression(ips->Width_expr(), input_mapping);
+                        bool pos = ips->VpiIndexedPartSelectType() == vpiPosIndexed;
+                        if (w_sig.is_fully_const()) {
+                            int w = w_sig.as_const().as_int();
+                            if (base_sig.is_fully_const() && w > 0) {
+                                int b = base_sig.as_const().as_int();
+                                int off = pos ? b : (b - w + 1);
+                                if (off >= 0 && off + w <= element_sig.size()) {
+                                    result = element_sig.extract(off, w);
+                                } else {
+                                    log_warning("vpiVarSelect: indexed part select "
+                                                "[%d +/- %d] out of range for %d-bit "
+                                                "element of '%s'\n",
+                                                b, w, element_sig.size(),
+                                                base_name.c_str());
+                                }
+                            } else if (!base_sig.empty() && w > 0) {
+                                // Dynamic base — shift the ELEMENT, not the
+                                // whole array, and take w bits.
+                                RTLIL::Wire* y = module->addWire(NEW_ID, w);
+                                module->addShiftx(NEW_ID, element_sig, base_sig, y);
+                                result = RTLIL::SigSpec(y);
+                            }
+                        } else {
+                            log_warning("vpiVarSelect: non-constant width in indexed "
+                                        "part select on '%s'\n", base_name.c_str());
                         }
                     } else if (second_idx->VpiType() == vpiBitSelect) {
                         // Bit select within the element.  Index may be dynamic

--- a/src/frontends/uhdm/memory_analysis.cpp
+++ b/src/frontends/uhdm/memory_analysis.cpp
@@ -484,6 +484,9 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
     
     // Extract memory dimensions from the array_net structure
     int width = 1; // Default bit width
+    // Outer packed dimension when the memory WORD is itself a packed array
+    // (`logic [NDATA-1:0][DATA_SIZE-1:0]`); 0 = plain vector word.
+    int packed_outer_dim = 0;
     int size = 1;  // Default array size
     int start_offset = 0;
     // Memory dimensions may be interface struct-parameter expressions
@@ -526,25 +529,49 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
             if (typespec && typespec->UhdmType() == uhdmlogic_typespec) {
                 auto logic_typespec = any_cast<const UHDM::logic_typespec*>(typespec);
                 if (logic_typespec->Ranges() && !logic_typespec->Ranges()->empty()) {
-                    auto range = (*logic_typespec->Ranges())[0];
-                    if (range->Left_expr() && range->Right_expr()) {
-                        // The packed width may be an interface struct-parameter
-                        // expression like `s.CFG.BUS.DAT-1`; force constant folding
-                        // so the `-1` operation collapses to a constant.
-                        bool saved_fcf = force_const_fold;
-                        force_const_fold = true;
+                    // Multiply ALL packed dimensions.  Only Ranges()[0] was
+                    // consulted, so a memory whose element is a packed
+                    // MULTI-DIMENSIONAL array — `typedef logic [NDATA-1:0]
+                    // [DATA_SIZE-1:0] mem_t [DEPTH]` — got the width of the
+                    // OUTER dimension alone (NDATA, not NDATA*DATA_SIZE).  A
+                    // per-byte write into such a memory then indexes past the
+                    // word and aborts yosys outright with
+                    // "Assert `offset + length <= size()' failed" (CVA6's
+                    // behavioural byte-enable SRAM, hpdcache_sram_wbyteenable).
+                    int packed_total = 1;
+                    int outer_dim = 0;
+                    bool all_const = true;
+                    // A bound may be an interface struct-parameter expression
+                    // like `s.CFG.BUS.DAT-1`; force folding so `-1` collapses.
+                    bool saved_fcf = force_const_fold;
+                    force_const_fold = true;
+                    for (auto range : *logic_typespec->Ranges()) {
+                        if (!range->Left_expr() || !range->Right_expr()) {
+                            all_const = false;
+                            break;
+                        }
                         RTLIL::SigSpec left_spec = import_expression(range->Left_expr());
                         RTLIL::SigSpec right_spec = import_expression(range->Right_expr());
-                        force_const_fold = saved_fcf;
-                        
-                        if (left_spec.is_fully_const() && right_spec.is_fully_const()) {
-                            int left = left_spec.as_int();
-                            int right = right_spec.as_int();
-                            width = std::abs(left - right) + 1;
-
-                            if (mode_debug)
-                                log("    Packed range: [%d:%d], width=%d\n", left, right, width);
+                        if (!left_spec.is_fully_const() || !right_spec.is_fully_const()) {
+                            all_const = false;
+                            break;
                         }
+                        int left = left_spec.as_int();
+                        int right = right_spec.as_int();
+                        int dim = std::abs(left - right) + 1;
+                        if (outer_dim == 0) outer_dim = dim;   // first = outermost
+                        packed_total *= dim;
+                        if (mode_debug)
+                            log("    Packed range: [%d:%d]\n", left, right);
+                    }
+                    force_const_fold = saved_fcf;
+                    if (all_const && packed_total > 0) {
+                        width = packed_total;
+                        if (logic_typespec->Ranges()->size() > 1)
+                            packed_outer_dim = outer_dim;
+                        if (mode_debug)
+                            log("    Packed width=%d (%d dims)\n", width,
+                                (int)logic_typespec->Ranges()->size());
                     }
                 }
             }
@@ -570,8 +597,33 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
                 }
             }
         }
-        if (ats->Elem_typespec() && ats->Elem_typespec()->Actual_typespec())
-            width = get_width_from_typespec(ats->Elem_typespec()->Actual_typespec());
+        if (ats->Elem_typespec() && ats->Elem_typespec()->Actual_typespec()) {
+            // Pass the instance: the element's packed bounds are usually
+            // parameter expressions (`logic [NDATA-1:0][DATA_SIZE-1:0]`), and
+            // without a scope to resolve them against the width silently
+            // collapses to 1 — which then aborts yosys on the first per-byte
+            // write into the memory.
+            const UHDM::typespec* ets = ats->Elem_typespec()->Actual_typespec();
+            int ew = get_width_from_typespec(ets, current_instance);
+            if (ew > 0) width = ew;
+            // Same geometry note as above: if the element is itself a packed
+            // MULTI-dim array, record the outer dimension so an
+            // `mem[addr][j][sel]` write can place element j.
+            if (ets->UhdmType() == uhdmlogic_typespec) {
+                auto elt = any_cast<const UHDM::logic_typespec*>(ets);
+                if (elt->Ranges() && elt->Ranges()->size() > 1) {
+                    auto r0 = (*elt->Ranges())[0];
+                    if (r0->Left_expr() && r0->Right_expr()) {
+                        bool sv = force_const_fold; force_const_fold = true;
+                        RTLIL::SigSpec l0 = import_expression(r0->Left_expr());
+                        RTLIL::SigSpec r0s = import_expression(r0->Right_expr());
+                        force_const_fold = sv;
+                        if (l0.is_fully_const() && r0s.is_fully_const())
+                            packed_outer_dim = std::abs(l0.as_int() - r0s.as_int()) + 1;
+                    }
+                }
+            }
+        }
         if (mode_debug)
             log("    From array_typespec: width=%d, size=%d, start_offset=%d\n",
                 width, size, start_offset);
@@ -585,6 +637,13 @@ void UhdmImporter::create_memory_from_array(const array_net* uhdm_array) {
     memory->width = width;
     memory->size = size;
     memory->start_offset = start_offset;
+    // Record the OUTER packed dimension when the word is itself a packed array
+    // (`logic [NDATA-1:0][DATA_SIZE-1:0]`).  A write of the form
+    // `mem[addr][j][sel]` needs it to place element j at j*(width/NDATA);
+    // without it the element index has to be dropped, which silently writes
+    // every element at element 0's offset.
+    if (packed_outer_dim > 1)
+        memory->attributes[ID(packed_outer_dim)] = RTLIL::Const(packed_outer_dim);
 
     // Add source attribute
     add_src_attribute(memory->attributes, uhdm_array);
@@ -607,6 +666,9 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
     
     // Extract memory dimensions from the array_var structure
     int width = 1; // Default bit width
+    // Outer packed dimension when the memory WORD is itself a packed array
+    // (`logic [NDATA-1:0][DATA_SIZE-1:0]`); 0 = plain vector word.
+    int packed_outer_dim = 0;
     int size = 1;  // Default array size
     int start_offset = 0;
     // Memory dimensions may be interface struct-parameter expressions
@@ -651,25 +713,49 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
             if (typespec && typespec->UhdmType() == uhdmlogic_typespec) {
                 auto logic_typespec = any_cast<const UHDM::logic_typespec*>(typespec);
                 if (logic_typespec->Ranges() && !logic_typespec->Ranges()->empty()) {
-                    auto range = (*logic_typespec->Ranges())[0];
-                    if (range->Left_expr() && range->Right_expr()) {
-                        // The packed width may be an interface struct-parameter
-                        // expression like `s.CFG.BUS.DAT-1`; force constant folding
-                        // so the `-1` operation collapses to a constant.
-                        bool saved_fcf = force_const_fold;
-                        force_const_fold = true;
+                    // Multiply ALL packed dimensions.  Only Ranges()[0] was
+                    // consulted, so a memory whose element is a packed
+                    // MULTI-DIMENSIONAL array — `typedef logic [NDATA-1:0]
+                    // [DATA_SIZE-1:0] mem_t [DEPTH]` — got the width of the
+                    // OUTER dimension alone (NDATA, not NDATA*DATA_SIZE).  A
+                    // per-byte write into such a memory then indexes past the
+                    // word and aborts yosys outright with
+                    // "Assert `offset + length <= size()' failed" (CVA6's
+                    // behavioural byte-enable SRAM, hpdcache_sram_wbyteenable).
+                    int packed_total = 1;
+                    int outer_dim = 0;
+                    bool all_const = true;
+                    // A bound may be an interface struct-parameter expression
+                    // like `s.CFG.BUS.DAT-1`; force folding so `-1` collapses.
+                    bool saved_fcf = force_const_fold;
+                    force_const_fold = true;
+                    for (auto range : *logic_typespec->Ranges()) {
+                        if (!range->Left_expr() || !range->Right_expr()) {
+                            all_const = false;
+                            break;
+                        }
                         RTLIL::SigSpec left_spec = import_expression(range->Left_expr());
                         RTLIL::SigSpec right_spec = import_expression(range->Right_expr());
-                        force_const_fold = saved_fcf;
-                        
-                        if (left_spec.is_fully_const() && right_spec.is_fully_const()) {
-                            int left = left_spec.as_int();
-                            int right = right_spec.as_int();
-                            width = std::abs(left - right) + 1;
-
-                            if (mode_debug)
-                                log("    Packed range: [%d:%d], width=%d\n", left, right, width);
+                        if (!left_spec.is_fully_const() || !right_spec.is_fully_const()) {
+                            all_const = false;
+                            break;
                         }
+                        int left = left_spec.as_int();
+                        int right = right_spec.as_int();
+                        int dim = std::abs(left - right) + 1;
+                        if (outer_dim == 0) outer_dim = dim;   // first = outermost
+                        packed_total *= dim;
+                        if (mode_debug)
+                            log("    Packed range: [%d:%d]\n", left, right);
+                    }
+                    force_const_fold = saved_fcf;
+                    if (all_const && packed_total > 0) {
+                        width = packed_total;
+                        if (logic_typespec->Ranges()->size() > 1)
+                            packed_outer_dim = outer_dim;
+                        if (mode_debug)
+                            log("    Packed width=%d (%d dims)\n", width,
+                                (int)logic_typespec->Ranges()->size());
                     }
                 }
             }
@@ -695,8 +781,33 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
                 }
             }
         }
-        if (ats->Elem_typespec() && ats->Elem_typespec()->Actual_typespec())
-            width = get_width_from_typespec(ats->Elem_typespec()->Actual_typespec());
+        if (ats->Elem_typespec() && ats->Elem_typespec()->Actual_typespec()) {
+            // Pass the instance: the element's packed bounds are usually
+            // parameter expressions (`logic [NDATA-1:0][DATA_SIZE-1:0]`), and
+            // without a scope to resolve them against the width silently
+            // collapses to 1 — which then aborts yosys on the first per-byte
+            // write into the memory.
+            const UHDM::typespec* ets = ats->Elem_typespec()->Actual_typespec();
+            int ew = get_width_from_typespec(ets, current_instance);
+            if (ew > 0) width = ew;
+            // Same geometry note as above: if the element is itself a packed
+            // MULTI-dim array, record the outer dimension so an
+            // `mem[addr][j][sel]` write can place element j.
+            if (ets->UhdmType() == uhdmlogic_typespec) {
+                auto elt = any_cast<const UHDM::logic_typespec*>(ets);
+                if (elt->Ranges() && elt->Ranges()->size() > 1) {
+                    auto r0 = (*elt->Ranges())[0];
+                    if (r0->Left_expr() && r0->Right_expr()) {
+                        bool sv = force_const_fold; force_const_fold = true;
+                        RTLIL::SigSpec l0 = import_expression(r0->Left_expr());
+                        RTLIL::SigSpec r0s = import_expression(r0->Right_expr());
+                        force_const_fold = sv;
+                        if (l0.is_fully_const() && r0s.is_fully_const())
+                            packed_outer_dim = std::abs(l0.as_int() - r0s.as_int()) + 1;
+                    }
+                }
+            }
+        }
         if (mode_debug)
             log("    From array_typespec: width=%d, size=%d, start_offset=%d\n",
                 width, size, start_offset);
@@ -710,6 +821,13 @@ void UhdmImporter::create_memory_from_array(const array_var* uhdm_array) {
     memory->width = width;
     memory->size = size;
     memory->start_offset = start_offset;
+    // Record the OUTER packed dimension when the word is itself a packed array
+    // (`logic [NDATA-1:0][DATA_SIZE-1:0]`).  A write of the form
+    // `mem[addr][j][sel]` needs it to place element j at j*(width/NDATA);
+    // without it the element index has to be dropped, which silently writes
+    // every element at element 0's offset.
+    if (packed_outer_dim > 1)
+        memory->attributes[ID(packed_outer_dim)] = RTLIL::Const(packed_outer_dim);
 
     // Add source attribute
     add_src_attribute(memory->attributes, uhdm_array);

--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -11166,7 +11166,7 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
                     const MemoryWriteInfo& info = *infop;
                     const expr* addr_expr = nullptr;
                     int lo = 0, hi = 0;
-                    if (parse_mem_partial_select(vs, addr_expr, lo, hi)) {
+                    if (parse_mem_partial_select(vs, addr_expr, lo, hi, info.data_wire->width)) {
                         int w = hi - lo + 1;
                         RTLIL::SigSpec addr = import_expression(addr_expr);
                         if (addr.size() != info.addr_wire->width) {
@@ -13232,7 +13232,7 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                             const MemoryWriteInfo& info = *infop;
                             const expr* addr_expr = nullptr;
                             int lo = 0, hi = 0;
-                            if (parse_mem_partial_select(vs, addr_expr, lo, hi)) {
+                            if (parse_mem_partial_select(vs, addr_expr, lo, hi, info.data_wire->width)) {
                                 int w = hi - lo + 1;
                                 RTLIL::SigSpec addr = import_expression(addr_expr);
                                 if (addr.size() != info.addr_wire->width) {
@@ -13253,6 +13253,14 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                                     if (data.size() < w) data.extend_u0(w);
                                     else data = data.extract(0, w);
                                 }
+                                if (lo < 0 || w <= 0 ||
+                                    lo + w > info.data_wire->width) {
+                                    log_warning("UHDM: memory partial write "
+                                        "[%d +: %d] out of range for %d-bit word of "
+                                        "'%s' - falling back to a full-word write\n",
+                                        lo, w, info.data_wire->width,
+                                        std::string(vs->VpiName()).c_str());
+                                } else {
                                 case_rule->actions.push_back(RTLIL::SigSig(
                                     RTLIL::SigSpec(info.addr_wire), addr));
                                 case_rule->actions.push_back(RTLIL::SigSig(
@@ -13261,6 +13269,7 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                                     RTLIL::SigSpec(info.en_wire).extract(lo, w),
                                     RTLIL::SigSpec(RTLIL::State::S1, w)));
                                 return;
+                                }
                             }
                         }
                     }

--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -1399,7 +1399,8 @@ void UhdmImporter::collect_blocking_assigned_names(const any* stmt, std::set<std
 
 // Helper function to check if an assignment is a memory write
 bool UhdmImporter::parse_mem_partial_select(const UHDM::var_select* vs,
-                                            const UHDM::expr*& addr_expr, int& lo, int& hi) {
+                                            const UHDM::expr*& addr_expr, int& lo, int& hi,
+                                            int mem_word_width) {
     addr_expr = nullptr;
     const UHDM::any* sel = nullptr;
     const UHDM::expr* second = nullptr;
@@ -1425,13 +1426,38 @@ bool UhdmImporter::parse_mem_partial_select(const UHDM::var_select* vs,
         lo = hi = b.as_int();
         return true;
     }
+    // `mem[addr][j][sel]`: the memory WORD is itself a packed array and `j`
+    // picks one of its elements.  `second` holds that index; it used to be
+    // parsed and then dropped, so every element wrote at element 0's offset
+    // (CVA6's byte-enable SRAM wrote word j's bytes into word 0).  Fold it into
+    // the offset once the selector below has produced lo/hi.
+    int mid_offset = 0;
+    if (second && mem_word_width > 0) {
+        RTLIL::SigSpec m = import_expression(second);
+        if (!m.is_fully_const()) return false;   // dynamic element index: not this path
+        int outer = 0;
+        if (auto memp = module->memories.count(RTLIL::escape_id(std::string(vs->VpiName())))
+                            ? module->memories.at(RTLIL::escape_id(std::string(vs->VpiName())))
+                            : nullptr) {
+            auto it = memp->attributes.find(ID(packed_outer_dim));
+            if (it != memp->attributes.end()) outer = it->second.as_int();
+        }
+        if (outer <= 0) return false;            // unknown geometry: do not guess
+        int stride = mem_word_width / outer;
+        if (stride <= 0 || stride * outer != mem_word_width) return false;
+        mid_offset = m.as_int() * stride;
+    } else if (second) {
+        // A middle index with no word width to scale by — cannot place it.
+        return false;
+    }
+
     if (sel->VpiType() == vpiPartSelect) {
         auto ps = any_cast<const part_select*>(sel);
         RTLIL::SigSpec l = import_expression(ps->Left_range());
         RTLIL::SigSpec r = import_expression(ps->Right_range());
         if (!l.is_fully_const() || !r.is_fully_const()) return false;
-        lo = std::min(l.as_int(), r.as_int());
-        hi = std::max(l.as_int(), r.as_int());
+        lo = std::min(l.as_int(), r.as_int()) + mid_offset;
+        hi = std::max(l.as_int(), r.as_int()) + mid_offset;
         return true;
     }
     // indexed_part_select: `[base +: width]` (type 1) or `[base -: width]` (2)
@@ -1445,6 +1471,8 @@ bool UhdmImporter::parse_mem_partial_select(const UHDM::var_select* vs,
     } else {                                       // +:
         lo = b; hi = b + w - 1;
     }
+    lo += mid_offset;
+    hi += mid_offset;
     return true;
 }
 

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -970,8 +970,11 @@ struct UhdmImporter {
     // the address expression and the constant bit range [lo,hi] of its slice.
     // Handles part_select (`[hi:lo]`) and indexed_part_select (`[base+:w]` /
     // `[base-:w]`).  Returns false if there is no selector or it isn't constant.
+    // `mem_word_width` lets the parser fold a MIDDLE index (`mem[addr][j][sel]`,
+    // where the word is a packed array) into lo/hi; pass 0 when unknown.
     bool parse_mem_partial_select(const UHDM::var_select* vs,
-                                  const UHDM::expr*& addr_expr, int& lo, int& hi);
+                                  const UHDM::expr*& addr_expr, int& lo, int& hi,
+                                  int mem_word_width = 0);
     void scan_for_memory_writes(const any* stmt, std::set<std::string>& memory_names, RTLIL::Module* module);
     bool has_for_loop(const any* stmt);
     bool needs_sync_path(const any* stmt, bool inside_conditional = false);

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -118,10 +118,10 @@ hpdcache_regbank_wbyteenable_1rw       4   180   crash
 hpdcache_regbank_wmask_1rw             4   180   crash
 hpdcache_rrarb                         4   180   proven
 hpdcache_rtab                          4   180   error
-hpdcache_sram                          4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
-hpdcache_sram_1rw                      4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
-hpdcache_sram_wbyteenable              4   400   error
-hpdcache_sram_wbyteenable_1rw          4   400   error
+hpdcache_sram                          4   180   proven
+hpdcache_sram_1rw                      4   180   proven
+hpdcache_sram_wbyteenable              4   400   timeout  # now elaborates+miters (was error: 1-bit memory word); SAT budget
+hpdcache_sram_wbyteenable_1rw          4   400   timeout  # now elaborates+miters (was error: 1-bit memory word); SAT budget
 hpdcache_sram_wmask                    4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_sram_wmask_1rw                4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_sync_buffer                   4   900   proven

--- a/test/mem_packed_2d_byte_write/README.md
+++ b/test/mem_packed_2d_byte_write/README.md
@@ -1,0 +1,73 @@
+# mem_packed_2d_byte_write
+
+A memory whose element is a **packed 2-D array**, written **per byte** under two
+nested loop variables — CVA6's behavioural byte-enable SRAM
+(`hpdcache_sram_wbyteenable`):
+
+```systemverilog
+typedef logic [NDATA-1:0][DATA_SIZE-1:0] mem_t [DEPTH];
+mem_t mem;
+...
+for (int j = 0; j < NDATA; j++)
+  for (int i = 0; i < DATA_SIZE/8; i++)
+    if (wbyteenable[j][i]) mem[addr][j][i*8 +: 8] <= wdata[j][i*8 +: 8];
+```
+
+This **aborted yosys outright**:
+
+```
+ERROR: Assert `offset + length <= size()' failed in kernel/rtlil.cc:5285
+```
+
+## Three bugs, and the order matters
+
+**1. The memory word width collapsed** (`memory_analysis.cpp`).
+For `typedef logic [NDATA-1:0][DATA_SIZE-1:0] mem_t [DEPTH]` only
+`Ranges()[0]` was consulted, so the word took the **outer dimension alone** —
+the memory came out **1 bit** wide instead of `NDATA*DATA_SIZE`. Any per-byte
+write then indexed past the word and hit the assert. Two separate causes:
+all packed dimensions are now multiplied, *and* the typedef path passes
+`current_instance`, without which parameter-based bounds
+(`[NDATA-1:0]`) do not resolve and the width silently falls back to 1.
+Both `create_memory_from_array` overloads (`array_net` and `array_var`) had
+the identical defect.
+
+**2. The middle index was parsed and then dropped**
+(`process_helper.cpp`). `parse_mem_partial_select` assumed `mem[addr][sel]`.
+Given `mem[addr][j][i*8 +: 8]` it bound `j` to its `second` local and never
+used it, so **every element wrote at element 0's byte offset**. It now folds
+`j` in as `j * (word_width / NDATA)`, using the outer dimension recorded on
+the memory at creation, and returns false rather than guessing when that
+geometry is unknown or the index is dynamic.
+
+**3. `import_bit_select` had no `vpiIndexedPartSelect` case**
+(`expression.cpp`). In the var_select dispatch, `wdata[j][i*8 +: 8]` fell
+through to the generic branch, which re-imports the selector against the
+**full base** wire instead of the element.
+
+## Why fixing only the crash would have been worse
+
+After bug 1 alone the design read cleanly — no assert, no warning — but the
+slang miter still reported **FAIL**: a hard error had become a *silent wrong
+answer*, every word's bytes landing in word 0. Bug 2 is what makes it correct.
+Do not treat "it no longer crashes" as done here.
+
+## Checking
+
+`read_verilog` cannot parse this shape, so this is a **slang-miter-only** test.
+Note it needs a **sequential** miter, unlike the other type-parameter tests:
+the design is clocked and contains a memory, so `test_slang_equiv.ys` runs
+`memory` (satgen has no `$memwr_v2`/`$memrd` model) and `async2sync` before
+`sat -prove-asserts -seq 4 -set-init-zero`.
+
+## CVA6 effect
+
+| module | before | after |
+|---|---|---|
+| `hpdcache_sram` | cex | **proven** |
+| `hpdcache_sram_1rw` | cex | **proven** |
+| `hpdcache_sram_wbyteenable` | error (abort) | elaborates + miters; SAT budget |
+| `hpdcache_sram_wbyteenable_1rw` | error (abort) | elaborates + miters; SAT budget |
+
+The two `wbyteenable` modules remain `timeout` at 1800 s — a SAT capacity
+limit, not a frontend defect.

--- a/test/mem_packed_2d_byte_write/dut.sv
+++ b/test/mem_packed_2d_byte_write/dut.sv
@@ -1,0 +1,34 @@
+// CVA6 behavioural byte-enable SRAM: a MEMORY whose element is a packed 2-D
+// array, written per byte under two nested loop variables.
+//     typedef logic [NDATA-1:0][DATA_SIZE-1:0] mem_t [DEPTH];
+//     for (int j...) for (int i...)
+//        if (wbyteenable[j][i]) mem[addr][j][i*8 +: 8] <= wdata[j][i*8 +: 8];
+module dut #(
+    parameter int unsigned DATA_SIZE = 64,
+    parameter int unsigned DEPTH     = 4,
+    parameter int unsigned NDATA     = 2
+) (
+    input  logic                              clk,
+    input  logic                              cs,
+    input  logic                              we,
+    input  logic [1:0]                        addr,
+    input  logic [NDATA-1:0][DATA_SIZE-1:0]   wdata,
+    input  logic [NDATA-1:0][DATA_SIZE/8-1:0] wbyteenable,
+    output logic [NDATA-1:0][DATA_SIZE-1:0]   rdata
+);
+  typedef logic [NDATA-1:0][DATA_SIZE-1:0] mem_t [DEPTH];
+  mem_t mem;
+
+  always_ff @(posedge clk) begin
+    if (cs) begin
+      if (we) begin
+        for (int j = 0; j < NDATA; j++) begin
+          for (int i = 0; i < DATA_SIZE/8; i++) begin
+            if (wbyteenable[j][i]) mem[addr][j][i*8 +: 8] <= wdata[j][i*8 +: 8];
+          end
+        end
+      end
+      rdata <= mem[addr];
+    end
+  end
+endmodule

--- a/test/mem_packed_2d_byte_write/test_slang_equiv.ys
+++ b/test/mem_packed_2d_byte_write/test_slang_equiv.ys
@@ -1,0 +1,26 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the CVA6-realistic
+# shape here (a memory whose element is a packed 2-D array, written per byte
+# under two loop variables), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+#
+# This design is CLOCKED and contains a memory, so the miter is SEQUENTIAL:
+# `memory` lowers $memwr_v2/$memrd (satgen has no model for them) and
+# async2sync makes the flops SAT-modellable, then the proof runs over N cycles
+# from a zero-initialised state — the same recipe test/cva6_equiv uses.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; memory; opt -fast; async2sync
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; memory; opt -fast; async2sync
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_assert gold gate miter
+hierarchy -top miter
+sat -verify -prove-asserts -seq 4 -set-init-zero miter


### PR DESCRIPTION
`typedef logic [NDATA-1:0][DATA_SIZE-1:0] mem_t [DEPTH]`, written per byte under two nested loops, **aborted yosys**:

```
ERROR: Assert `offset + length <= size()' failed in kernel/rtlil.cc:5285
```

That is CVA6's behavioural byte-enable SRAM. **Three bugs, and the order matters.**

### 1. The memory word width collapsed — `memory_analysis.cpp`

Only `Ranges()[0]` was consulted, so the word took the **outer packed dimension alone** — **1 bit** instead of `NDATA*DATA_SIZE`. Two causes: all packed dimensions are now multiplied, **and** the typedef path passes `current_instance`, without which parameter-based bounds (`[NDATA-1:0]`) don't resolve and the width silently falls back to 1. Both `create_memory_from_array` overloads (`array_net`, `array_var`) had it.

### 2. The middle index was parsed and then dropped — `process_helper.cpp`

`parse_mem_partial_select` assumed `mem[addr][sel]`. Given `mem[addr][j][i*8 +: 8]` it bound `j` to a local and **never used it**, so *every* element wrote at element 0's byte offset. It now folds `j` in as `j * (word_width / NDATA)` using the outer dimension recorded on the memory at creation, and **refuses rather than guesses** when the geometry is unknown or the index is dynamic.

### 3. `import_bit_select` had no `vpiIndexedPartSelect` case — `expression.cpp`

In the var_select dispatch, `wdata[j][i*8 +: 8]` fell through to the generic branch, which re-imports the selector against the **full base** wire instead of the element.

### ⚠️ Fixing only the crash would have been worse

After bug 1 alone the design read cleanly — no assert, no warning — but the slang miter still reported **FAIL**. A hard error had become a **silent wrong answer**, every word's bytes landing in word 0. Bug 2 is what makes it correct. The repro README states this so "it no longer crashes" isn't mistaken for done.

Also adds a bounds guard on the partial-write extract: an out-of-range slice now warns and falls back instead of aborting the run.

### Test

`test/mem_packed_2d_byte_write`. Note it needs a **sequential** miter (`memory` + `async2sync` + `sat -prove-asserts -seq`), unlike the combinational template the type-parameter tests use — the design is clocked and satgen has no `$memwr_v2`/`$memrd` model.

### CVA6

| module | before | after |
|---|---|---|
| `hpdcache_sram` | cex | **proven** |
| `hpdcache_sram_1rw` | cex | **proven** |
| `hpdcache_sram_wbyteenable` | error (abort) | timeout — elaborates + miters |
| `hpdcache_sram_wbyteenable_1rw` | error (abort) | timeout — elaborates + miters |

**65 proven / 38 cex / 8 error**, from 63/40/10. The two `wbyteenable` timeouts are SAT capacity at 1800 s, not a frontend defect.

### Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter **40/41** (`arb_idx_cast` the only known-fail), 0 true failures, 0 crashes.
- No Surelog change this round, so that gate doesn't apply.

**One NEW co-sim warning, `rp32_r5p_csr` — verified pre-existing, not from this change.** With these edits stashed and the frontend rebuilt, Verilator fails to build that netlist *identically*: same file, same line, same 104256-bit literal exceeding its width limit. I deliberately did **not** add it to `sim_equiv_warn_baseline.txt` — that file is shrink-only and shouldn't be grown to silence a signal. Flagging it for your call instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)