### PR TITLE
uhdm: evaluate $bits() of a type-parameter-typed variable (CVA6 cva6_rvfi_probes PROVEN)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -3112,6 +3112,51 @@ RTLIL::SigSpec UhdmImporter::import_expression(const expr* uhdm_expr, const std:
                         }
                     }
 
+                    // `$bits(v)` where v's declared type is a TYPE PARAMETER.
+                    // Surelog defers this query to elaboration (it cannot fold
+                    // it at definition time, where the parameter has no
+                    // binding), so it arrives here as a live sys_func_call whose
+                    // argument is a bare ref_obj.  Importing that ref as an
+                    // expression can still yield 1 bit, so take the width from
+                    // the DECLARATION: resolve the variable's typespec through
+                    // the type parameter, falling back to the already-imported
+                    // RTLIL wire.  CVA6 cva6_rvfi_probes gates its whole output
+                    // on `$bits(rvfi_probes_o.instr) == $bits(instr)`.
+                    if (total_bits <= 1) {
+                        if (auto ro2 = dynamic_cast<const UHDM::ref_obj*>(first_arg)) {
+                            std::string vn2 = std::string(ro2->VpiName());
+                            const UHDM::ref_typespec* vrt = nullptr;
+                            if (auto ag2 = ro2->Actual_group()) {
+                                if (auto v2 = dynamic_cast<const UHDM::variables*>(ag2))
+                                    vrt = v2->Typespec();
+                                else if (auto n2 = dynamic_cast<const UHDM::net*>(ag2))
+                                    vrt = n2->Typespec();
+                            }
+                            if (!vrt)
+                                if (auto mi2 = dynamic_cast<const UHDM::module_inst*>(current_instance)) {
+                                    if (mi2->Variables())
+                                        for (auto v : *mi2->Variables())
+                                            if (std::string(v->VpiName()) == vn2) { vrt = v->Typespec(); break; }
+                                    if (!vrt && mi2->Nets())
+                                        for (auto n : *mi2->Nets())
+                                            if (std::string(n->VpiName()) == vn2) { vrt = n->Typespec(); break; }
+                                }
+                            int w2 = 0;
+                            if (vrt && vrt->Actual_typespec()) {
+                                const UHDM::typespec* vts =
+                                    resolve_type_param_typespec(vrt->Actual_typespec(), current_instance);
+                                if (vts) w2 = get_width_from_typespec(vts, current_instance);
+                            }
+                            if (w2 <= 1 && !vn2.empty()) {
+                                RTLIL::Wire* vw = name_map.count(vn2)
+                                                      ? name_map[vn2]
+                                                      : module->wire(RTLIL::escape_id(vn2));
+                                if (vw) w2 = vw->width;
+                            }
+                            if (w2 > total_bits) total_bits = w2;
+                        }
+                    }
+
                     // Walk a typespec to extract its dimensions in outer→inner
                     // order.  For multi-range packed types (logic [a:b][c:d])
                     // the ranges are dim 1, dim 2, …; nested Elem_typespec

--- a/test/cva6_equiv/cva6_modules.txt
+++ b/test/cva6_equiv/cva6_modules.txt
@@ -66,7 +66,7 @@ cva6_icache                            4   900   proven
 cva6_icache_axi_wrapper                4   400   proven   # proven by the dynamic element-field write + packed element-range fixes
 cva6_mmu                               4   180   proven
 cva6_ptw                               1   900   proven
-cva6_rvfi_probes                       4   180   cex
+cva6_rvfi_probes                       4   180   proven
 cva6_shared_tlb                        4   900   proven
 cva6_tlb                               4   900   proven
 cvxif_compressed_if_driver             4   900   proven


### PR DESCRIPTION
Pairs with **chipsalliance/Surelog#4158**, now **merged** — the submodule is bumped to `870cddbf47` in this PR.

## The bug

CVA6 `cva6_rvfi_probes` differed from the RTL on **300 of 300** co-sim cycles (slang: 0). Its entire output is gated on a width check:

```systemverilog
rvfi_probes_instr_t instr;          // a TYPE PARAMETER
...
if ($bits(rvfi_probes_o.instr) == $bits(instr)) rvfi_probes_o.instr = instr;
if ($bits(rvfi_probes_o.csr)   == $bits(csr))   rvfi_probes_o.csr   = csr;
```

The UHDM arrived with both `$bits` calls already folded to constants — `1204` (correct) and **`1`** (wrong):

```
cell $eq $eq$cva6_rvfi_probes.sv:133$66
  connect \A 64'…010010110100      <- 1204
  connect \B 64'…000000000001      <- 1
```

So the guards were false, both fields stayed `'0`, and the whole 6974-bit `rvfi_probes_o` was zero. That is exactly why **3394** of 6976 bits differed — 3394 is the popcount of the RTL value against our all-zero output.

Root cause was in Surelog: `compileBits()` folds at *definition*-compile time, where the type parameter has no binding, so `getTypespec()` returns its default (`parameter type T = logic` → 1 bit) and the query freezes at 1 for every instantiation. Fixed in #4158 by deferring the fold.

## This change

With the fold deferred, the query arrives as a live `sys_func_call` whose argument is a bare `ref_obj` — and importing that ref as an expression can still yield 1 bit. So take the width from the **declaration**: resolve the variable's typespec through the type parameter, falling back to the already-imported RTLIL wire.

Plus the submodule bump to the merged Surelog master.

## Results

| | before | after |
|---|---|---|
| co-sim (300 cycles) | 300 divergences | **0** (`slang_vs_rtl=0` too) |
| formal miter | cex | **PROVEN** |
| CVA6 coverage | 84/142 | **85/142** |

Gates below were run against the pre-merge branch, whose fix commit (`8e35500ede`) is identical to the one merged. After bumping the submodule to the merged master the target was re-verified — `cva6_rvfi_probes` still **proven**, coverage 85/142 — but the full suite was not re-run for the bump.

- CVA6 sweep: **133 as expected, 0 regressions**, 5 skipped.
- Regression: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59, **0 new warnings**, baselined backlog unchanged at 43.
- Surelog regression: **791 PASS, 0 DIFF, 0 FAIL** (3 goldens refreshed, UHDM object counts only).

## On the absence of a reduced repro

The natural DUT — a type-parameter-typed variable in a submodule — hits a **separate, still-open** Surelog gap: the elaborated net keeps the parameter's *default* typespec rather than the bound type,

```
\_logic_net: (work@sub.v)
  \_ref_typespec: |vpiActual: \_logic_typespec: , line:5:33   <- the `logic` default
```

so the variable measures 1 bit at its declaration and the DUT fails for a different reason. CVA6's `instr` resolves correctly and does not hit that gap, so `cva6_rvfi_probes` in the manifest is the guard (same argument as #657).

## Discarded during triage

The module emits 70 `Could not resolve struct member access 'instr.<field>'` warnings, which look like the obvious culprit. They are **not** — the netlist contains no `1'x` and `instr` is fully driven; those come from the untrusted AllModules definition pass. A recovery path written for them never fired and was removed rather than shipped as dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)