### PR TITLE
uhdm: two crash guards — null module and reference cycles (crash bucket 19 → 0)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -5571,6 +5571,26 @@ RTLIL::Wire* UhdmImporter::find_wire_in_scope(const std::string& signal_name, co
 
 // Import reference to object
 RTLIL::SigSpec UhdmImporter::import_ref_obj(const ref_obj* uhdm_ref, const UHDM::scope* inst, const std::map<std::string, RTLIL::SigSpec>* input_mapping) {
+    // Break reference CYCLES.  A parameter whose value resolves back to itself
+    // (directly, or around a chain of parameters) recursed through
+    // import_expression until the stack was exhausted: CVA6's fpnew_top died
+    // with SIGSEGV about 53,000 frames deep, reported only as an opaque
+    // "crash".  Guard on the OBJECT, not a depth counter, so genuinely deep
+    // (but finite) parameter chains still resolve.
+    struct CycleGuard {
+        std::set<const UHDM::any*>& set_;
+        const UHDM::any* key_;
+        bool inserted_;
+        CycleGuard(std::set<const UHDM::any*>& s, const UHDM::any* k)
+            : set_(s), key_(k), inserted_(s.insert(k).second) {}
+        ~CycleGuard() { if (inserted_) set_.erase(key_); }
+    } _cycle_guard(ref_obj_in_progress, uhdm_ref);
+    if (!_cycle_guard.inserted_) {
+        log_warning("UHDM: cyclic reference through '%s' — returning empty "
+                    "instead of recursing\n",
+                    std::string(uhdm_ref->VpiName()).c_str());
+        return RTLIL::SigSpec();
+    }
     // Get the referenced object name
     std::string ref_name = std::string(uhdm_ref->VpiName());
     

--- a/src/frontends/uhdm/uhdm2rtlil.cpp
+++ b/src/frontends/uhdm/uhdm2rtlil.cpp
@@ -1689,6 +1689,14 @@ int UhdmImporter::width_from_def_var(const std::string& def_name,
 // is a parameter present in the current RTLIL module's parameter_default_values.
 bool UhdmImporter::expr_uses_resolved_param(const any* e) {
     if (!e) return false;
+    // No RTLIL module yet: type_param_signature() probes port widths BEFORE
+    // import_module creates `module`, and this function dereferences it for
+    // parameter_default_values — a null deref that SEGFAULTED read_uhdm on
+    // most of the CVA6 cache subsystem (hpdcache, hpdcache_ctrl, std_nbdcache,
+    // …).  Same contract as the null-module guards in import_operation and
+    // import_hier_path: with no module there are no resolved parameters to
+    // find, so the answer is simply "no".
+    if (!module) return false;
     if (e->UhdmType() == uhdmref_obj) {
         std::string n = std::string(any_cast<const ref_obj*>(e)->VpiName());
         return !n.empty() &&

--- a/src/frontends/uhdm/uhdm2rtlil.h
+++ b/src/frontends/uhdm/uhdm2rtlil.h
@@ -686,6 +686,11 @@ struct UhdmImporter {
     // name is a parameter present in the current RTLIL module's
     // parameter_default_values — i.e. a width we have actually resolved.
     bool expr_uses_resolved_param(const UHDM::any* e);
+    // ref_obj resolutions currently on the stack.  A parameter whose value
+    // resolves back to itself (directly or through a chain) otherwise recurses
+    // until the process dies of stack exhaustion — CVA6 fpnew_top segfaulted
+    // at ~53k frames of import_ref_obj/import_expression.
+    std::set<const UHDM::any*> ref_obj_in_progress;
 
     // Package support
     void import_package(const UHDM::package* uhdm_package);

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -35,7 +35,7 @@ alu_wrapper                            4   900   proven
 amo_alu                                4   180   error
 amo_buffer                             4   900   proven
 ariane_regfile_fpga                    4   400   elabfail  # slang gap: $random init (Verilator accepts); FPGA variant, not in the shipped config
-axi_adapter                            4   180   crash
+axi_adapter                            4   180   proven
 axi_shim                               4   400   proven
 bht                                    4   900   proven
 bht2lvl                                4   180   cex
@@ -53,9 +53,9 @@ csr_regfile                            4   180   cex
 cva6                                   4   180   timeout
 cva6_fifo_v3                           4   900   proven
 cva6_hpdcache_if_adapter               4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
-cva6_hpdcache_subsystem                4   180   crash
-cva6_hpdcache_subsystem_axi_arbiter    4   180   crash
-cva6_hpdcache_wrapper                  4   180   crash
+cva6_hpdcache_subsystem                4   180   error    # was crash (segfault); now Async reset yields non-constant value
+cva6_hpdcache_subsystem_axi_arbiter    4   180   cex      # cex now measurable (was crash: null-module segfault) - TRIAGE
+cva6_hpdcache_wrapper                  4   180   error    # was crash (segfault); now chunk offset assert
 cva6_icache                            4   900   proven
 cva6_icache_axi_wrapper                4   400   cex      # cex now measurable (was error: 1-bit chained-type-param port) - TRIAGE
 cva6_mmu                               4   180   proven
@@ -82,39 +82,39 @@ fpnew_opgroup_block                    4   180   cex
 fpnew_opgroup_fmt_slice                4   180   cex
 fpnew_opgroup_multifmt_slice           4   180   timeout
 fpnew_rounding                         4   900   proven
-fpnew_top                              4   180   crash
+fpnew_top                              4   180   error    # was crash (segfault); now read_slang "Feature unimplemented"
 fpu_wrap                               4   180   cex
 frontend                               4   180   cex
-hpdcache                               4   180   crash
-hpdcache_1hot_to_binary                4   180   crash
+hpdcache                               4   180   error    # was crash (segfault); now Async reset yields non-constant value
+hpdcache_1hot_to_binary                4   180   proven
 hpdcache_amo                           4   900   proven
 hpdcache_cbuf                          4   180   proven
 hpdcache_cmo                           4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_core_arbiter                  4   180   cex      # cex now measurable (was error) - TRIAGE
-hpdcache_ctrl                          4   180   crash
+hpdcache_ctrl                          4   180   timeout  # was crash (segfault); now timeout
 hpdcache_ctrl_pe                       4   180   cex
 hpdcache_data_downsize                 4   400   elabfail  # dead at this config: accessWidth == memDataWidth, so hpdcache_data_resize instantiates neither resizer (both binding directions hit its own $fatal)
 hpdcache_data_resize                   4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_data_upsize                   4   180   cex      # cex now measurable (was crash) - TRIAGE
-hpdcache_decoder                       4   180   crash
+hpdcache_decoder                       4   180   proven
 hpdcache_demux                         4   180   proven
 hpdcache_fifo_reg                      4   900   proven
 hpdcache_fifo_reg_initialized          4   180   cex
-hpdcache_flush                         4   180   crash
+hpdcache_flush                         4   180   cex      # cex now measurable (was crash: null-module segfault) - TRIAGE
 hpdcache_fxarb                         4   180   proven
 hpdcache_lfsr                          4   900   proven
-hpdcache_mem_req_read_arbiter          4   180   crash
+hpdcache_mem_req_read_arbiter          4   180   proven
 hpdcache_mem_req_write_arbiter         4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_mem_resp_demux                4   180   proven
 hpdcache_mem_to_axi_read               4   400   proven
 hpdcache_mem_to_axi_write              4   400   proven
 hpdcache_memctrl                       4   180   timeout
-hpdcache_miss_handler                  4   180   crash
+hpdcache_miss_handler                  4   180   elabfail  # was crash (segfault); now elabfail
 hpdcache_mshr                          4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_mux                           4   180   proven
 hpdcache_prio_1hot_encoder             4   180   proven
 hpdcache_prio_bin_encoder              4   180   proven
-hpdcache_regbank_wbyteenable_1rw       4   180   crash
+hpdcache_regbank_wbyteenable_1rw       4   180   elabfail  # was crash (segfault); now elabfail
 hpdcache_regbank_wmask_1rw             4   180   cex      # cex now measurable (was crash) - TRIAGE
 hpdcache_rrarb                         4   180   proven
 hpdcache_rtab                          4   180   cex      # cex now measurable (was error: rtab_entry_t defaulted to logic) - TRIAGE
@@ -127,9 +127,9 @@ hpdcache_sram_wmask_1rw                4   180   proven
 hpdcache_sync_buffer                   4   900   proven
 hpdcache_uncached                      4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
 hpdcache_victim_plru                   4   180   cex      # cex now measurable (was error: zero-width [-1:0] ports) - TRIAGE
-hpdcache_victim_random                 4   180   crash
+hpdcache_victim_random                 4   180   proven
 hpdcache_victim_sel                    4   180   cex      # cex now measurable (was error: type-param width) - TRIAGE
-hpdcache_wbuf                          4   180   crash
+hpdcache_wbuf                          4   180   elabfail  # was crash (segfault); now elabfail
 hwpf_stride                            4   400   proven
 hwpf_stride_arb                        4   400   proven
 hwpf_stride_wrapper                    4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
@@ -145,7 +145,7 @@ load_store_unit                        4   180   cex
 load_unit                              4   900   proven
 lsu_bypass                             4   900   proven
 macro_decoder                          4   180   cex
-miss_handler                           4   180   crash
+miss_handler                           4   180   cex      # cex now measurable (was crash: null-module segfault) - TRIAGE
 mult                                   4   180   timeout
 multiplier                             4   180   timeout
 norm_div_sqrt_mvp                      4   900   proven
@@ -160,8 +160,8 @@ ras                                    4   900   proven
 raw_checker                            4   900   proven
 scoreboard                             4   180   error
 serdiv                                 4   180   timeout
-std_cache_subsystem                    4   180   crash
-std_nbdcache                           4   180   crash
+std_cache_subsystem                    4   180   timeout  # was crash (segfault); now timeout
+std_nbdcache                           4   180   cex      # cex now measurable (was crash: null-module segfault) - TRIAGE
 store_buffer                           4   900   proven
 store_unit                             4   900   proven
 tag_cmp                                4   400   cex
@@ -169,7 +169,7 @@ trigger_module                         4   900   proven
 wt_axi_adapter                         4   400   cex      # cex now measurable (was error: 1-bit chained-type-param port) - TRIAGE
 wt_cache_subsystem                     4   180   timeout
 wt_dcache                              4   180   timeout
-wt_dcache_ctrl                         4   180   crash
+wt_dcache_ctrl                         4   180   cex      # cex now measurable (was crash: null-module segfault) - TRIAGE
 wt_dcache_mem                          4   180   cex      # UHDM WRONG (adjudicated): wr_ack_o rtl=0 uhdm=1 slang=0, seeds 1/2/3
 wt_dcache_missunit                     4   400   cex      # UHDM WRONG (adjudicated): c524 wr_cl_vld_o rtl=1 uhdm=0 slang=1
 wt_dcache_wbuffer                      4   180   cex      # UHDM WRONG (adjudicated): c1 every output slang==rtl, uhdm=0


### PR DESCRIPTION
Every one of the 19 CVA6 modules recorded as `crash` improved; **the bucket is now empty**. Both defects hid behind that one opaque label, and they were different things — a null dereference and a stack overflow.

### 1. Null-module deref — `uhdm2rtlil.cpp`, `expr_uses_resolved_param`

It reads `module->parameter_default_values`, but its caller `type_param_signature()` probes port widths **before** `import_module` creates `module` — so `read_uhdm` **segfaulted** on most of the cache subsystem.

This is the same contract the guards in `import_operation` and `import_hier_path` already document ("width probing runs before the module exists"); this function was simply missed. With no module there are no resolved parameters, so the answer is `false`.

### 2. Reference cycle → stack overflow — `expression.cpp`, `import_ref_obj`

A parameter whose value resolves back to itself recursed through `import_expression` until the process died: gdb showed **53,338 frames** on `fpnew_top`.

Guarded on **object identity, not a depth counter**. A depth cap would silently truncate the legitimately deep parameter chains fpnew is full of; this only trips on a real cycle, and it *warns* rather than failing quietly. `fpnew_top` now reads with exactly **one** such warning — one genuine cycle.

### Results (all 19, re-swept with fresh elaboration)

| outcome | modules |
|---|---|
| **5 newly PROVEN** | `axi_adapter`, `hpdcache_1hot_to_binary`, `hpdcache_decoder`, `hpdcache_mem_req_read_arbiter`, `hpdcache_victim_random` |
| **5 → cex** | `cva6_hpdcache_subsystem_axi_arbiter`, `hpdcache_flush`, `wt_dcache_ctrl`, `miss_handler`, `std_nbdcache` |
| **4 → error** | with *specific* signatures instead of a segfault |
| **5 → elabfail/timeout** | measurable states |

The four errors are no longer mysterious: `hpdcache` + `cva6_hpdcache_subsystem` both report "Async reset yields non-constant value" (likely one shared cause), `cva6_hpdcache_wrapper` a chunk-offset assert, and `fpnew_top` now fails on the **reference** side (`read_slang` "Feature unimplemented"), not ours. Each is recorded in the manifest with its new signature so the next round starts from a diagnosis rather than re-deriving one.

**73 proven / 45 cex / 9 error / 0 crash / 14 timeout / 6 elabfail.**

### Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter **41/42** (`arb_idx_cast` the only known-fail), 0 true failures, 0 crashes, 0 new sim-equiv warnings. This gate is doing real work here: the cycle guard sits in `import_ref_obj`, one of the hottest paths in the frontend.
- No Surelog change this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)