### PR TITLE
uhdm: don't resolve a struct-FIELD ref by its bare name (CVA6 frontend)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -10756,7 +10756,19 @@ RTLIL::SigSpec UhdmImporter::import_hier_path(const hier_path* uhdm_hier, const 
                 // hoisted to module scope (`work@t.sat`), which can COLLIDE
                 // with a same-named local variable — bht's `.sat` field read
                 // resolved to the local `sat` wire and corrupted the update.
-                std::string_view ref_full_name = ref->VpiFullName();
+                // The guard above was documented but never implemented: a
+                // struct-FIELD ref still fell through here, and CVA6
+                // instr_queue has BOTH a `.instr`/`.cf` struct field and
+                // module-level wires named `instr`/`cf`.  The continuous
+                // assigns `instr_data_in[i].instr = instr[...]` then resolved
+                // their LHS to the SOURCE array \instr, leaving instr_data_in
+                // undriven and multi-driving \instr -- 140 driver-driver
+                // conflicts that opt_clean resolved to constants, so the whole
+                // frontend fetch datapath came out zero.
+                bool field_ref = ref->Actual_group() &&
+                                 ref->Actual_group()->UhdmType() == uhdmtypespec_member;
+                std::string_view ref_full_name = field_ref ? std::string_view()
+                                                           : ref->VpiFullName();
                 if (!ref_full_name.empty()) {
                     std::string full_str = std::string(ref_full_name);
                     // Extract module-relative path


### PR DESCRIPTION
## A guard that existed only as a comment

`import_hier_path`'s `VpiFullName` fallback carries this warning:

```c
// NEVER for a struct-FIELD ref (Actual_group is a typespec_member): its
// VpiFullName is the bare field name hoisted to module scope (`work@t.sat`),
// which can COLLIDE with a same-named local variable — bht's `.sat` field read
// resolved to the local `sat` wire and corrupted the update.
```

No code below it ever checked `typespec_member` — the lookup ran unconditionally.

## What it cost

CVA6's `instr_queue` has **both** `.instr`/`.cf` struct fields and module-level wires named `instr`/`cf`:

```systemverilog
assign instr_data_in[i].instr = instr[CVA6Cfg.INSTR_PER_FETCH+i-idx_is_q];
assign instr_data_in[i].cf    = cf[CVA6Cfg.INSTR_PER_FETCH+i-idx_is_q];
```

Both resolved their **LHS to the source array** — `\instr` / `\cf`:

```
LHS signal: \instr                                <- wrong
LHS is hier_path: instr_data_in[i].instr
LHS signal: \instr_data_in [137:74]               <- right (no name collision)
LHS is hier_path: instr_data_in[i].ex_vaddr
```

So `instr_data_in` was left undriven while `\instr` gained extra drivers — **140 driver-driver conflicts**, which `opt_clean` resolved to constants ("Resolved using constant"), zeroing the whole frontend fetch datapath. Sibling fields whose names don't collide (`.ex`, `.ex_vaddr`) resolved fine, which is exactly what made the failure look partial and hard to spot.

## Fix

Skip the fallback when the ref's `Actual_group` is a `typespec_member` — i.e. implement the guard as documented.

## Results

| | before | after |
|---|---|---|
| driver-driver conflicts | 140 | **0** |
| `frontend` co-sim (300 cycles) | 294 divergences | **0** (`slang_vs_rtl=0` too) |

`frontend`'s formal miter still returns `cex` — the same unreachable-state limitation as `scoreboard` — so its manifest entry **stays `cex`** rather than claiming a proof. The honest result is a clean co-sim with slang also at 0.

- Regression: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59, **0 new warnings**, baselined backlog unchanged at 43.
- CVA6 sweep: **133 as expected, 0 regressions**, coverage 85/142.

## How it was found

The co-sim XOR showed a mostly-zero output. `proc; flatten` alone was clean — the conflicts appeared only under `opt_clean`, which is what turns a doubly-driven net into a constant. Bisecting the individual `opt` passes is what surfaced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)