### PR TITLE
uhdm: later-wins supersede for part-select comb writes

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -12217,6 +12217,18 @@ void UhdmImporter::import_assignment_comb(const assignment* uhdm_assign, RTLIL::
                 mapped.append(ch);
             }
             if (any_mapped) {
+                // Later-wins, exactly as in the whole-wire branch above: RTLIL
+                // runs a case's actions BEFORE its switches, so this
+                // unconditional root-level write would otherwise be overridden
+                // by an EARLIER conditional write to the same bits.  The
+                // whole-wire branch got this fix but the PART-SELECT branch did
+                // not, even though the CVA6 case that motivated it writes a bit
+                // select: issue_read_operands' trailing
+                //   stall_raw[0] = xrej ? 0 : stall_rs1[0]||stall_rs2[0]||...
+                // still lost to `if (rs1_has_raw) stall_raw[i] = 1'b1` in the
+                // unrolled loop above it.
+                if (!in_always_ff_body_mode && !in_always_ff_context)
+                    remove_target_from_switches(&proc->root_case, mapped);
                 proc->root_case.actions.push_back(RTLIL::SigSig(mapped, rhs));
                 // In always_ff, a same-cycle BLOCKING write to a bit/part-select
                 // must be visible to later reads of the same signal (e.g. the

--- a/test/sim_equiv_analyzed.txt
+++ b/test/sim_equiv_analyzed.txt
@@ -697,3 +697,18 @@ Test: arb_idx_cast
     as tc_sram's `data_t [NumPorts-1:0][Latency-1:0] rdata_q`, whose second
     index selects a whole sub-element, and wt_dcache_mem then fails to import).
 
+Test: regbank_depth1
+    `rdata` is assigned ONLY inside `if (cs)` of the non-reset branch and
+    never in the async-reset branch, so it has no reset value and holds
+    across `!cs` cycles.  Verilator's 2-state RTL starts it at 0 while the
+    gate-level netlist retains the last value written through the byte-enable
+    memory, so the two drift apart on random stimulus (2 mismatches at cycles
+    136/137, `rtl=0x0 nl=0xac57`).  The harness itself flags the run VACUOUS
+    ("outputs were all-zero every cycle") -- the RTL side never exercised the
+    read port.
+    ADJUDICATED: the SAT-from-reset miter proves UHDM == Verilog over 24
+    cycles ("SAT proof finished - no model found: SUCCESS!"), and
+    triage_cosim.py independently returns EQUIVALENT/ARTEFACT.  Not a
+    frontend bug.  Note the suite's OTHER two gates are both blind here:
+    equiv_make pairs nothing because the design is memory-vs-registers, so
+    equiv_check.log reports "No $equiv cells found" in gold and gate alike.


### PR DESCRIPTION
Clears both co-sim divergences flagged in #657: one real bug, one adjudicated artefact.

## The bug: part-select writes had no later-wins supersede

RTLIL runs a case's actions **before** its switches, inverting SystemVerilog source order — an unconditional root-level write in `root_case.actions` is overridden by an *earlier* conditional write sitting in a switch. `remove_target_from_switches()` exists to undo that, but `import_assignment_comb()` called it only from its **whole-wire** branch.

The CVA6 case its own comment cites writes a **bit select**:

```systemverilog
for (i) if (rs1_has_raw) stall_raw[i] = 1'b1;      // conditional, in a loop
stall_raw[0] = xrej ? 1'b0 : stall_rs1[0] || ...;  // unconditional, LAST
```

A bit/part-select LHS takes the chunk-remapping branch, which had no supersede, so the trailing write still lost:

```
assign $0\v [0] Mux$16          <- unconditional, runs FIRST
switch \cond
  case 1'1: assign $0\v [0] 1'1 <- conditional, runs AFTER and wins
```

`test/comb_uncond_after_cond` covers both shapes, and only its **scalar half was passing** — the loop half (`loop_o`) diverged from the RTL on 52 of 200 co-sim cycles (bit 0: `rtl=0xe nl=0xf`). Now **52 → 0 mismatches**. Gated off in the always_ff paths, matching the whole-wire branch.

## The artefact: regbank_depth1

`rdata` is assigned only inside `if (cs)` of the non-reset branch and never in the async-reset branch, so it has no reset value. Verilator's 2-state RTL starts it at 0 while the gate-level netlist holds the last byte-enable write — 2 mismatches at cycles 136/137. The harness itself flags the run **VACUOUS** ("outputs were all-zero every cycle").

Adjudicated three ways:
- SAT-from-reset miter over 24 cycles: `SAT proof finished - no model found: SUCCESS!`
- `triage_cosim.py` independently: **EQUIVALENT / ARTEFACT**
- Worth noting the suite's other two gates are **blind** here — `equiv_make` pairs nothing on a memory-vs-registers design, so `equiv_check.log` reports "No $equiv cells found" in gold *and* gate.

Documented in `sim_equiv_analyzed.txt`. Deliberately **not** added to `sim_equiv_warn_baseline.txt`, whose stated policy is *"NEVER add an entry to silence a new warning — triage it instead"*; that file is untouched in this PR.

## Gates

- Regression: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59, **0 new warnings**, baselined backlog unchanged at 43, analyzed 52 → 53, artefacts 46 → 47.
- CVA6 sweep: **132 as expected, 0 regressions**, coverage 84/142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)