### PR TITLE
uhdm: recognise an indexed part-select LHS as a class — CVA6 wt_dcache now co-sim CLEAN

### DIFF
--- a/src/frontends/uhdm/process.cpp
+++ b/src/frontends/uhdm/process.cpp
@@ -9247,6 +9247,7 @@ void UhdmImporter::inline_func_body_comb(const any* stmt, RTLIL::Process* proc,
                     // collapsed to a passthrough).
                     lhs_name = std::string(lhs_var->VpiName());
                 } else if (lhs_expr->VpiType() == vpiPartSelect ||
+                           lhs_expr->VpiType() == vpiIndexedPartSelect ||
                            lhs_expr->VpiType() == vpiBitSelect) {
                     // Part/bit-select write to a function LOCAL
                     // (`data_tmp[CVA6Cfg.XLEN-1:0] = {…}` in CVA6 store_unit's
@@ -9257,7 +9258,23 @@ void UhdmImporter::inline_func_body_comb(const any* stmt, RTLIL::Process* proc,
                     // was DROPPED silently (d_tmp kept its all-zero init).
                     std::string base;
                     int sel_off = -1, sel_w = -1;
-                    if (lhs_expr->VpiType() == vpiPartSelect) {
+                    if (lhs_expr->VpiType() == vpiIndexedPartSelect) {
+                        // `local[k*W +: W] = …` — same class as the plain
+                        // part-select below; without it the write was dropped
+                        // with "dropped part/bit-select write".
+                        auto ips = any_cast<const UHDM::indexed_part_select*>(lhs_expr);
+                        base = std::string(ips->VpiName());
+                        RTLIL::SigSpec b = import_expression(
+                            any_cast<const expr*>(ips->Base_expr()), &func_mapping);
+                        RTLIL::SigSpec w = import_expression(
+                            any_cast<const expr*>(ips->Width_expr()), &func_mapping);
+                        if (b.is_fully_const() && w.is_fully_const()) {
+                            int o = b.as_const().as_int();
+                            int wd = w.as_const().as_int();
+                            if (ips->VpiIndexedPartSelectType() == 2) o = o - wd + 1;
+                            if (wd > 0 && o >= 0) { sel_off = o; sel_w = wd; }
+                        }
+                    } else if (lhs_expr->VpiType() == vpiPartSelect) {
                         auto ps = any_cast<const part_select*>(lhs_expr);
                         base = std::string(!ps->VpiName().empty()
                                                ? ps->VpiName() : ps->VpiDefName());
@@ -10646,14 +10663,44 @@ bool UhdmImporter::emit_dynamic_array_elem_field_write(
         // through to import_hier_path's READ path, which drove a stray temp
         // wire and inferred a latch instead of updating the array.
         std::vector<std::string> ffields;
-        if (nsel >= 1 && nsel < peM.size()) {
+        // A trailing INDEXED PART-SELECT element (`arr[i].field[k*8 +: 8]`)
+        // narrows the write to a constant slice of the member, exactly like the
+        // trailing bit-select handled via `field_bs` below.  Without peeling it
+        // the tail-walk's all-ref_obj test failed, `frf` stayed null and the
+        // whole write was DROPPED: CVA6 wt_dcache_wbuffer's byte-enable loop
+        // wrote `.valid[k]`/`.dirty[k]` (bit-selects, already handled) but never
+        // `.data[k*8+:8]`, so the write buffer's control bits were correct while
+        // its DATA field stayed zero.
+        size_t field_end = peM.size();
+        int tail_slice_off = -1, tail_slice_w = -1;
+        if (peM.size() >= 3 &&
+            peM.back()->UhdmType() == uhdmindexed_part_select) {
+            auto lips = any_cast<const UHDM::indexed_part_select*>(peM.back());
+            if (lips && lips->Base_expr() && lips->Width_expr()) {
+                RTLIL::SigSpec bb = import_expression(
+                    dynamic_cast<const UHDM::expr*>(lips->Base_expr()));
+                RTLIL::SigSpec ww = import_expression(
+                    dynamic_cast<const UHDM::expr*>(lips->Width_expr()));
+                if (bb.is_fully_const() && ww.is_fully_const()) {
+                    int o = bb.as_const().as_int();
+                    int wd = ww.as_const().as_int();
+                    if (lips->VpiIndexedPartSelectType() == 2) o = o - wd + 1;
+                    if (wd > 0 && o >= 0) {
+                        tail_slice_off = o;
+                        tail_slice_w = wd;
+                        field_end--;
+                    }
+                }
+            }
+        }
+        if (nsel >= 1 && nsel < field_end) {
             bool all_ref = true;
-            for (size_t t = nsel; t < peM.size(); t++)
+            for (size_t t = nsel; t < field_end; t++)
                 if (peM[t]->UhdmType() != uhdmref_obj) { all_ref = false; break; }
             if (all_ref) {
-                for (size_t t = nsel; t < peM.size(); t++)
+                for (size_t t = nsel; t < field_end; t++)
                     ffields.push_back(std::string(peM[t]->VpiName()));
-                frf = any_cast<const ref_obj*>(peM[peM.size() - 1]);
+                frf = any_cast<const ref_obj*>(peM[field_end - 1]);
             }
         }
         if (frf) {
@@ -10738,6 +10785,16 @@ bool UhdmImporter::emit_dynamic_array_elem_field_write(
                         found_field = false;
                     else
                         write_w = sub_w;
+                }
+                // Constant slice of the member from a trailing indexed
+                // part-select: shift the member offset and write only it.
+                if (found_field && tail_slice_w > 0) {
+                    if (tail_slice_off + tail_slice_w > field_width) {
+                        found_field = false;
+                    } else {
+                        field_offset += tail_slice_off;
+                        write_w = tail_slice_w;
+                    }
                 }
                 if (found_field && field_width > 0) {
                     std::vector<int> strides(nsel, elem_w2);

--- a/test/cva6_equiv/cosim_sweep_results.md
+++ b/test/cva6_equiv/cosim_sweep_results.md
@@ -23,7 +23,7 @@ functional difference — 11 of the 25 below are functionally clean.
 | cva6 | timeout | **300** | 0 | 🐛 UHDM_WRONG |
 | std_cache_subsystem | timeout | **300** | 0 | 🐛 UHDM_WRONG |
 | wt_cache_subsystem | timeout | **300** | 0 | 🐛 UHDM_WRONG |
-| wt_dcache | timeout | **300** | 0 | 🐛 UHDM_WRONG |
+| wt_dcache | timeout | ~~300~~ **0** | 0 | ✅ FIXED (PRs #662/#663/#664) |
 | ex_stage | cex | **63** | 0 | 🐛 UHDM_WRONG |
 | fpu_wrap | cex | **62** | 0 | 🐛 UHDM_WRONG |
 | issue_stage | timeout | **1** | 0 | 🐛 UHDM_WRONG |
@@ -46,15 +46,27 @@ functional difference — 11 of the 25 below are functionally clean.
 | macro_decoder | cex | — | — | ❓ co-sim did not run (elaboration error) |
 | zcmt_decoder | cex | — | — | ❓ co-sim did not run (elaboration error) |
 
-Totals: **7 UHDM_WRONG**, 3 BOTH_DIFFER, 11 NO_DIVERGENCE, 4 no-run.
+Totals at sweep time: **7 UHDM_WRONG**, 3 BOTH_DIFFER, 11 NO_DIVERGENCE, 4 no-run.
+(`wt_dcache` has since been fixed; `frontend` was fixed by PR #660.)
 
 ## Reading the UHDM_WRONG group
 
-`cva6` (the whole CPU), `wt_cache_subsystem` and `wt_dcache` are all at 300/300
-with slang clean. `wt_dcache` is instantiated by `wt_cache_subsystem`, which is
-instantiated by `cva6`, so these are very likely **one bug seen three times**;
-`wt_dcache` is the leaf and the right place to attack. `std_cache_subsystem` is
-the alternative (non-WT) cache and may or may not share the cause.
+`cva6` (the whole CPU), `wt_cache_subsystem` and `wt_dcache` were all at 300/300
+with slang clean, and since `wt_dcache` is instantiated by `wt_cache_subsystem`
+which is instantiated by `cva6`, the obvious guess was **one bug seen three
+times**.
+
+**That guess was WRONG, and the correction is worth keeping.** `wt_dcache` is
+now co-sim clean (0/300) after three fixes, and re-adjudicating the parents
+afterwards gives:
+
+    wt_cache_subsystem :: uhdm_vs_rtl=300 slang_vs_rtl=0
+    std_cache_subsystem:: uhdm_vs_rtl=300 slang_vs_rtl=0
+    cva6               :: uhdm_vs_rtl=300 slang_vs_rtl=0
+
+— i.e. **unchanged**.  Each carries its own independent defect; a parent being
+at 300/300 says nothing about the child.  Do not assume nesting implies a shared
+cause: re-adjudicate the parent after fixing the child.
 
 `issue_stage` at 1/300 is the cheapest single item — one divergent cycle,
 usually a crisp localisation.
@@ -72,6 +84,12 @@ usually a crisp localisation.
   271 vs 63) the RTL-vs-synth comparison itself is suspect.
 - The 4 no-run modules need their harness/elaboration issue fixed before they
   can be measured at all.
+
+KNOWN FLAW in the generator: it reads the status column with `awk $NF`, which picks up a trailing `#` comment instead of the status — so
+`wt_dcache_wbuffer`, `wt_dcache_mem` and `wt_dcache_ctrl` never appeared
+above.  Re-adjudicated by hand they are BOTH_DIFFER (299 vs 216), 
+BOTH_DIFFER (63 vs 63) and NO_DIVERGENCE (0/0) respectively, so the
+manifest comments calling the first two "UHDM WRONG" are stale.
 
 Regenerate with the loop in
 `/tmp/.../scratchpad/cosim_all.sh` (300 cycles per module, ~2 h for all 25).


### PR DESCRIPTION
Fourth and last site of a family that produced **three separate dropped writes** in CVA6's write-through dcache: an LHS of the form `<target>[base +: w]` was not recognised, so the write was silently discarded.

## 1. `emit_dynamic_array_elem_field_write`

The multi-index branch already narrowed a write for a trailing **bit**-select (`arr[i].field[k]`) via `field_bs`/`write_w`. A trailing **indexed** part-select is the same idea with a constant offset — but the tail-walk required *every* element after the index run to be a `ref_obj`, so the 3-element path

```
[ bit_select(arr), ref_obj(field), indexed_part_select ]
```

failed that test, `frf` stayed null, and the write was dropped.

CVA6 `wt_dcache_wbuffer.sv:594`, inside the byte-enable loop:

```systemverilog
wbuffer_d[wr_ptr].valid[k]     = 1'b1;                        // bit-select  -> worked
wbuffer_d[wr_ptr].dirty[k]     = 1'b1;                        // bit-select  -> worked
wbuffer_d[wr_ptr].data[k*8+:8] = req_port_i.data_wdata[k*8+:8];  // DROPPED
```

So the buffer's control bits were correct while its **data field stayed zero** — every store read back as 0. That asymmetry (control right, data empty) is what made it hard to spot.

Now the trailing indexed part-select is peeled into `(slice_off, slice_w)` and folded into the member offset and write width.

## 2. `inline_func_body_comb`

Matched `vpiPartSelect`/`vpiBitSelect` only, announcing the loss as `dropped part/bit-select write`. Added the indexed case with the same `+:` / `-:` fold.

The family's other two sites, `process_stmt_to_case` and `collect_dynamic_expanded_array_writes`, are already fixed in #663 and #662.

## Result

**`wt_dcache` co-sim 300/300 → 0/300** (`uhdm_vs_rtl=0 slang_vs_rtl=0`), the culmination of three fixes:

| | defect |
|---|---|
| #662 | SRAM byte writes dropped (`var_select`) — 17416 comb loops |
| #663 | `repData64` replication dropped in function bodies |
| this | write-buffer `.data[k*8+:8]` dropped |

Its miter still times out on SAT capacity, so the manifest entry stays `timeout`.

- Regression: **PASSED** — 0 true failures, 0 crashes, slang-miter 59/59, **0 new warnings**, baselined backlog unchanged at 42.
- CVA6 sweep: **133 as expected, 0 regressions**, coverage 85/142.

## Correcting a prediction I got wrong

`cosim_sweep_results.md` (PR #661) predicted that `cva6` / `wt_cache_subsystem` / `wt_dcache` were "very likely **one bug seen three times**", since they nest in that order and were all at exactly 300/300.

**That is falsified.** With `wt_dcache` clean, re-adjudicating the parents gives:

```
wt_cache_subsystem  :: uhdm_vs_rtl=300 slang_vs_rtl=0
std_cache_subsystem :: uhdm_vs_rtl=300 slang_vs_rtl=0
cva6                :: uhdm_vs_rtl=300 slang_vs_rtl=0
```

— unchanged. Each has its own independent defect; nesting implies nothing about a shared cause. The doc now says so, and also records that the sweep generator reads the status column with `awk $NF`, which picks up trailing `#` comments and silently omitted `wt_dcache_{wbuffer,mem,ctrl}` from the original table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)