### PR TITLE
docs: CLAUDE.md yosys section — v0.68 + fork patch (was stale at v0.67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a Yosys frontend that converts SystemVerilog to RTLIL (Register Transfer Level Intermediate Language) via UHDM (Universal Hardware Data Model). The workflow is: SystemVerilog → Surelog → UHDM → UHDM Frontend → RTLIL → Yosys synthesis.
 
-The Yosys submodule is pinned at **upstream YosysHQ tag v0.67**
-(`third_party/yosys`; the old `write_verilog signed` fork patch is now upstream,
-so no fork is needed). v0.67 requires **C++20** (kernel/yosys_common.h
-hard-errors otherwise), so the plugin's `CMAKE_CXX_STANDARD` is 20.
+The Yosys submodule is pinned at **YosysHQ tag v0.68 + one fork patch**
+(`third_party/yosys`, tracking alainmarcel/yosys branch
+`v0.68-proc-dlatch-memo`): the proc_dlatch memoization of the
+find_mux_feedback/find_mux_constant DAG walks, which are exponential on
+shared mux subtrees without it (CVA6 cva6_tlb).  The patch is not yet
+upstreamed — when YosysHQ merges it, repoint `.gitmodules` to
+https://github.com/YosysHQ/yosys.git.  v0.68 requires **C++20**
+(kernel/yosys_common.h hard-errors otherwise), so the plugin's
+`CMAKE_CXX_STANDARD` is 20.  (v0.68 is the latest stable release as of
+2026-08-24; Yosys has no "stable" branch — releases are tags.)
 
-**v0.67 is CMake-only** — the top-level Makefile is gone.  Our CMakeLists builds
+**v0.68 is CMake-only** — the top-level Makefile is gone.  Our CMakeLists builds
 Yosys via `cmake -B third_party/yosys/build … && cmake --build … && cmake
 --install` (was `make CONFIG=gcc PREFIX=… install`), installing the yosys binary
 + yosys-config into `out/current/`.  The build passes


### PR DESCRIPTION
Audit result of "update yosys to latest stable": **no version update is needed** — the submodule already tracks the latest stable.

- Latest upstream stable: tag **v0.68** (released 2026-08-05); verified via `git ls-remote` that nothing newer exists and that YosysHQ has no "stable"/release branch (releases are tags).
- Our submodule: exactly **v0.68 + the proc_dlatch memoization patch** (`bbc149ed5`, fork branch `alainmarcel/yosys:v0.68-proc-dlatch-memo`, pushed and matching the recorded pointer).
- The memoization is **still not upstreamed** (checked upstream main's `passes/proc/proc_dlatch.cc`), so the fork remains required.

Only the documentation was stale — CLAUDE.md still described a plain v0.67 pin. This PR updates that section; no code or submodule pointer changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)