### PR TITLE
uhdm: element-field pattern type + in-flight comb operand reads (CVA6 id_stage PROVEN)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -4438,7 +4438,41 @@ static const UHDM::typespec* assignment_lhs_typespec(const UHDM::operation* uhdm
     else if (auto sn = dynamic_cast<const UHDM::struct_net*>(lhs)) rt = sn->Typespec();
     else if (auto lv = dynamic_cast<const UHDM::logic_var*>(lhs)) rt = lv->Typespec();
     else if (auto ln = dynamic_cast<const UHDM::logic_net*>(lhs)) rt = ln->Typespec();
+    else if (auto pav = dynamic_cast<const UHDM::packed_array_var*>(lhs)) {
+        if (pav->Elements() && !pav->Elements()->empty())
+            if (auto e0 = dynamic_cast<const UHDM::expr*>((*pav->Elements())[0]))
+                rt = e0->Typespec();
+    }
     return rt ? rt->Actual_typespec() : nullptr;
+}
+
+// Rewrite chunks of `res` that reference a wire carrying an in-flight (blocking)
+// value in the current always_comb onto that value.  A read of a signal the SAME
+// block writes must observe the value written earlier in the block; reading the
+// process's own output wire instead closes a combinational loop (CVA6 id_stage:
+// `if (!issue_n[0].valid)` follows `issue_n[0].valid = 1'b0`).  Applied only to
+// operation OPERANDS and comb conditions, which are values, never assignment
+// targets, so a write target is never rewritten to a non-wire.
+static RTLIL::SigSpec remap_sig_inflight(const RTLIL::SigSpec& res,
+                                         const std::map<std::string, RTLIL::SigSpec>& ccv) {
+    if (res.empty() || ccv.empty()) return res;
+    RTLIL::SigSpec out;
+    bool changed = false;
+    for (const auto& ch : res.chunks()) {
+        if (ch.wire) {
+            std::string wn = ch.wire->name.str();
+            if (!wn.empty() && wn[0] == '\\') wn = wn.substr(1);
+            auto it = ccv.find(wn);
+            if (it != ccv.end() && it->second.size() == ch.wire->width &&
+                ch.offset + ch.width <= it->second.size()) {
+                out.append(it->second.extract(ch.offset, ch.width));
+                changed = true;
+                continue;
+            }
+        }
+        out.append(RTLIL::SigSpec(ch));
+    }
+    return changed ? out : res;
 }
 
 RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UHDM::scope* inst, const std::map<std::string, RTLIL::SigSpec>* input_mapping) {
@@ -5124,6 +5158,9 @@ RTLIL::SigSpec UhdmImporter::import_operation(const operation* uhdm_op, const UH
                     }
                 }
             }
+            if (input_mapping == &current_comb_values && current_comb_process &&
+                !in_always_ff_body_mode && !in_always_ff_context)
+                op_sig = remap_sig_inflight(op_sig, current_comb_values);
             operands.push_back(op_sig);
         }
     }

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -139,7 +139,7 @@ hpdcache_wbuf                          4   180   elabfail  # was crash (segfault
 hwpf_stride                            4   400   proven
 hwpf_stride_arb                        4   400   proven
 hwpf_stride_wrapper                    4   400   cex      # cex now measurable (was error: type-param width) - TRIAGE
-id_stage                               4   180   cex
+id_stage                               4   180   proven
 instr_decoder                          4   400   proven
 instr_queue                            4   900   proven
 instr_realign                          4   900   proven


### PR DESCRIPTION
CVA6 `id_stage` diverged from the RTL on **499 of 500** co-sim cycles (slang: 0), and its UHDM netlist carried a **combinational loop** that slang's did not. Two distinct defects, both reached through `issue_n[0]`.

## 1. Pattern packing lost the LHS struct type

`assignment_lhs_typespec()` returned null for `issue_n[0] = '{...}`. The LHS `bit_select` resolves to a `packed_array_var`, which carries **no `Typespec()` of its own** — the element type lives on `Elements()[0]` (a `struct_var` holding the `struct_typespec`).

With no struct typespec, every pattern member fell back to context-width/member-count = `472/4 = 118` bits:

```
assign $0\issue_n { 117'0 Mux \decoded_instruction[117:0] 86'0 \orig_instr 117'0 }
```

truncating the 438-bit `scoreboard_entry_t` member and zero-padding the rest. With the fix the members pack at their real widths.

## 2. A comb read ignored the in-flight (blocking) value

```systemverilog
issue_n = issue_q;
if (issue_instr_ack_i[0]) issue_n[0].valid = 1'b0;
if (!issue_n[0].valid && fetch_entry_valid_i[0]) ...   // must see the clear above
```

The condition read resolved to `\issue_n` — the wire this very process drives — closing a combinational loop:

```
assign _0005_ = ! \dut.issue_n [471];
assign _0004_ = _0005_ && fetch_entry_valid_i;
assign \dut.issue_n [471] = flush_i ? 1'h0 : _0599_;
```

`import_operation` now remaps each operand onto `current_comb_values`, gated on the caller having passed `&current_comb_values`. The comb condition importers pass it; LHS/target imports never do, so an **assignment target can never be rewritten to a non-wire**. The correct in-flight value (the `thread_comb_if` mux) was already being computed and recorded — nothing consumed it on this path.

## Results

| | before | after |
|---|---|---|
| id_stage co-sim (500 cyc) | 499 divergences | **0** (`slang_vs_rtl=0` too) |
| id_stage `check` | logic loop | **no loop** |
| id_stage formal miter | cex | **PROVEN** |
| CVA6 coverage | 83/142 | **84/142** |

- Full CVA6 sweep: **132 as expected, 0 regressions, 5 skipped**, 10 inconclusive (SAT budget).
- Regression suite: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59.

## On the absence of a reduced repro

Three successive DUTs reproducing the shape (element-field write followed by a condition read; with and without a generate scope; one- and two-element packed arrays) all took a **different resolution path** and passed *without* the fix. A test that passes with and without the change guards nothing, so none was added — `id_stage` in the CVA6 manifest is the guard.

## Discarded during triage

An `import_bit_select` wrapper and an in-flight path in the N-index `hier_path` handler were both tried; with the operand remap in place `id_stage` proves without either, so both were removed rather than shipped as dead code.

## Note on the two new sim-equiv warnings

The regression flags `comb_uncond_after_cond` and `regbank_depth1` as new-vs-baseline. A/B confirms **identical** mismatch counts (52 and 2) with and without this patch — pre-existing divergences in two recently added tests that were never baselined. Not baselined here either (that would silence them); they remain open backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)