### PR TITLE
uhdm: register byte-sliced dynamic array writes (var_select) — CVA6 cache SRAM writes were dropped

### DIFF
--- a/src/frontends/uhdm/process_helper.cpp
+++ b/src/frontends/uhdm/process_helper.cpp
@@ -1714,7 +1714,24 @@ void UhdmImporter::collect_dynamic_expanded_array_writes(
         case vpiAssignStmt: {
             const assignment* assign = require_assignment(stmt, "collect_dynamic_expanded_array_writes");
             if (auto lhs = assign->Lhs()) {
-                if (lhs->VpiType() == vpiBitSelect) {
+                // A BYTE-ENABLED write `base[idx][j*W +: W] <= …` (tech_cells
+                // generic tc_sram, which every CVA6 cache SRAM instantiates)
+                // reaches us as a VAR_SELECT, so matching only vpiBitSelect
+                // missed it: the array was never
+                // registered per-element, no `$0\base[k]` temps were made, and
+                // emit_dynamic_unpacked_array_elem_write's case actions -- which
+                // fall back to the RAW element wire when the temp is absent --
+                // were never committed by a sync rule.  The SRAM writes were
+                // silently DROPPED, leaving every element undriven and
+                // self-referential (17416 logic loops in CVA6 wt_dcache).
+                if (lhs->VpiType() == vpiVarSelect) {
+                    // Surelog emits `base[idx][j*W +: W]` as a var_select whose
+                    // Exprs() are the index expressions; the FIRST is the
+                    // element index.
+                    if (auto vs = any_cast<const UHDM::var_select*>(lhs))
+                        if (vs->Exprs() && !vs->Exprs()->empty())
+                            record(std::string(vs->VpiName()), (*vs->Exprs())[0]);
+                } else if (lhs->VpiType() == vpiBitSelect) {
                     const bit_select* bs = any_cast<const bit_select*>(lhs);
                     record(std::string(bs->VpiName()), bs->VpiIndex());
                 }


### PR DESCRIPTION
Every CVA6 cache SRAM instantiates tech_cells_generic's `tc_sram`, and **all of its writes were being silently dropped**.

## The shape

`tc_sram` writes its storage byte-wise under an async-reset `always_ff`:

```systemverilog
if (be_i[i][j]) sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
```

The array is *legitimately* demoted to per-element registers — its reset arm does `foreach (init_val[i]) sram[i] <= init_val[i]`, and an RTLIL `memwr` cannot carry an async reset.

## The bug

`collect_dynamic_expanded_array_writes` registers each element so the temp-wire + sync-rule machinery gives it a `$0\base[k]`. It matched only `lhs->VpiType() == vpiBitSelect` — a **whole-element** write. Surelog emits the byte-sliced form as a **`vpiVarSelect`**, so nothing was registered.

With no temp wire, `emit_dynamic_unpacked_array_elem_write` fell back to targeting the **raw** `\sram[k]` wire inside a case rule — and a case-rule action on a raw wire is never committed without a sync update. The writes vanished, leaving every element undriven and self-referential:

```
_01878_ = cond ? mshr_q[38:31] : sram[0][7:0]     <- reads sram[0]
sram[0][7:0] = vld_req[0] ? _10784_ : 8'h00       <- drives it combinationally
```

## Fix

Match `vpiVarSelect` too, taking the first index expression as the element index.

## Results — CVA6 `wt_dcache`

| | before | after |
|---|---|---|
| `$0\sram[k]` temp wires | **0** | **3072** |
| sram updates on `posedge clk_i` | **0** | 256 per SRAM instance |
| combinational logic loops | **17416** | **8** |

- Regression: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59, **0 new warnings**, baselined backlog unchanged at 43.
- CVA6 sweep: **133 as expected, 0 regressions**, coverage 85/142.

## Scope — what this does *not* fix

`wt_dcache` still co-sims 300/300. Its first divergence is `mem_data_o.data` at cycle 0, a purely combinational path that never touches the SRAM (the RTL takes the AMO arm, `{amo_req_i[31:0]}` duplicated; we produce 0). That is a **separate** bug in the same module, still open. This fix stands on its own — dropped writes are dropped writes — but does not by itself clear the module.

## Notes for whoever touches this next

- Recursing through `part_select->VpiParent()` walks **up** the tree and segfaults; descend only into children (`indexed_part_select::Base_expr()`).
- An `indexed_part_select` branch I first wrote for this never fired (Surelog gives `var_select` here), so it was removed rather than shipped unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)