### PR TITLE
uhdm: trailing bit range on an array element of a struct member

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -11550,13 +11550,63 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
             if (ts) {
                 // Calculate bit offset for struct member access
                 std::string remaining_path = path_name.substr(struct_name.length() + 1);
+                // A trailing bit range on the member — `rsp.rdata[0][32 +: 32]`
+                // (CVA6 cva6_hpdcache_if_adapter's AMO response) — was left in
+                // the member NAME.  calculate_struct_member_offset then
+                // resolved `rdata[0]` and returned that element's FULL width,
+                // so the range was dropped and the resulting chunk ran past the
+                // end of the struct wire, aborting yosys with
+                // "Assert `chunk_.offset + chunk_.width <= chunk_.wire->width'".
+                // Split the range off, resolve the member without it, then
+                // apply it to the member's slice.
+                int sub_lsb = 0, sub_width = 0;
+                bool have_sub = false;
+                {
+                    size_t ob = remaining_path.find_last_of('[');
+                    if (ob != std::string::npos &&
+                        remaining_path.back() == ']') {
+                        std::string sel = remaining_path.substr(
+                            ob + 1, remaining_path.size() - ob - 2);
+                        int a = 0, b = 0;
+                        if (sscanf(sel.c_str(), "%d+:%d", &a, &b) == 2) {
+                            sub_lsb = a; sub_width = b; have_sub = true;
+                        } else if (sscanf(sel.c_str(), "%d-:%d", &a, &b) == 2) {
+                            sub_width = b; sub_lsb = a - b + 1; have_sub = true;
+                        } else if (sscanf(sel.c_str(), "%d:%d", &a, &b) == 2) {
+                            sub_lsb = std::min(a, b);
+                            sub_width = std::abs(a - b) + 1;
+                            have_sub = true;
+                        }
+                        if (have_sub)
+                            remaining_path = remaining_path.substr(0, ob);
+                    }
+                }
                 int bit_offset = 0;
                 int member_width = 0;
                 if (calculate_struct_member_offset(ts, remaining_path, inst, bit_offset, member_width)) {
+                    if (have_sub) {
+                        if (sub_lsb < 0 || sub_width <= 0 ||
+                            sub_lsb + sub_width > member_width) {
+                            log_warning("UHDM: range [%d +: %d] out of range for "
+                                        "%d-bit member '%s'\n",
+                                        sub_lsb, sub_width, member_width,
+                                        remaining_path.c_str());
+                            have_sub = false;
+                        } else {
+                            bit_offset += sub_lsb;
+                            member_width = sub_width;
+                        }
+                    }
                     if (mode_debug)
                         log("    Calculated struct member '%s' offset=%d, width=%d\n",
                             path_name.c_str(), bit_offset, member_width);
-                    return RTLIL::SigSpec(struct_wire, bit_offset, member_width);
+                    if (bit_offset >= 0 && member_width > 0 &&
+                        bit_offset + member_width <= struct_wire->width)
+                        return RTLIL::SigSpec(struct_wire, bit_offset, member_width);
+                    log_warning("UHDM: struct member '%s' slice [%d +: %d] exceeds "
+                                "the %d-bit wire — leaving unresolved\n",
+                                path_name.c_str(), bit_offset, member_width,
+                                struct_wire->width);
                 }
             }
         }

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -53,9 +53,9 @@ csr_regfile                            4   180   cex
 cva6                                   4   180   timeout
 cva6_fifo_v3                           4   900   proven
 cva6_hpdcache_if_adapter               4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
-cva6_hpdcache_subsystem                4   180   error    # was crash (segfault); now Async reset yields non-constant value
+cva6_hpdcache_subsystem                4   180   error  # chunk-offset assert FIXED; now blocked on the async-reset (evalFunc struct_var) issue
 cva6_hpdcache_subsystem_axi_arbiter    4   180   cex      # cex now measurable (was crash: null-module segfault) - TRIAGE
