### PR TITLE
uhdm: decl-init LHS fix — the code #644 described but did not contain

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -13654,6 +13654,23 @@ void UhdmImporter::import_statement_comb(const any* uhdm_stmt, RTLIL::CaseRule* 
                             comb_lhs_keep_base = (lhs_map_ != nullptr);
                             RTLIL::SigSpec lhs_sig = import_expression(lhs, lhs_map_);
                             comb_lhs_keep_base = false;
+                            // Declaration initializer (`automatic logic [3:0]
+                            // index = addr - BASE;` in a case arm): the Lhs is
+                            // the VARIABLE object itself, which
+                            // import_expression rejects — resolve it by NAME to
+                            // the block-local wire.  Without this the init was
+                            // silently dropped and every read of the local saw
+                            // x (csr_regfile's pmpcfg decode never raised its
+                            // odd-index exception).
+                            if (lhs_sig.empty() && lhs->VpiType() != vpiRefObj) {
+                                std::string vn = std::string(lhs->VpiName());
+                                if (!vn.empty()) {
+                                    RTLIL::Wire* vw = name_map.count(vn)
+                                        ? name_map[vn]
+                                        : module->wire(RTLIL::escape_id(vn));
+                                    if (vw) lhs_sig = RTLIL::SigSpec(vw);
+                                }
+                            }
                             // Propagate LHS width as context so arithmetic ops
                             // widen to it (SV context-determined sizing).
                             int prev_ctx = expression_context_width;


### PR DESCRIPTION
My mistake in #644: the commit message and the merged test artifacts describe the declaration-initializer LHS fix, but I staged `expression.cpp` (which had no changes) instead of `process.cpp` — the actual 17-line fix never shipped. Without it, `test/case_auto_local_sub`'s committed goldens (generated with the fix) fail the suite, and csr_regfile's pmpcfg co-sim regresses to 4/2000.

This PR is exactly that fix. Please merge promptly to make main consistent with its own test expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)