### PR TITLE
uhdm: indexed part-select LHS in function bodies (CVA6 wt_dcache_wbuffer replication dropped)

### DIFF
--- a/src/frontends/uhdm/expression.cpp
+++ b/src/frontends/uhdm/expression.cpp
@@ -937,6 +937,55 @@ void UhdmImporter::process_stmt_to_case(const any* stmt, RTLIL::CaseRule* case_r
                 } else {
                     log_warning("Part-select LHS %s has non-constant range\n", base_name.c_str());
                 }
+            } else if (assign->Lhs()->UhdmType() == uhdmindexed_part_select) {
+                // Indexed part-select LHS `out[k*W +: W] = …`.  Only the plain
+                // `[hi:lo]` form was handled, so the byte/hword/word replication
+                // loops in CVA6 wt_dcache_wbuffer's repData64/repData32
+                //     2'b00: for (int k = 0; k < 8; k++) out[k*8+:8] = data[offset*8+:8];
+                // wrote nothing: miss_wdata_o's three replication case arms all
+                // collapsed to the same undriven value, so the write buffer fed
+                // the miss unit zeros instead of the replicated store data.
+                const indexed_part_select* ips =
+                    any_cast<const indexed_part_select*>(assign->Lhs());
+                std::string base_name = std::string(ips->VpiName());
+                int base_val = -1, width_val = -1;
+                if (ips->Base_expr()) {
+                    RTLIL::SigSpec s2 = import_expression(
+                        any_cast<const expr*>(ips->Base_expr()), &input_mapping);
+                    if (s2.is_fully_const()) base_val = s2.as_int();
+                }
+                if (ips->Width_expr()) {
+                    RTLIL::SigSpec s2 = import_expression(
+                        any_cast<const expr*>(ips->Width_expr()), &input_mapping);
+                    if (s2.is_fully_const()) width_val = s2.as_int();
+                }
+                if (base_val >= 0 && width_val > 0) {
+                    // `-:` counts DOWN from the base.
+                    int offset = (ips->VpiIndexedPartSelectType() == vpiPosIndexed)
+                                     ? base_val : (base_val - width_val + 1);
+                    RTLIL::SigSpec base_spec;
+                    if (base_name == func_name) {
+                        base_spec = RTLIL::SigSpec(result_wire);
+                    } else {
+                        auto it = input_mapping.find(base_name);
+                        if (it != input_mapping.end())
+                            base_spec = it->second;
+                    }
+                    if (offset >= 0 && base_spec.size() > 0 &&
+                        offset + width_val <= base_spec.size()) {
+                        lhs_sig = base_spec.extract(offset, width_val);
+                        if (mode_debug)
+                            log("  process_stmt_to_case: indexed part-select LHS "
+                                "%s[%d +: %d]\n", base_name.c_str(), offset, width_val);
+                    } else {
+                        log_warning("Indexed part-select LHS %s[%d +: %d] out of "
+                                    "bounds (base_size=%d)\n", base_name.c_str(),
+                                    offset, width_val, base_spec.size());
+                    }
+                } else {
+                    log_warning("Indexed part-select LHS %s has non-constant "
+                                "base/width\n", base_name.c_str());
+                }
             } else if (assign->Lhs()->UhdmType() == uhdmbit_select) {
                 // Handle bit select assignment
                 const bit_select* bs = any_cast<const bit_select*>(assign->Lhs());


### PR DESCRIPTION
## The gap

`process_stmt_to_case` — the function-lowering path used by `process_function_with_context` — handles a part-select (`out[hi:lo] = …`) and a bit-select LHS, but **not an indexed part-select** (`out[base +: width]`). Such a write fell through with no target and was silently discarded.

## What it cost

CVA6's `wt_dcache_wbuffer` replicates a sub-dword store across the lane using exactly that form:

```systemverilog
function automatic logic [XLEN-1:0] repData64(input data, offset, size);
  unique case (size)
    2'b00:   for (int k = 0; k < 8; k++) out[k*8+:8]   = data[offset*8+:8];   // byte
    2'b01:   for (int k = 0; k < 4; k++) out[k*16+:16] = data[offset*8+:16];  // hword
    2'b10:   for (int k = 0; k < 2; k++) out[k*32+:32] = data[offset*8+:32];  // word
    default: out = data;
  endcase
endfunction
```

Every replication write was dropped, so all three arms collapsed onto one value driven at a **single bit** — `_09920_[39] = 1'h0`, undriven elsewhere:

```
assign miss_wdata_o = _24410_(_09921_, { _09920_, _09920_, _09920_ }, {…});
```

`miss_wdata_o = repData64(...)` therefore fed the miss unit zeros instead of the replicated store data.

## Fix

Handle `uhdmindexed_part_select`, mirroring the existing part-select branch and honouring the `-:` direction.

| | before | after |
|---|---|---|
| driven bits of the replication value | **1 of 64** | **all 64** |
| case arms | one shared undriven value | per-byte pmuxes, correctly replicated |

## On the routing (the thing I checked first)

The routing was already **correct**: `repData64` takes `process_function_with_context`, confirmed from the generated wire names (`$repData64$func$wt_dcache_wbuffer.sv:276$…$result`). Both inliner routes are guarded by `is_straight_line`, which rejects `vpiCase`. The defect was in that path's LHS handling, not in the choice of path — an earlier theory that `has_for_loop` missing `vpiCase` was to blame turned out to be inert here and was discarded rather than shipped.

## Scope

`wt_dcache` **still co-sims 300/300**. Its first divergence is `mem_data_o.data` at cycle 0: the replicated value is now correct but does not reach the output (slang selects `miss_wdata_i[idx]` as `idx<4 ? X : 0` where we use a `$shiftx` over the concatenated array — the next thing to look at). This fix stands on its own; it does not close the module.

- Regression: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59, **0 new warnings**, baselined backlog 43 → 42.
- CVA6 sweep: **133 as expected, 0 regressions**, coverage 85/142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)