-cva6_hpdcache_wrapper                  4   180   error    # was crash (segfault); now chunk offset assert
+cva6_hpdcache_wrapper                  4   180   error  # chunk-offset assert FIXED; now blocked on the async-reset (evalFunc struct_var) issue
 cva6_icache                            4   900   proven
 cva6_icache_axi_wrapper                4   400   cex      # cex now measurable (was error: 1-bit chained-type-param port) - TRIAGE
 cva6_mmu                               4   180   proven

--- a/test/struct_array_member_partsel/README.md
+++ b/test/struct_array_member_partsel/README.md
@@ -1,0 +1,60 @@
+# struct_array_member_partsel
+
+A trailing bit range applied to an **array element of a struct member**:
+
+```systemverilog
+assign hi_o = rsp_i.rdata[0][32 +: 32];   // rdata is logic [1:0][63:0]
+```
+
+This is CVA6 `cva6_hpdcache_if_adapter`'s AMO response forwarding
+(`hpdcache_rsp_i.rdata[0][32 +: 32]`), and it **aborted yosys**:
+
+```
+ERROR: Assert `chunk_.offset + chunk_.width <= chunk_.wire->width' failed
+```
+
+## Cause
+
+`import_hier_path` splits a struct access into a base and a member path, then
+asks `calculate_struct_member_offset` for the member's bit offset and width.
+The trailing range was left inside the member NAME:
+
+```
+Detected struct member access: base='hpdcache_rsp_i', member='rdata[0][32+:32]'
+Calculated struct member '…rdata[0][32+:32]' offset=2054, width=64
+```
+
+The resolver matched `rdata[0]` and returned that element's **full 64-bit**
+width — the `[32 +: 32]` was silently dropped. The resulting 64-bit chunk at
+that offset ran past the end of the struct wire, and yosys aborted.
+
+## Fix
+
+Split the trailing range off the member path, resolve the member without it,
+then apply the range to the member's slice (`offset += lsb; width = w`).
+Handles `[a +: w]`, `[a -: w]` and `[hi:lo]`.
+
+A bounds guard was added alongside: a slice that still exceeds the wire now
+**warns and leaves the path unresolved** instead of aborting the whole run. An
+abort gives no diagnosis and takes the rest of the design with it.
+
+## Checking
+
+`read_verilog` cannot parse this package/struct shape, so this is a
+**slang-miter-only** test. The miter PROVES it, so the slice lands on the same
+bits slang selects — not merely "no longer crashes". Coverage:
+
+| expression | checks |
+|---|---|
+| `rdata[0][32 +: 32]` | the failing case — upper half of element 0 |
+| `rdata[0][0 +: 32]`  | lower half, same element |
+| `rdata[1][32 +: 32]` | a non-zero element index |
+| `rdata[0]`           | whole element, control (no trailing range) |
+
+## CVA6
+
+`cva6_hpdcache_wrapper` and `cva6_hpdcache_subsystem` get past this abort and
+now stop at the **async-reset** error instead — a separate, documented issue
+(`evalFunc` returns a value-less `struct_var` for a function that builds its
+result by assigning members). This fix removed a blocker in front of that one;
+it does not resolve it, and both modules remain `error`.

--- a/test/struct_array_member_partsel/dut.sv
+++ b/test/struct_array_member_partsel/dut.sv
@@ -1,0 +1,28 @@
+// A trailing bit range on an ARRAY ELEMENT of a struct member:
+//     hpdcache_rsp_i.rdata[0][32 +: 32]
+// (CVA6 cva6_hpdcache_if_adapter's AMO response forwarding).
+//
+// The range was left inside the member NAME, so the member resolver returned
+// the element's FULL width and the range was dropped — the resulting chunk ran
+// past the end of the struct wire and aborted yosys outright:
+//     Assert `chunk_.offset + chunk_.width <= chunk_.wire->width' failed
+package pk;
+  typedef struct packed {
+    logic [1:0]        tag;
+    logic [1:0][63:0]  rdata;    // array member, 64-bit elements
+    logic              err;
+  } rsp_t;
+endpackage
+
+module dut (
+    input  pk::rsp_t   rsp_i,
+    output logic [31:0] hi_o,
+    output logic [31:0] lo_o,
+    output logic [63:0] whole_o,
+    output logic [31:0] elem1_hi_o
+);
+  assign hi_o       = rsp_i.rdata[0][32 +: 32];   // upper half of element 0
+  assign lo_o       = rsp_i.rdata[0][0  +: 32];   // lower half of element 0
+  assign whole_o    = rsp_i.rdata[0];             // whole element (control)
+  assign elem1_hi_o = rsp_i.rdata[1][32 +: 32];   // upper half of element 1
+endmodule

--- a/test/struct_array_member_partsel/test_slang_equiv.ys
+++ b/test/struct_array_member_partsel/test_slang_equiv.ys
@@ -1,0 +1,26 @@
+# UHDM-vs-slang miter for dut.  read_verilog cannot parse the CVA6-realistic
+# shape here (a memory whose element is a packed 2-D array, written per byte
+# under two loop variables), so the golden reference is the built-in read_slang
+# frontend — the same reference used for CVA6 latch parity.
+#
+# This design is CLOCKED and contains a memory, so the miter is SEQUENTIAL:
+# `memory` lowers $memwr_v2/$memrd (satgen has no model for them) and
+# async2sync makes the flops SAT-modellable, then the proof runs over N cycles
+# from a zero-initialised state — the same recipe test/cva6_equiv uses.
+read_uhdm slpp_all/surelog.uhdm
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gold
+design -stash gold
+
+read_slang dut.sv --top dut
+hierarchy -check -top dut
+flatten; proc; opt -fast
+rename dut gate
+design -stash gate
+
+design -copy-from gold -as gold gold
+design -copy-from gate -as gate gate
+miter -equiv -flatten -make_outputs gold gate miter
+
+sat -verify -prove trigger 0 -show-inputs -show-outputs miter


### PR DESCRIPTION
`rsp.rdata[0][32 +: 32]` **aborted yosys**:

```
ERROR: Assert `chunk_.offset + chunk_.width <= chunk_.wire->width' failed
```

### Cause

`import_hier_path` splits a struct access into a base and a member path, then asks `calculate_struct_member_offset` for the member's offset and width. The trailing range was left inside the member **name**:

```
Detected struct member access: base='hpdcache_rsp_i', member='rdata[0][32+:32]'
Calculated struct member '…rdata[0][32+:32]' offset=2054, width=64
```

So the resolver matched `rdata[0]`, returned that element's **full 64-bit** width, and the `[32 +: 32]` was silently dropped. The resulting 64-bit chunk at that offset ran past the end of the struct wire.

### Fix

Split the range off, resolve the member without it, then apply it to the member's slice. Handles `[a +: w]`, `[a -: w]` and `[hi:lo]`.

Also adds a **bounds guard**: a slice that still exceeds the wire now warns and leaves the path unresolved instead of aborting. An abort gives no diagnosis and takes the rest of the design down with it — this class of failure appears in the manifest as an opaque `error`.

### Test

`test/struct_array_member_partsel` — slang-miter **PROVEN**, so the slice lands on the bits slang selects rather than merely not crashing:

| expression | checks |
|---|---|
| `rdata[0][32 +: 32]` | the failing case |
| `rdata[0][0 +: 32]` | lower half, same element |
| `rdata[1][32 +: 32]` | non-zero element index |
| `rdata[0]` | whole element, control |

### CVA6

`cva6_hpdcache_wrapper` and `cva6_hpdcache_subsystem` now get **past** this abort and stop at the async-reset error instead — a separate, documented issue (`evalFunc` returns a value-less `struct_var` for a function that builds its result by assigning members). This removed a blocker sitting in front of that one; it does **not** resolve it, and both modules stay `error`. Annotated in the manifest so the next round starts from the right cause.

### Gates

- **Internal suite PASSED** — Miter-Formal 0, Slang-Miter **42/43** (`arb_idx_cast` the only known-fail), 0 true failures, 0 crashes, 0 new sim-equiv warnings.
- No Surelog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)